### PR TITLE
Help text

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,22 +22,83 @@ GIN command line client
 Usage: gin [--version] <command> [<args>...]
 
 Options:
-	-h --help    This help screen
-	--version    Client version
+    -h --help    This help screen
+    --version    Client version
 
 Commands:
-	gin login    [<username>]
-	gin logout
-	gin create   [<name>] [<description>]
-	gin get      [<repopath>]
-	gin upload
-	gin download
-	gin repos    [<username>]
-	gin info     [<username>]
-	gin keys     [-v | --verbose]
-	gin keys     --add <filename>
+    gin login    [<username>]
+    gin logout
+    gin create   [<name>] [<description>]
+    gin get      <repopath>
+    gin upload
+    gin download
+    gin repos    [<username>]
+    gin info     [<username>]
+    gin keys     [-v | --verbose]
+    gin keys     --add <filename>
 
 Command help:
+
+    login        Login to the GIN services
+
+                 If no <username> is specified on the command line, you will be
+                 prompted for it. The login command always prompts for a
+                 password.
+
+
+    logout       Logout of the GIN services
+
+
+    create       Create a new repository on the GIN server
+
+                 If no <name> is provided, you will be prompted for one.
+                 A repository <description> can only be specified on the
+                 command line after the <name>.
+
+
+    get          Download a remote repository to a new directory
+
+                 The repository path <repopath> must be specified on the
+                 command line. A repository  path is the owner's username,
+                 followed by a / and the repository name (e.g., user/datarepo).
+
+
+    upload       Upload local changes to the remote repository
+
+                 The upload command should be run from inside the directory of
+                 an existing repository.
+
+
+    download     Download remote changes to the local repository
+
+                 The download command should be run from inside the directory
+                 of an existing repository.
+
+
+    repos        List accessible repositories
+
+                 Without any argument, lists all the publicly accessible
+                 repositories on the GIN server.
+                 If a <username> is specified, this command will list the
+                 specified user's publicly accessible repositories.
+                 If you are logged in, it will also list any repositories
+                 owned by the user that you have access to.
+
+    info         Print user information
+
+                 Without argument, print the information of the currently
+                 logged in user or, if you are not logged in, prompt for a
+                 username to look up.
+                 If a <username> is specified, print the user's information.
+
+
+    keys         List or add SSH keys
+
+                 By default will list the keys (description and fingerprint)
+                 associated with the logged in user. The verbose flag will also
+                 print the full public keys.
+                 To add a new key, use the --add option and specify a pub key
+                 <filename>.
 `
 
 // TODO: Load from config

--- a/main.go
+++ b/main.go
@@ -59,17 +59,18 @@ Command help:
     get          Download a remote repository to a new directory
 
                  The repository path <repopath> must be specified on the
-                 command line. A repository  path is the owner's username,
-                 followed by a / and the repository name (e.g., user/datarepo).
+                 command line. A repository path is the owner's username,
+                 followed by a "/" and the repository name
+                 (e.g., peter/eegdata).
 
 
-    upload       Upload local changes to the remote repository
+    upload       Upload local repository changes to the remote repository
 
                  The upload command should be run from inside the directory of
                  an existing repository.
 
 
-    download     Download remote changes to the local repository
+    download     Download remote repository changes to the local repository
 
                  The download command should be run from inside the directory
                  of an existing repository.

--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ Command help:
                  If no <name> is provided, you will be prompted for one.
                  A repository <description> can only be specified on the
                  command line after the <name>.
+                 Login required. 
 
 
     get          Download a remote repository to a new directory
@@ -62,6 +63,7 @@ Command help:
                  command line. A repository path is the owner's username,
                  followed by a "/" and the repository name
                  (e.g., peter/eegdata).
+                 Login required.
 
 
     upload       Upload local repository changes to the remote repository
@@ -88,6 +90,7 @@ Command help:
                  If you are logged in, it will also list any repositories
                  owned by the user that you have access to.
 
+
     info         Print user information
 
                  Without argument, print the information of the currently
@@ -103,6 +106,7 @@ Command help:
                  print the full public keys.
                  To add a new key, use the --add option and specify a pub key
                  <filename>.
+                 Login required.
 `
 
 // TODO: Load from config

