### PR TITLE
Generate temporary keys for git remote transactions

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -8,8 +8,10 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path/filepath"
 
 	"github.com/G-Node/gin-cli/client"
+	"github.com/G-Node/gin-cli/util"
 	"github.com/G-Node/gin-core/gin"
 	"github.com/howeyc/gopass"
 )
@@ -17,8 +19,8 @@ import (
 const authhost = "https://auth.gin.g-node.org"
 
 func storeToken(token string) error {
-	// TODO: Store token in config directory
-	return ioutil.WriteFile("token", []byte(token), 0600)
+	tokenfile := filepath.Join(util.ConfigPath(), "token")
+	return ioutil.WriteFile(tokenfile, []byte(token), 0600)
 }
 
 func noTokenWarning(warn bool) {
@@ -29,8 +31,8 @@ func noTokenWarning(warn bool) {
 
 // LoadToken Get the current signed in username and auth token
 func LoadToken(warn bool) (string, string, error) {
-	// TODO: Load token from config directory
-	tokenBytes, err := ioutil.ReadFile("token")
+	tokenfile := filepath.Join(util.ConfigPath(), "token")
+	tokenBytes, err := ioutil.ReadFile(tokenfile)
 	tokenInfo := gin.TokenInfo{}
 	var username, token string
 

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func download(patharg interface{}) error {
 // condAppend Conditionally append str to b if not empty
 func condAppend(b *bytes.Buffer, str *string) {
 	if str != nil && *str != "" {
-		b.WriteString(*str + " ")
+		_, _ = b.WriteString(*str + " ")
 	}
 }
 
@@ -143,10 +143,10 @@ func printAccountInfo(userarg interface{}) error {
 
 	var outBuffer bytes.Buffer
 
-	outBuffer.WriteString(fmt.Sprintf("User [%s]\nName: %s\n", info.Login, fullnameBuffer.String()))
+	_, _ = outBuffer.WriteString(fmt.Sprintf("User [%s]\nName: %s\n", info.Login, fullnameBuffer.String()))
 
 	if info.Email != nil && info.Email.Email != "" {
-		outBuffer.WriteString(fmt.Sprintf("Email: %s\n", info.Email.Email))
+		_, _ = outBuffer.WriteString(fmt.Sprintf("Email: %s\n", info.Email.Email))
 		// TODO: Display public status if current user == info.Login
 	}
 
@@ -160,7 +160,7 @@ func printAccountInfo(userarg interface{}) error {
 		condAppend(&affiliationBuffer, &affiliation.Country)
 
 		if affiliationBuffer.Len() > 0 {
-			outBuffer.WriteString(fmt.Sprintf("Affiliation: %s\n", affiliationBuffer.String()))
+			_, _ = outBuffer.WriteString(fmt.Sprintf("Affiliation: %s\n", affiliationBuffer.String()))
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -41,17 +41,15 @@ func upload(patharg interface{}) error {
 
 func download(patharg interface{}) error {
 	// Check if the current directory is a git repository.
-	// Perform a git pull.
+	// Y: Perform a git pull.
+	// N: Clone, then pull.
 	var pathstr string
 	if patharg == nil {
 		pathstr = ""
-	} else {
-		pathstr = patharg.(string)
+		// TODO: Pull and Annex Pull
 	}
-	if pathstr == "" {
-		return fmt.Errorf("No repository specified.")
-	}
-	return repo.DownloadRepo(pathstr)
+	pathstr = patharg.(string)
+	return repo.CloneRepo(pathstr)
 }
 
 // condAppend Conditionally append str to b if not empty

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -81,8 +81,8 @@ func UploadRepo(localPath string) error {
 	return AnnexPush(localPath)
 }
 
-// DownloadRepo downloads the files of a given repository.
-func DownloadRepo(repoPath string) error {
+// CloneRepo downloads the files of a given repository.
+func CloneRepo(repoPath string) error {
 	localPath := path.Base(repoPath)
 	fmt.Printf("Fetching repository '%s'... ", localPath)
 	_, err := Clone(repoPath)

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -64,10 +64,13 @@ func CreateRepo(name, description string) error {
 
 // UploadRepo adds files to a repository and uploads them.
 func UploadRepo(localPath string) error {
+	defer CleanUpTemp()
+
 	idx, err := AddPath(localPath)
 	if err != nil {
 		return err
 	}
+
 	err = Commit(localPath, idx)
 	if err != nil {
 		return err
@@ -83,6 +86,8 @@ func UploadRepo(localPath string) error {
 
 // CloneRepo downloads the files of a given repository.
 func CloneRepo(repoPath string) error {
+	defer CleanUpTemp()
+
 	localPath := path.Base(repoPath)
 	fmt.Printf("Fetching repository '%s'... ", localPath)
 	_, err := Clone(repoPath)

--- a/util/keygen.go
+++ b/util/keygen.go
@@ -1,0 +1,43 @@
+package util
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// KeyPair simply holds a private-public key pair as strings, with no extra information.
+type KeyPair struct {
+	Private string
+	Public  string
+}
+
+// MakeKeyPair generates and returns a private-public key pair.
+func MakeKeyPair() (*KeyPair, error) {
+	privkey, err := rsa.GenerateKey(rand.Reader, 2048) // TODO: Key size as parameter
+	if err != nil {
+		return nil, fmt.Errorf("Error generating key pair: %s", err)
+	}
+
+	// Private key to string
+	privkeyDer := x509.MarshalPKCS1PrivateKey(privkey)
+	privBlk := pem.Block{
+		Type:    "RSA PRIVATE KEY",
+		Headers: nil,
+		Bytes:   privkeyDer,
+	}
+	privStr := string(pem.EncodeToMemory(&privBlk))
+
+	// Public key to string
+	pubkey, err := ssh.NewPublicKey(&privkey.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+	pubStr := string(ssh.MarshalAuthorizedKey(pubkey))
+
+	return &KeyPair{privStr, pubStr}, nil
+}

--- a/util/xdg.go
+++ b/util/xdg.go
@@ -25,9 +25,9 @@ func ConfigPath() (path string) {
 
 	if xdghome != "" {
 		path = filepath.Join(xdghome, suffix)
+	} else {
+		path = filepath.Join(homedir, ".config", suffix)
 	}
-
-	path = filepath.Join(homedir, ".config", suffix)
 	makePath(path)
 	return path
 }

--- a/util/xdg.go
+++ b/util/xdg.go
@@ -1,0 +1,33 @@
+// Simple utility functions for getting configuration paths based on the XDG specification.
+
+package util
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+var suffix = "gin"
+
+func makePath(path string) {
+	err := os.MkdirAll(path, 0777)
+	if err != nil {
+		fmt.Printf("Error accessing directory %s\n", path)
+		panic(err)
+	}
+}
+
+// ConfigPath returns the configuration path where configuration files should be stored.
+func ConfigPath() (path string) {
+	xdghome := os.Getenv("XDG_CONFIG_HOME")
+	homedir := os.Getenv("HOME")
+
+	if xdghome != "" {
+		path = filepath.Join(xdghome, suffix)
+	}
+
+	path = filepath.Join(homedir, ".config", suffix)
+	makePath(path)
+	return path
+}


### PR DESCRIPTION
When making transactions against a git repo (clone, pull, push), and the SSH agent identity fails (or does not exist), the following now occurs:

1. A temporary key pair is generated.
2. The public key is uploaded to gin-auth (requires a valid token).
3. The private key is used to perform the git transaction.
4. The private key is stored in a temporary directory.
5. The temporary private key file is used for the git-annex shell command.
6. The temporary directory is removed.

Temporary file is required for the git-annex commands, since the client currently uses exec to run annex.

Additionally, the token is now stored in a configuration path (determined based on the XDG specification).