### PR TITLE
Upload data and fix for infinite credential retry

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -215,7 +215,7 @@ func AddKey(key, description string) error {
 
 	address := fmt.Sprintf("%s/api/accounts/%s/keys", authhost, username)
 	// TODO: Check err and req.StatusCode
-
+	// TODO: clean up key struct
 	mkBody := func(key, description string) io.Reader {
 		pw := &struct {
 			Key         string `json:"key"`

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -22,6 +22,12 @@ func storeToken(token string) error {
 	return ioutil.WriteFile("token", []byte(token), 0600)
 }
 
+func noTokenWarning(warn bool) {
+	if warn {
+		fmt.Println("You are not logged in.")
+	}
+}
+
 // LoadToken Get the current signed in username and auth token
 func LoadToken(warn bool) (string, string, error) {
 	// TODO: Load token from config directory
@@ -30,10 +36,8 @@ func LoadToken(warn bool) (string, string, error) {
 	var username, token string
 
 	if err != nil {
-		if warn {
-			fmt.Println("You are not logged in.")
-		}
-		return "", "", err
+		noTokenWarning(warn)
+		return "", "", nil
 	}
 
 	token = string(tokenBytes)
@@ -55,8 +59,7 @@ func LoadToken(warn bool) (string, string, error) {
 
 	username = tokenInfo.Login
 	if username == "" && warn {
-		// Token invalid: Delete file?
-		fmt.Println("You are not logged in.")
+		noTokenWarning(warn)
 		token = ""
 	}
 	return username, token, nil

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"github.com/G-Node/gin-cli/client"
 	"github.com/G-Node/gin-core/gin"
@@ -150,7 +149,7 @@ func Login(userarg interface{}) error {
 	}
 
 	fmt.Printf("[Login success] You are now logged in as %s\n", username)
-	fmt.Printf("You have been granted the following permissions: %v\n", strings.Replace(authresp.Scope, " ", ", ", -1))
+	// fmt.Printf("You have been granted the following permissions: %v\n", strings.Replace(authresp.Scope, " ", ", ", -1))
 
 	return nil
 

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -117,7 +117,7 @@ func Login(userarg interface{}) error {
 		// read error or gopass.ErrInterrupted
 		if err == gopass.ErrInterrupted {
 			fmt.Println("Cancelled.")
-			return err
+			return nil
 		}
 		if err == gopass.ErrMaxLengthExceeded {
 			fmt.Println("Error: Input too long.")

--- a/main.go
+++ b/main.go
@@ -31,30 +31,29 @@ func createRepo(name, description interface{}) error {
 	return repo.CreateRepo(repoName, repoDesc)
 }
 
-func upload(path interface{}) error {
-	// Check if the current directory is a git repository.
-	// If it has any unstaged commits it should stage, commit, and push.
-	// repo.UploadRepo(path)
-	return fmt.Errorf("Command [upload] not yet implemented.")
+func upload(patharg interface{}) error {
+	var pathstr string
+	if patharg == nil {
+		pathstr = ""
+	} else {
+		pathstr = patharg.(string)
+	}
+	return repo.UploadRepo(pathstr)
 }
 
-func download(path interface{}) error {
+func download(patharg interface{}) error {
 	// Check if the current directory is a git repository.
 	// Perform a git pull.
 	var pathstr string
-	if path == nil {
+	if patharg == nil {
 		pathstr = ""
 	} else {
-		pathstr = path.(string)
+		pathstr = patharg.(string)
 	}
 	if pathstr == "" {
 		return fmt.Errorf("No repository specified.")
 	}
-	err := repo.DownloadRepo(pathstr)
-	if err != nil {
-		return err
-	}
-	return nil
+	return repo.DownloadRepo(pathstr)
 }
 
 // condAppend Conditionally append str to b if not empty

--- a/main.go
+++ b/main.go
@@ -33,9 +33,7 @@ func createRepo(name, description interface{}) error {
 
 func upload(patharg interface{}) error {
 	var pathstr string
-	if patharg == nil {
-		pathstr = ""
-	} else {
+	if patharg != nil {
 		pathstr = patharg.(string)
 	}
 	return repo.UploadRepo(pathstr)

--- a/repo/git.go
+++ b/repo/git.go
@@ -43,6 +43,8 @@ func matchPathCB(p, mp string) int {
 
 // **************** //
 
+// Git commands
+
 func getRepo(startPath string) (*git.Repository, error) {
 	localRepoPath, err := git.Discover(startPath, false, nil)
 	if err != nil {
@@ -137,6 +139,36 @@ func Commit(localPath string, idx *git.Index) error {
 	return err
 
 }
+
+// Push pushes all local commits to theh default remote & branch
+// (git push)
+func Push(localPath string) error {
+	repository, err := git.OpenRepository(localPath)
+	if err != nil {
+		return err
+	}
+
+	origin, err := repository.Remotes.Lookup("origin")
+	if err != nil {
+		return err
+	}
+
+	rcbs := git.RemoteCallbacks{
+		CredentialsCallback:      credsCB,
+		CertificateCheckCallback: certCB,
+	}
+
+	popts := &git.PushOptions{
+		RemoteCallbacks: rcbs,
+	}
+	refspecs := []string{"refs/heads/master"}
+
+	return origin.Push(refspecs, popts)
+}
+
+// **************** //
+
+// Git annex commands
 
 // AnnexPull downloads all annexed files.
 // (git annex sync --no-push --content)

--- a/repo/git.go
+++ b/repo/git.go
@@ -36,6 +36,31 @@ func remoteCreateCB(repo *git.Repository, name, url string) (*git.Remote, git.Er
 
 // **************** //
 
+func getRepo(startPath string) (*git.Repository, error) {
+	localRepoPath, err := git.Discover(startPath, false, nil)
+	if err != nil {
+		return nil, err
+	}
+	return git.OpenRepository(localRepoPath)
+}
+
+// AddPath adds files or directories to the index
+func AddPath(localPath string) error {
+	repo, err := getRepo(localPath)
+	if err != nil {
+		return err
+	}
+	idx, err := repo.Index()
+	if err != nil {
+		return err
+	}
+	err = idx.AddByPath(localPath)
+	if err != nil {
+		return err
+	}
+	return idx.Write()
+}
+
 // Clone downloads a repository and sets the remote fetch and push urls.
 // (git clone ...)
 func Clone(repopath string) (*git.Repository, error) {
@@ -64,8 +89,8 @@ func Clone(repopath string) (*git.Repository, error) {
 
 // AnnexPull downloads all annexed files.
 // (git annex sync --no-push --content)
-func AnnexPull(path string) error {
-	_, err := exec.Command("git", "-C", path, "annex", "sync", "--no-push", "--content").Output()
+func AnnexPull(localPath string) error {
+	_, err := exec.Command("git", "-C", localPath, "annex", "sync", "--no-push", "--content").Output()
 
 	if err != nil {
 		return fmt.Errorf("Error downloading files: %s", err.Error())

--- a/repo/git.go
+++ b/repo/git.go
@@ -34,6 +34,10 @@ func remoteCreateCB(repo *git.Repository, name, url string) (*git.Remote, git.Er
 	return remote, git.ErrOk
 }
 
+func matchPathCB(p, mp string) int {
+	return 0
+}
+
 // **************** //
 
 func getRepo(startPath string) (*git.Repository, error) {
@@ -46,19 +50,23 @@ func getRepo(startPath string) (*git.Repository, error) {
 
 // AddPath adds files or directories to the index
 func AddPath(localPath string) error {
-	repo, err := getRepo(localPath)
-	if err != nil {
-		return err
-	}
-	idx, err := repo.Index()
-	if err != nil {
-		return err
-	}
-	err = idx.AddByPath(localPath)
-	if err != nil {
-		return err
-	}
-	return idx.Write()
+	// repo, err := getRepo(localPath)
+	// if err != nil {
+	// 	return err
+	// }
+	// idx, err := repo.Index()
+	// if err != nil {
+	// 	return err
+	// }
+	// Currently adding everything to annex
+	// Eventually will decide on what is versioned and what is annexed based on MIME type
+	// err = idx.AddAll([]string{localPath}, git.IndexAddDefault, matchPathCB)
+	// if err != nil {
+	// 	return err
+	// }
+	// return idx.Write()
+
+	return AnnexAdd(localPath)
 }
 
 // Clone downloads a repository and sets the remote fetch and push urls.
@@ -95,6 +103,16 @@ func AnnexPull(localPath string) error {
 	if err != nil {
 		return fmt.Errorf("Error downloading files: %s", err.Error())
 	}
+	return nil
+}
 
+// AnnexAdd adds a path to the annex
+// (git annex add)
+func AnnexAdd(localPath string) error {
+	_, err := exec.Command("git", "annex", "add", localPath).Output()
+
+	if err != nil {
+		return fmt.Errorf("Error adding files to repository: %s", err.Error())
+	}
 	return nil
 }

--- a/repo/git.go
+++ b/repo/git.go
@@ -106,7 +106,18 @@ func AnnexPull(localPath string) error {
 	return nil
 }
 
-// AnnexAdd adds a path to the annex
+// AnnexPush uploads all annexed files.
+// (git annex sync --no-pull --content)
+func AnnexPush(localPath string) error {
+	_, err := exec.Command("git", "-C", localPath, "annex", "sync", "--no-pull", "--content").Output()
+
+	if err != nil {
+		return fmt.Errorf("Error uploading files: %s", err.Error())
+	}
+	return nil
+}
+
+// AnnexAdd adds a path to the annex.
 // (git annex add)
 func AnnexAdd(localPath string) error {
 	_, err := exec.Command("git", "annex", "add", localPath).Output()

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -59,20 +59,12 @@ func CreateRepo(name, description string) error {
 		return fmt.Errorf("Failed to create repository. Server returned: %s", res.Status)
 	}
 
-	// TODO: Initialise? Do a git annex init and push?
-
 	return nil
 }
 
-// ResolvePath resolves a valid repository path given a user's input.
-func ResolvePath(path string) (string, error) {
-	// TODO: Write the function, eh?
-	return path, nil
-}
-
-// UploadRepo adds files to a repository and upload.
-func UploadRepo(path string) error {
-	return nil
+// UploadRepo adds files to a repository and uploads them.
+func UploadRepo(localPath string) error {
+	return AddPath(localPath)
 }
 
 // DownloadRepo downloads the files of a given repository.

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -73,9 +73,12 @@ func UploadRepo(localPath string) error {
 		return err
 	}
 
-	// TODO: git push then annexpush
+	err = Push(localPath)
+	if err != nil {
+		return err
+	}
 
-	return nil
+	return AnnexPush(localPath)
 }
 
 // DownloadRepo downloads the files of a given repository.

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -64,7 +64,18 @@ func CreateRepo(name, description string) error {
 
 // UploadRepo adds files to a repository and uploads them.
 func UploadRepo(localPath string) error {
-	return AddPath(localPath)
+	idx, err := AddPath(localPath)
+	if err != nil {
+		return err
+	}
+	err = Commit(localPath, idx)
+	if err != nil {
+		return err
+	}
+
+	// TODO: git push then annexpush
+
+	return nil
 }
 
 // DownloadRepo downloads the files of a given repository.


### PR DESCRIPTION
Adds upload command which performs the following operations:
- Adds all specified files (or directories) to the annex.
- Performs a git commit.
- Pushes to default remote.

Also fixes an issue where git actions against a remote would hang the client as the credential check would continuously repeat on failure.