--- a/main.go
+++ b/main.go
@@ -66,12 +66,15 @@ Command help:
 
     upload       Upload local repository changes to the remote repository
 
+                 Uploads any changes made on the local data to the GIN server.
                  The upload command should be run from inside the directory of
                  an existing repository.
 
 
     download     Download remote repository changes to the local repository
 
+                 Downloads any changes made to the data on the server to the
+                 local data directory.
                  The download command should be run from inside the directory
                  of an existing repository.
 

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/G-Node/gin-cli/auth"
 	"github.com/G-Node/gin-cli/repo"
 	"github.com/G-Node/gin-cli/util"
+	"github.com/G-Node/gin-cli/web"
 	"github.com/docopt/docopt-go"
 	"github.com/howeyc/gopass"
 )
@@ -61,6 +62,17 @@ func login(userarg interface{}) {
 	util.CheckError(err)
 	fmt.Printf("[Login success] You are now logged in as %s\n", username)
 	// fmt.Printf("You have been granted the following permissions: %v\n", strings.Replace(authresp.Scope, " ", ", ", -1))
+}
+
+func logout() {
+	authcl := auth.NewClient("") // host configuration unnecessary
+	err := authcl.LoadToken()
+	if err != nil {
+		util.Die("You are not logged in.")
+	}
+
+	err = web.DeleteToken()
+	util.CheckErrorMsg(err, "Error deleting user token.")
 }
 
 func createRepo(name, description interface{}) {
@@ -128,7 +140,6 @@ func condAppend(b *bytes.Buffer, str *string) {
 }
 
 func printKeys(printFull bool) {
-
 	authcl := auth.NewClient(authhost)
 	keys, err := authcl.GetUserKeys()
 	util.CheckError(err)
@@ -256,6 +267,7 @@ GIN command line client
 
 Usage:
 	gin login    [<username>]
+	gin logout
 	gin create   [<name>] [-d <description>]
 	gin get      [<repopath>]
 	gin upload
@@ -293,5 +305,7 @@ Usage:
 		}
 	case args["repos"].(bool):
 		listRepos(args["<username>"])
+	case args["logout"].(bool):
+		logout()
 	}
 }

--- a/main.go
+++ b/main.go
@@ -360,14 +360,17 @@ func printAccountInfo(args []string) {
 	fmt.Println(outBuffer.String())
 }
 
