### PR TITLE
Temporary key handling fixes

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -187,7 +187,7 @@ func SearchAccount(query string) []gin.Account {
 	return results
 }
 
-// AddKey Adds the given key to the current user's authorised keys
+// AddKey adds the given key to the current user's authorised keys
 func AddKey(key, description string, temp bool) error {
 	username, token, err := LoadToken(true)
 	util.CheckErrorMsg(err, "This command requires login.")

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -167,9 +167,9 @@ func SearchAccount(query string) []gin.Account {
 
 	params := url.Values{}
 	params.Add("q", query)
-	url := fmt.Sprintf("%s/api/accounts?%s", authhost, params.Encode())
 	authcl := client.NewClient(authhost)
-	res, err := authcl.Get(url)
+	address := fmt.Sprintf("/api/accounts?%s", params.Encode())
+	res, err := authcl.Get(address)
 	util.CheckErrorMsg(err, "[Account search] Request failed.")
 
 	if res.StatusCode != 200 {

--- a/client/client.go
+++ b/client/client.go
@@ -39,7 +39,7 @@ func (client *Client) DoLogin(username, password string) ([]byte, error) {
 	params.Add("username", username)
 	params.Add("password", password)
 	params.Add("grant_type", "password")
-	params.Add("client_id", "gin")
+	params.Add("client_id", "gin-cli")
 	params.Add("client_secret", "97196a1c-silly-biscuit3-d161ea15a676")
 
 	address := fmt.Sprintf("%s/oauth/token", client.Host)

--- a/client/client.go
+++ b/client/client.go
@@ -40,7 +40,7 @@ func (client *Client) DoLogin(username, password string) ([]byte, error) {
 	params.Add("password", password)
 	params.Add("grant_type", "password")
 	params.Add("client_id", "gin")
-	params.Add("client_secret", "secret")
+	params.Add("client_secret", "97196a1c-silly-biscuit3-d161ea15a676")
 
 	address := fmt.Sprintf("%s/oauth/token", client.Host)
 

--- a/main.go
+++ b/main.go
@@ -96,7 +96,7 @@ func addKey(fnarg interface{}) {
 	// TODO: Accept custom description for key and simply default to filename
 	key := string(keyBytes)
 	description := strings.TrimSpace(strings.Split(key, " ")[2])
-	err = auth.AddKey(string(keyBytes), description)
+	err = auth.AddKey(string(keyBytes), description, false)
 	util.CheckError(err)
 	fmt.Printf("New key added '%s'\n", description)
 }

--- a/repo/git.go
+++ b/repo/git.go
@@ -36,11 +36,13 @@ func setupTempKeyPair() (*util.KeyPair, error) {
 	}
 
 	privKeyFile, err = util.SaveTempKeyFile(tempKeyPair.Private)
+	if err != nil {
+		return nil, err
+	}
 
 	description := fmt.Sprintf("tmpkey@%s", strconv.FormatInt(time.Now().Unix(), 10))
 	pubkey := fmt.Sprintf("%s %s", strings.TrimSpace(tempKeyPair.Public), description)
 	err = auth.AddKey(pubkey, description, true)
-
 	if err != nil {
 		return nil, err
 	}

--- a/repo/git.go
+++ b/repo/git.go
@@ -379,7 +379,11 @@ func Push(localPath string) error {
 // (git annex init)
 func AnnexInit(localPath string) error {
 	initError := fmt.Errorf("Repository annex initialisation failed.")
-	err := exec.Command("git", "-C", localPath, "annex", "init", "--version=6").Run()
+	cmd := exec.Command("git", "-C", localPath, "annex", "init", "--version=6")
+	if privKeyFile.Active {
+		cmd.Args = append(cmd.Args, "-c", privKeyFile.SSHOptString())
+	}
+	err := cmd.Run()
 	if err != nil {
 		return initError
 	}

--- a/repo/git.go
+++ b/repo/git.go
@@ -33,7 +33,7 @@ type tempFile struct {
 
 var privKeyFile tempFile
 
-// MakeTempKeyPair create a temporary key pair and stores it in a temporary directory.
+// MakeTempKeyPair creates a temporary key pair and stores it in a temporary directory.
 // It also sets the global tempFile for use by the annex commands. The key pair is
 // returned directly.
 func MakeTempKeyPair() (*util.KeyPair, error) {

--- a/repo/git.go
+++ b/repo/git.go
@@ -87,7 +87,7 @@ func makeCredsCB() git.CredentialsCallback {
 			}
 			description := fmt.Sprintf("tmpkey@%s", strconv.FormatInt(time.Now().Unix(), 10))
 			pubkey := fmt.Sprintf("%s %s", strings.TrimSpace(tempKeyPair.Public), description)
-			err = auth.AddKey(pubkey, description)
+			err = auth.AddKey(pubkey, description, true)
 			if err != nil {
 				return git.ErrUser, nil
 			}

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -64,7 +64,7 @@ func UploadRepo(localPath string) {
 	util.CheckError(err)
 
 	// since no git command is called, we need to explicitly create temporary keys
-	_, err = MakeTempKeyPair()
+	_, err = setupTempKeyPair()
 	util.CheckError(err)
 
 	err = AnnexPush(localPath)

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -62,6 +62,11 @@ func UploadRepo(localPath string) {
 
 	_, err := AddPath(localPath)
 	util.CheckError(err)
+
+	// since no git command is called, we need to explicitly create temporary keys
+	_, err = MakeTempKeyPair()
+	util.CheckError(err)
+
 	err = AnnexPush(localPath)
 	util.CheckError(err)
 }


### PR DESCRIPTION
- Specify temporary key flag when sending key to gin-auth
- Annex init requires key auth
- Temporary key file creation moved to its own function