### PR TITLE
Travis deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,14 @@ install:
  # coveralls
  - go get github.com/mattn/goveralls
  - go get golang.org/x/tools/cmd/cover
- # go path fork workaround
- # - mkdir $GOPATH/src/github.com/G-Node && ln -s $GOPATH/src/github.com/achilleas-k/gin-cli $GOPATH/src/github.com/G-Node/gin-cli
- - go get ./...
+ # dependencies
+ - go get github.com/docopt/docopt-go
+ - go get github.com/howeyc/gopass
+ - go get golang.org/x/crypto/ssh
+ - go get github.com/G-node/gin-core 
+ - go get github.com/G-Node/gin-repo
+ - go get github.com/libgit2/git2go 
+ - go get golang.org/x/crypto
 
 script:
  - go vet ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,40 +4,39 @@ dist: trusty
 sudo: required
 
 go:
- - 1.7
- - tip
+  - 1.7
+  - tip
 
 before_install:
   - sudo apt-get update
   - sudo apt-get install git-annex
 
 install:
- # tools
- - go get github.com/golang/lint/golint
- - go get github.com/GeertJohan/fgt
- # libgit2 from sauce
- - srcdir=$(pwd)
- - wget -O libgit2.tar.gz -o /dev/null https://github.com/libgit2/libgit2/archive/v0.24.5.tar.gz && tar xzf libgit2.tar.gz && cd libgit2-0.24.5 && mkdir build && cd build && cmake .. && sudo cmake --build . --target install
- - cd $srcdir
- # coveralls
- - go get github.com/mattn/goveralls
- - go get golang.org/x/tools/cmd/cover
- # dependencies
- - go get github.com/docopt/docopt-go
- - go get github.com/howeyc/gopass
- - go get golang.org/x/crypto/ssh
- - go get github.com/G-node/gin-core 
- - go get github.com/G-Node/gin-repo
- - go get github.com/libgit2/git2go 
- - go get golang.org/x/crypto
+  # tools
+  - go get github.com/golang/lint/golint
+  - go get github.com/GeertJohan/fgt
+  # libgit2 from sauce
+  - srcdir=$(pwd)
+  - wget -O libgit2.tar.gz -o /dev/null https://github.com/libgit2/libgit2/archive/v0.24.5.tar.gz && tar xzf libgit2.tar.gz && cd libgit2-0.24.5 && mkdir build && cd build && cmake .. && sudo cmake --build . --target install
+  - cd $srcdir
+  # coveralls
+  - go get github.com/mattn/goveralls
+  - go get golang.org/x/tools/cmd/cover
+  # dependencies
+  - go get github.com/G-node/gin-core/gin
+  - go get github.com/G-Node/gin-repo/wire
+  - go get github.com/docopt/docopt-go
+  - go get github.com/howeyc/gopass
+  - go get golang.org/x/crypto/ssh
+  - go get github.com/libgit2/git2go
 
 script:
- - go vet ./...
- - find -iname "*test.go" -execdir [ ! -e covprof.part ] \; -execdir go test -v -covermode=count -coverprofile=covprof.part \;
+  - go vet ./...
+  - find -iname "*test.go" -execdir [ ! -e covprof.part ] \; -execdir go test -v -covermode=count -coverprofile=covprof.part \;
 
 after_success:
- # collect all coverage profiles
- - "echo \"mode: count\" > profile.cov"
- - "grep -h -v -F \"mode: count\" --include=covprof.part -r . >> profile.cov"
- # upload coverage profile
- - goveralls -coverprofile=profile.cov -service=travis-ci
+  # collect all coverage profiles
+  - "echo \"mode: count\" > profile.cov"
+  - "grep -h -v -F \"mode: count\" --include=covprof.part -r . >> profile.cov"
+  # upload coverage profile
+  - goveralls -coverprofile=profile.cov -service=travis-ci

--- a/util/xdg.go
+++ b/util/xdg.go
@@ -19,10 +19,13 @@ func makePath(path string) error {
 }
 
 // ConfigPath returns the configuration path where configuration files should be stored.
-func ConfigPath(create bool) (path string, err error) {
+func ConfigPath(create bool) (string, error) {
 	// TODO: OS dependent paths
 	xdghome := os.Getenv("XDG_CONFIG_HOME")
 	homedir := os.Getenv("HOME")
+
+	var path string
+	var err error
 
 	if xdghome != "" {
 		path = filepath.Join(xdghome, suffix)


### PR DESCRIPTION
Changing travis config to explicitly pull dependencies. This works around an issue with forks when trying to pull dependencies automatically. It also helps keep track of the dependencies.

I've also included a small change in in `util/xdg.go`: There was no real need to use named return values in the `ConfigPath` function.