### PR TITLE
Unlocked annex files (annex v6)

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,6 +31,16 @@ func createRepo(name, description interface{}) {
 	repo.CreateRepo(repoName, repoDesc)
 }
 
+func getRepo(repoarg interface{}) {
+	var repostr string
+	if repoarg != nil {
+		repostr = repoarg.(string)
+		repo.CloneRepo(repostr)
+	} else {
+		util.Die("No repository specified.")
+	}
+}
+
 func upload(patharg interface{}) {
 	var pathstr string
 	if patharg != nil {
@@ -40,18 +50,12 @@ func upload(patharg interface{}) {
 }
 
 func download(patharg interface{}) {
-	var pathstr string
-	if patharg != nil {
-		pathstr = patharg.(string)
-		repo.CloneRepo(pathstr)
-	}
-
-	// No repo specified -- attempting to pull in cwd
+	// TODO: If path is specified, do `git annex get`
 	if repo.IsRepo(".") {
 		repo.DownloadRepo()
+	} else {
+		util.Die("Current directory is not a repository.")
 	}
-
-	util.CheckError(fmt.Errorf("Current directory is not a repository."))
 }
 
 // condAppend Conditionally append str to b if not empty
@@ -192,6 +196,7 @@ GIN command line client
 Usage:
 	gin login    [<username>]
 	gin create   [<name>] [-d <description>]
+	gin get      [<repository>]
 	gin upload   [<path>]
 	gin download [<path>]
 	gin repos    [<username>]
@@ -208,6 +213,8 @@ Usage:
 		auth.Login(args["<username>"])
 	case args["create"].(bool):
 		createRepo(args["<name>"], args["<description>"])
+	case args["get"].(bool):
+		getRepo(args["<repository>"])
 	case args["upload"].(bool):
 		upload(args["<path>"])
 	case args["download"].(bool):

--- a/main.go
+++ b/main.go
@@ -41,16 +41,11 @@ func getRepo(repoarg interface{}) {
 	}
 }
 
-func upload(patharg interface{}) {
-	var pathstr string
-	if patharg != nil {
-		pathstr = patharg.(string)
-	}
-	repo.UploadRepo(pathstr)
+func upload() {
+	repo.UploadRepo(".")
 }
 
-func download(patharg interface{}) {
-	// TODO: If path is specified, do `git annex get`
+func download() {
 	if repo.IsRepo(".") {
 		repo.DownloadRepo()
 	} else {
@@ -197,8 +192,8 @@ Usage:
 	gin login    [<username>]
 	gin create   [<name>] [-d <description>]
 	gin get      [<repository>]
-	gin upload   [<path>]
-	gin download [<path>]
+	gin upload
+	gin download
 	gin repos    [<username>]
 	gin info     [<username>]
 	gin keys     [-v | --verbose]
@@ -216,9 +211,9 @@ Usage:
 	case args["get"].(bool):
 		getRepo(args["<repository>"])
 	case args["upload"].(bool):
-		upload(args["<path>"])
+		upload()
 	case args["download"].(bool):
-		download(args["<path>"])
+		download()
 	case args["info"].(bool):
 		printAccountInfo(args["<username>"])
 	case args["keys"].(bool):

--- a/repo/git.go
+++ b/repo/git.go
@@ -377,6 +377,16 @@ func Push(localPath string) error {
 
 // Git annex commands
 
+// AnnexInit initialises the repository for annex
+// (git annex init)
+func AnnexInit(localPath string) error {
+	err := exec.Command("git", "-C", localPath, "annex", "init").Run()
+	if err != nil {
+		return fmt.Errorf("Repository annex initialisation failed.")
+	}
+	return nil
+}
+
 // AnnexPull downloads all annexed files.
 // (git annex sync --no-push --content)
 func AnnexPull(localPath string) error {

--- a/repo/git.go
+++ b/repo/git.go
@@ -393,6 +393,20 @@ func AnnexInit(localPath string) error {
 	if err != nil {
 		return initError
 	}
+
+	// list of extensions that are added to git (not annex)
+	// TODO: Read from file
+	gitexts := [...]string{"md", "rst", "txt", "c", "cpp", "h", "hpp", "py", "go"}
+	includes := make([]string, len(gitexts))
+	for idx, ext := range gitexts {
+		includes[idx] = fmt.Sprintf("include=*.%s", ext)
+	}
+	sizethreshold := "10M"
+	lfvalue := fmt.Sprintf("largerthan=%s and not (%s)", sizethreshold, strings.Join(includes, " or "))
+	err = exec.Command("git", "-C", localPath, "config", "annex.largefiles", lfvalue).Run()
+	if err != nil {
+		return initError
+	}
 	return nil
 }
 

--- a/repo/git.go
+++ b/repo/git.go
@@ -187,8 +187,8 @@ func Clone(repopath string) (*git.Repository, error) {
 	}
 	fetchopts := &git.FetchOptions{RemoteCallbacks: *cbs}
 	opts := git.CloneOptions{
-		Bare:                 false,
-		CheckoutBranch:       "master", // TODO: default branch
+		Bare: false,
+		// CheckoutBranch:       "master", // TODO: default branch
 		FetchOptions:         fetchopts,
 		RemoteCreateCallback: remoteCreateCB,
 	}

--- a/repo/git.go
+++ b/repo/git.go
@@ -409,7 +409,6 @@ func AnnexInit(localPath string) error {
 // (git annex sync --no-push --content)
 // (git annex get --all)
 func AnnexPull(localPath string) error {
-	// cmd := exec.Command("git", "-C", localPath, "annex", "sync", "--no-push", "--content")
 	cmd := exec.Command("git", "-C", localPath, "annex", "get", "--all")
 	if privKeyFile.Active {
 		cmd.Args = append(cmd.Args, "-c", privKeyFile.SSHOptString())

--- a/repo/git.go
+++ b/repo/git.go
@@ -163,11 +163,6 @@ func AddPath(localPath string) (*git.Index, error) {
 	if err != nil {
 		return nil, err
 	}
-	// err = idx.AddAll([]string{localPath}, git.IndexAddDefault, matchPathCB)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// return idx, idx.Write()
 	err = AnnexAdd(localPath, idx)
 	return idx, err
 }
@@ -473,10 +468,6 @@ func AnnexAdd(localPath string, idx *git.Index) error {
 		if !outStruct.Success {
 			return fmt.Errorf("Error adding files to repository: Failed to add %s", outStruct.File)
 		}
-		// err = idx.AddByPath(outStruct.File)
-		// if err != nil {
-		// 	return err
-		// }
 	}
 
 	return nil

--- a/repo/git.go
+++ b/repo/git.go
@@ -214,12 +214,15 @@ func Commit(localPath string, idx *git.Index) error {
 		return err
 	}
 	head, err := repository.Head()
+	var headCommit *git.Commit
 	if err != nil {
-		return err
-	}
-	headCommit, err := repository.LookupCommit(head.Target())
-	if err != nil {
-		return err
+		// Head commit not found. Root commit?
+		head = nil
+	} else {
+		headCommit, err = repository.LookupCommit(head.Target())
+		if err != nil {
+			return err
+		}
 	}
 
 	message := "uploading" // TODO: Describe changes (in message)
@@ -235,9 +238,12 @@ func Commit(localPath string, idx *git.Index) error {
 	if err != nil {
 		return err
 	}
-	_, err = repository.CreateCommit("HEAD", signature, signature, message, tree, headCommit)
+	if headCommit == nil {
+		_, err = repository.CreateCommit("HEAD", signature, signature, message, tree)
+	} else {
+		_, err = repository.CreateCommit("HEAD", signature, signature, message, tree, headCommit)
+	}
 	return err
-
 }
 
 // Pull pulls all remote commits from the default remote & branch

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -60,12 +60,12 @@ func CreateRepo(name, description string) {
 func UploadRepo(localPath string) {
 	defer CleanUpTemp()
 
-	idx, err := AddPath(localPath)
+	_, err := AddPath(localPath)
 	util.CheckError(err)
-	err = Commit(localPath, idx)
-	util.CheckError(err)
-	err = Push(localPath)
-	util.CheckError(err)
+	// err = Commit(localPath, idx)
+	// util.CheckError(err)
+	// err = Push(localPath)
+	// util.CheckError(err)
 	err = AnnexPush(localPath)
 	util.CheckError(err)
 }
@@ -74,10 +74,10 @@ func UploadRepo(localPath string) {
 func DownloadRepo() {
 	defer CleanUpTemp()
 	// git pull
-	err := Pull()
-	util.CheckError(err)
+	// err := Pull()
+	// util.CheckError(err)
 	// git annex pull
-	err = AnnexPull(".")
+	err := AnnexPull(".")
 	util.CheckError(err)
 }
 
@@ -88,10 +88,9 @@ func CloneRepo(repoPath string) {
 	localPath := path.Base(repoPath)
 	fmt.Printf("Fetching repository '%s'... ", localPath)
 	_, err := Clone(repoPath)
-	util.CheckError(err)
 	fmt.Printf("done.\n")
 
-	// git annex init the clone
+	// git annex init the clone and set defaults
 	err = AnnexInit(localPath)
 	util.CheckError(err)
 

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -62,10 +62,6 @@ func UploadRepo(localPath string) {
 
 	_, err := AddPath(localPath)
 	util.CheckError(err)
-	// err = Commit(localPath, idx)
-	// util.CheckError(err)
-	// err = Push(localPath)
-	// util.CheckError(err)
 	err = AnnexPush(localPath)
 	util.CheckError(err)
 }
@@ -73,10 +69,6 @@ func UploadRepo(localPath string) {
 // DownloadRepo downloads the files in an already checked out repository.
 func DownloadRepo() {
 	defer CleanUpTemp()
-	// git pull
-	// err := Pull()
-	// util.CheckError(err)
-	// git annex pull
 	err := AnnexPull(".")
 	util.CheckError(err)
 }

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -91,6 +91,11 @@ func CloneRepo(repoPath string) {
 	util.CheckError(err)
 	fmt.Printf("done.\n")
 
+	// git annex init the clone
+	err = AnnexInit(localPath)
+	util.CheckError(err)
+
+	// TODO: Do not try to download files if repo is empty
 	fmt.Printf("Downloading files... ")
 	err = AnnexPull(localPath)
 	util.CheckError(err)


### PR DESCRIPTION
With this PR, annex is used in the new "version 6" mode, which is similar to the old, deprecated, direct mode.

Annexed files are not replaced by symlinks and instead they are kept in the working directory as unlocked. A configuration is set during cloning of the repository so that files with extensions denoting text or source code are not checked into annex but are instead added to git.

Since everything is handled through the annex commands, adding, committing, and pushing via git is no longer necessary. This may change in the future if we need an implementation with more fine grained control over what git and git annex are doing.

The old `download` command has now been separated into `download`, for synchronising file contents from remotes, and `get`, for cloning a remote repository. The old command would do one or the other depending on context, but the new separation is better for avoiding confusion.

This PR resolves the following issues:
- #17
- #18
- #20 

