### PR TITLE
Download in existing (checked out) repository

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,21 +40,18 @@ func upload(patharg interface{}) error {
 }
 
 func download(patharg interface{}) error {
-	// Check if the current directory is a git repository.
-	// Y: Perform a git pull.
-	// N: Clone, then pull.
-	if repo.IsRepo(".") {
-		if patharg != nil {
-			// TODO: File specified. Download specified file(s) only.
-		}
-	}
 	var pathstr string
-	if patharg == nil {
-		pathstr = ""
-		// TODO: Pull and Annex Pull
+	if patharg != nil {
+		pathstr = patharg.(string)
+		return repo.CloneRepo(pathstr)
 	}
-	pathstr = patharg.(string)
-	return repo.CloneRepo(pathstr)
+
+	// No repo specified -- attempting to pull in cwd
+	if repo.IsRepo(".") {
+		return repo.DownloadRepo()
+	}
+
+	return fmt.Errorf("Current directory is not a repository.")
 }
 
 // condAppend Conditionally append str to b if not empty

--- a/main.go
+++ b/main.go
@@ -43,6 +43,11 @@ func download(patharg interface{}) error {
 	// Check if the current directory is a git repository.
 	// Y: Perform a git pull.
 	// N: Clone, then pull.
+	if repo.IsRepo(".") {
+		if patharg != nil {
+			// TODO: File specified. Download specified file(s) only.
+		}
+	}
 	var pathstr string
 	if patharg == nil {
 		pathstr = ""

--- a/repo/git.go
+++ b/repo/git.go
@@ -137,6 +137,15 @@ func matchPathCB(p, mp string) int {
 
 // Git commands
 
+// IsRepo checks whether a given path is a git repository.
+func IsRepo(path string) bool {
+	err := getRepo(path)
+	if err != nil {
+		return false
+	}
+	return true
+}
+
 func getRepo(startPath string) (*git.Repository, error) {
 	localRepoPath, err := git.Discover(startPath, false, nil)
 	if err != nil {
@@ -232,7 +241,13 @@ func Commit(localPath string, idx *git.Index) error {
 
 }
 
-// Push pushes all local commits to theh default remote & branch
+// Pull pulls all remote commits from the default remote & branch
+// (git pull)
+func Pull() error {
+	repository, err := git.OpenRepository(".")
+}
+
+// Push pushes all local commits to the default remote & branch
 // (git push)
 func Push(localPath string) error {
 	repository, err := git.OpenRepository(localPath)

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -85,11 +85,10 @@ func UploadRepo(localPath string) error {
 }
 
 // DownloadRepo downloads the files in an already checked out repository.
-func DownloadRepo(repoPath string) error {
+func DownloadRepo() error {
 	defer CleanUpTemp()
-
-	localPath := path.Base(repoPath)
-
+	// Fetch and Merge
+	return Pull()
 }
 
 // CloneRepo downloads the files of a given repository.

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -87,8 +87,15 @@ func UploadRepo(localPath string) error {
 // DownloadRepo downloads the files in an already checked out repository.
 func DownloadRepo() error {
 	defer CleanUpTemp()
-	// Fetch and Merge
-	return Pull()
+	// git pull
+	err := Pull()
+	if err != nil {
+		return err
+	}
+
+	// git annex pull
+	return AnnexPull(".")
+
 }
 
 // CloneRepo downloads the files of a given repository.

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -43,7 +43,7 @@ func GetRepos(user, token string) ([]wire.Repo, error) {
 	return repoList, nil
 }
 
-// CreateRepo creates a repository on the server
+// CreateRepo creates a repository on the server.
 func CreateRepo(name, description string) error {
 	repocl := client.NewClient(repohost)
 	username, token, _ := auth.LoadToken(false)
@@ -82,6 +82,14 @@ func UploadRepo(localPath string) error {
 	}
 
 	return AnnexPush(localPath)
+}
+
+// DownloadRepo downloads the files in an already checked out repository.
+func DownloadRepo(repoPath string) error {
+	defer CleanUpTemp()
+
+	localPath := path.Base(repoPath)
+
 }
 
 // CloneRepo downloads the files of a given repository.


### PR DESCRIPTION
Previously, `gin download` would only perform a `git clone`.
Now, if the command in issued inside an existing repository, it will perform a `git pull` from origin/master.

During the pull (fetch & merge), if merge conflicts are encountered, the download is aborted. We should consider ways this might be automatically resolved. For now, a download succeeds if it can be fastforwarded only.