-func listRepos(userarg interface{}) {
+func listRepos(args []string) {
+	if len(args) > 1 {
+		util.Die(usage)
+	}
 	var username string
 	repocl := repo.NewClient(repohost)
 
-	if userarg == nil {
+	if len(args) == 0 {
 		username = ""
 	} else {
-		username = userarg.(string)
+		username = args[0]
 	}
 	repos, err := repocl.GetRepos(username)
 	util.CheckError(err)

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -32,16 +32,19 @@ func (repocl *Client) GetRepos(user string) ([]wire.Repo, error) {
 
 	if user == "" {
 		res, err = repocl.Get("/repos/public")
+		fmt.Print("Listing all public repositories\n\n")
 	} else {
 		err = repocl.LoadToken()
 		if err != nil {
-			return repoList, err
+			fmt.Print("You are not logged in - Showing public repositories\n\n")
 		}
 		res, err = repocl.Get(fmt.Sprintf("/users/%s/repos", user))
 	}
 
 	if err != nil {
 		return repoList, err
+	} else if res.StatusCode == 404 {
+		return repoList, fmt.Errorf("Server returned empty result. Either user does not exist or has no accessible repositories.")
 	} else if res.StatusCode != 200 {
 		return repoList, fmt.Errorf("[Repository request] Failed. Server returned: %s", res.Status)
 	}

--- a/util/xdg.go
+++ b/util/xdg.go
@@ -10,16 +10,16 @@ import (
 
 var suffix = "gin"
 
-func makePath(path string) {
+func makePath(path string) error {
 	err := os.MkdirAll(path, 0777)
 	if err != nil {
-		fmt.Printf("Error accessing directory %s\n", path)
-		panic(err)
+		return fmt.Errorf("Error accessing directory %s\n", path)
 	}
+	return nil
 }
 
 // ConfigPath returns the configuration path where configuration files should be stored.
-func ConfigPath() (path string) {
+func ConfigPath(create bool) (path string, err error) {
 	// TODO: OS dependent paths
 	xdghome := os.Getenv("XDG_CONFIG_HOME")
 	homedir := os.Getenv("HOME")
@@ -29,6 +29,11 @@ func ConfigPath() (path string) {
 	} else {
 		path = filepath.Join(homedir, ".config", suffix)
 	}
-	makePath(path)
-	return path
+	if create {
+		err = makePath(path)
+		if err != nil {
+			return "", err
+		}
+	}
+	return path, err
 }

--- a/web/web.go
+++ b/web/web.go
@@ -48,7 +48,9 @@ func (cl *Client) Get(address string) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", cl.Token))
+	if cl.Token != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", cl.Token))
+	}
 	return cl.web.Do(req)
 }
 
@@ -64,8 +66,10 @@ func (cl *Client) Post(address string, data interface{}) (*http.Response, error)
 	if err != nil {
 		return nil, err
 	}
-	// TODO: Don't set Authorization if Token is empty
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", cl.Token))
+
+	if cl.Token != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", cl.Token))
+	}
 	return cl.web.Do(req)
 }
 

--- a/web/web.go
+++ b/web/web.go
@@ -119,6 +119,12 @@ func (ut *UserToken) StoreToken() error {
 	return encoder.Encode(ut)
 }
 
+// DeleteToken deletes the token file if it exists. It essentially logs out the user.
+func DeleteToken() {
+	filepath := filepath.Join(util.ConfigPath(), "token")
+	_ = os.Remove(filepath)
+}
+
 // CloseRes closes a given result buffer (for use with defer).
 func CloseRes(b io.ReadCloser) {
 	err := b.Close()

--- a/web/web.go
+++ b/web/web.go
@@ -95,7 +95,11 @@ func NewClient(address string) *Client {
 // LoadToken reads the username and auth token from the token file and sets the
 // values in the struct.
 func (ut *UserToken) LoadToken() error {
-	filepath := filepath.Join(util.ConfigPath(), "token")
+	path, err := util.ConfigPath(false)
+	if err != nil {
+		return fmt.Errorf("Could not read token: Error accessing config directory.")
+	}
+	filepath := filepath.Join(path, "token")
 	file, err := os.Open(filepath)
 	if err != nil {
 		return fmt.Errorf("Error loading user token")
@@ -108,7 +112,11 @@ func (ut *UserToken) LoadToken() error {
 
 // StoreToken saves the username and auth token to the token file.
 func (ut *UserToken) StoreToken() error {
-	filepath := filepath.Join(util.ConfigPath(), "token")
+	path, err := util.ConfigPath(true)
+	if err != nil {
+		return fmt.Errorf("Could not save token: Error creating or accessing config directory.")
+	}
+	filepath := filepath.Join(path, "token")
 	file, err := os.Create(filepath)
 	if err != nil {
 		return fmt.Errorf("Error saving user token.")
@@ -120,9 +128,13 @@ func (ut *UserToken) StoreToken() error {
 }
 
 // DeleteToken deletes the token file if it exists. It essentially logs out the user.
-func DeleteToken() {
-	filepath := filepath.Join(util.ConfigPath(), "token")
-	_ = os.Remove(filepath)
+func DeleteToken() error {
+	path, err := util.ConfigPath(false)
+	if err != nil {
+		return fmt.Errorf("Could not delete token: Error accessing config directory.")
+	}
+	filepath := filepath.Join(path, "token")
+	return os.Remove(filepath)
 }
 
 // CloseRes closes a given result buffer (for use with defer).


### PR DESCRIPTION
This PR is primarily for the usage and help text on the command line. The change affects how the command line arguments are handled in docopt so there's some manual input argument count checks now.

Other changes:
- Optionally create configuration path when trying to access the config file. Before it would create it every time, but there are cases when we would rather default to another action when it does not exist.
- Logout command: Deletes the user token.