### PR TITLE
Annex mode defaults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ before_install:
   - sudo apt-get install git-annex
 
 install:
-  # import path fix for forks
-  - if [ ! -d ${GOPATH}/src/github.com/G-Node/gin-cli ]; then ln -s $srcdir ${GOPATH}/src/github.com/G-Node/gin-cli; fi
   # tools
   - go get github.com/golang/lint/golint
   - go get github.com/GeertJohan/fgt
@@ -21,11 +19,19 @@ install:
   - srcdir=$(pwd)
   - wget -O libgit2.tar.gz -o /dev/null https://github.com/libgit2/libgit2/archive/v0.24.6.tar.gz && tar xzf libgit2.tar.gz && cd libgit2-0.24.6 && mkdir build && cd build && cmake .. && sudo cmake --build . --target install && sudo ldconfig
   - cd $srcdir
-  # gin-cli deps
-  - go get -v ./...
   # coveralls
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
+  # dependencies
+  - go get github.com/docopt/docopt-go
+  - go get github.com/howeyc/gopass
+  - go get golang.org/x/crypto/ssh
+  - go get github.com/G-Node/gin-core/gin
+  - go get github.com/G-Node/gin-repo/wire
+  - go get gopkg.in/libgit2/git2go.v24
+  - go get golang.org/x/crypto/ssh
+  # import path symlink for forks
+  - if [ ! -d ${GOPATH}/src/github.com/G-Node/gin-cli ]; then ln -s $srcdir ${GOPATH}/src/github.com/G-Node/gin-cli; fi
 
 script:
   - go vet ./...

--- a/main.go
+++ b/main.go
@@ -341,8 +341,11 @@ func printAccountInfo(args []string) {
 	_, _ = outBuffer.WriteString(fmt.Sprintf("User [%s]\nName: %s\n", info.Login, fullnameBuffer.String()))
 
 	if info.Email != nil && info.Email.Email != "" {
-		_, _ = outBuffer.WriteString(fmt.Sprintf("Email: %s\n", info.Email.Email))
-		// TODO: Display public status if current user == info.Login
+		_, _ = outBuffer.WriteString(fmt.Sprintf("Email: %s", info.Email.Email))
+		if info.Email.IsPublic && info.Login == authcl.Username {
+			_, _ = outBuffer.WriteString(fmt.Sprintf(" (publicly visible)"))
+		}
+		_, _ = outBuffer.WriteString(fmt.Sprintf("\n"))
 	}
 
 	if info.Affiliation != nil {
@@ -355,7 +358,11 @@ func printAccountInfo(args []string) {
 		condAppend(&affiliationBuffer, &affiliation.Country)
 
 		if affiliationBuffer.Len() > 0 {
-			_, _ = outBuffer.WriteString(fmt.Sprintf("Affiliation: %s\n", affiliationBuffer.String()))
+			_, _ = outBuffer.WriteString(fmt.Sprintf("Affiliation: %s", affiliationBuffer.String()))
+			if info.Affiliation.IsPublic && info.Login == authcl.Username {
+				_, _ = outBuffer.WriteString(fmt.Sprintf(" (publicly visible)"))
+			}
+			_, _ = outBuffer.WriteString(fmt.Sprintf("\n"))
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -394,10 +394,6 @@ func listRepos(args []string) {
 	}
 }
 
-func tree(args []string) {
-	repo.PrintChanges(nil)
-}
-
 func main() {
 	fullUsage := usage + "\n" + cmdUsage
 	args, _ := docopt.Parse(fullUsage, nil, true, "GIN command line client v0.1", true)
@@ -423,8 +419,6 @@ func main() {
 		listRepos(cmdArgs)
 	case "logout":
 		logout(cmdArgs)
-	case "status":
-		tree(cmdArgs)
 	default:
 		util.Die(usage)
 	}

--- a/main.go
+++ b/main.go
@@ -394,6 +394,10 @@ func listRepos(args []string) {
 	}
 }
 
+func tree(args []string) {
+	repo.PrintChanges(nil)
+}
+
 func main() {
 	fullUsage := usage + "\n" + cmdUsage
 	args, _ := docopt.Parse(fullUsage, nil, true, "GIN command line client v0.1", true)
@@ -419,6 +423,8 @@ func main() {
 		listRepos(cmdArgs)
 	case "logout":
 		logout(cmdArgs)
+	case "status":
+		tree(cmdArgs)
 	default:
 		util.Die(usage)
 	}

--- a/main.go
+++ b/main.go
@@ -36,7 +36,9 @@ Commands:
     gin info     [<username>]
     gin keys     [-v | --verbose]
     gin keys     --add <filename>
+`
 
+const cmdUsage = `
 Command help:
 
     login        Login to the GIN services
@@ -386,8 +388,8 @@ func listRepos(args []string) {
 }
 
 func main() {
-
-	args, _ := docopt.Parse(usage, nil, true, "GIN command line client v0.1", true)
+	fullUsage := usage + "\n" + cmdUsage
+	args, _ := docopt.Parse(fullUsage, nil, true, "GIN command line client v0.1", true)
 	command := args["<command>"].(string)
 	cmdArgs := args["<args>"].([]string)
 

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ Command help:
                  If no <name> is provided, you will be prompted for one.
                  A repository <description> can only be specified on the
                  command line after the <name>.
-                 Login required. 
+                 Login required.
 
 
     get          Download a remote repository to a new directory

--- a/repo/git.go
+++ b/repo/git.go
@@ -162,7 +162,7 @@ func (repocl *Client) Connect(localPath string, push bool) error {
 
 	var headers []string
 
-	repository, err := git.OpenRepository(localPath)
+	repository, err := getRepo(localPath)
 	if err != nil {
 		return err
 	}
@@ -210,7 +210,7 @@ func (repocl *Client) Commit(localPath string, idx *git.Index) error {
 		Email: "gin",
 		When:  time.Now(),
 	}
-	repository, err := git.OpenRepository(localPath)
+	repository, err := getRepo(localPath)
 	if err != nil {
 		return err
 	}
@@ -250,7 +250,7 @@ func (repocl *Client) Commit(localPath string, idx *git.Index) error {
 // Pull pulls all remote commits from the default remote & branch
 // (git pull)
 func (repocl *Client) Pull(localPath string) error {
-	repository, err := git.OpenRepository(localPath)
+	repository, err := getRepo(localPath)
 	if err != nil {
 		return err
 	}
@@ -358,7 +358,7 @@ func (repocl *Client) Pull(localPath string) error {
 // Push pushes all local commits to the default remote & branch
 // (git push)
 func (repocl *Client) Push(localPath string) error {
-	repository, err := git.OpenRepository(localPath)
+	repository, err := getRepo(localPath)
 	if err != nil {
 		return err
 	}

--- a/repo/git.go
+++ b/repo/git.go
@@ -513,7 +513,7 @@ func AnnexAdd(localPath string) ([]string, error) {
 		// fmt.Printf("%d: %s\n", i, outStruct.File)
 	}
 
-	PrintChanges(added)
+	PrintChanges()
 	return added, nil
 }
 
@@ -541,14 +541,14 @@ func repoIndexPaths(localPath string) ([]string, error) {
 }
 
 // PrintChanges ...
-func PrintChanges(paths []string) {
+func PrintChanges() {
 	// TODO: Nicer status strings for the (WT) bunch?
 	statusStrings := map[git.Status]string{
 		git.StatusCurrent:         "Current",
-		git.StatusIndexNew:        "A", // "New",
-		git.StatusIndexModified:   "M", // "Modified",
-		git.StatusIndexDeleted:    "D", // "Deleted",
-		git.StatusIndexRenamed:    "Renamed",
+		git.StatusIndexNew:        "A",
+		git.StatusIndexModified:   "M",
+		git.StatusIndexDeleted:    "D",
+		git.StatusIndexRenamed:    "R",
 		git.StatusIndexTypeChange: "TypeChange",
 		git.StatusWtNew:           "New (WT)",
 		git.StatusWtModified:      "Modified (WT)",
@@ -571,7 +571,12 @@ func PrintChanges(paths []string) {
 	for i := 0; i < count; i++ {
 		entry, _ := status.ByIndex(i)
 		status := entry.Status
-		fmt.Printf("%s %s\n", statusStrings[status], "")
+		diffDelta := entry.HeadToIndex
+		statusLine := fmt.Sprintf("[%s] %s (%dB)", statusStrings[status], diffDelta.OldFile.Path, diffDelta.OldFile.Size)
+		if diffDelta.OldFile.Path != diffDelta.NewFile.Path {
+			statusLine = fmt.Sprintf("%s -> %s (%dB)", statusLine, diffDelta.NewFile.Path, diffDelta.NewFile.Size)
+		}
+		fmt.Println(statusLine)
 	}
 	status.Free()
 }

--- a/repo/git.go
+++ b/repo/git.go
@@ -462,15 +462,18 @@ func AnnexSync(localPath string) error {
 // (git annex sync --no-pull --content)
 func AnnexPush(localPath, commitMsg string) error {
 	cmd := exec.Command("git", "-C", localPath, "annex", "sync", "--no-pull", "--content", "--commit", fmt.Sprintf("--message=%s", commitMsg))
-	println("Performing push")
 	if privKeyFile.Active {
 		cmd.Args = append(cmd.Args, "-c", privKeyFile.SSHOptString())
 	}
 	println("CMD: ", strings.Join(cmd.Args, " "))
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
 	err := cmd.Run()
 
 	if err != nil {
-		return fmt.Errorf("Error uploading files: %s", err.Error())
+		return fmt.Errorf("Error uploading files: %s", stderr.String())
 	}
 	return nil
 }

--- a/repo/git.go
+++ b/repo/git.go
@@ -132,23 +132,17 @@ func getRepo(startPath string) (*git.Repository, error) {
 
 // AddPath adds files or directories to the index
 func AddPath(localPath string) (*git.Index, error) {
-	println("Adding files")
-	repo, err := getRepo(localPath)
-	if err != nil {
-		return nil, err
-	}
-	idx, err := repo.Index()
-	if err != nil {
-		return nil, err
-	}
-	err = AnnexAdd(localPath, idx)
-	var i uint
-	println("Adding paths")
-	for i = 0; i < idx.EntryCount(); i++ {
-		ie, _ := idx.EntryByIndex(i)
-		println(i, ie.Path)
-	}
-	return idx, err
+	// repo, err := getRepo(localPath)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// idx, err := repo.Index()
+	// if err != nil {
+	// 	return nil, err
+	// }
+	err := AnnexAdd(localPath)
+	// return idx, err
+	return nil, err
 }
 
 // Connect opens a connection to the git server. This is used to validate credentials

--- a/repo/git.go
+++ b/repo/git.go
@@ -488,14 +488,19 @@ type AnnexAddResult struct {
 func AnnexAdd(localPath string) ([]string, error) {
 	// TODO: Return error if no new files are added
 	fmt.Println("Performing git annex add")
-	out, err := exec.Command("git", "annex", "--json", "add", localPath).Output()
+	cmd := exec.Command("git", "annex", "--json", "add", localPath)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
 
 	if err != nil {
-		return nil, fmt.Errorf("Error adding files to repository: %s", err.Error())
+		return nil, fmt.Errorf("Error adding files to repository: %s", stderr.String())
 	}
 
 	var outStruct AnnexAddResult
-	files := bytes.Split(out, []byte("\n"))
+	files := bytes.Split(out.Bytes(), []byte("\n"))
 	// fmt.Println("Annex adding files")
 	added := make([]string, 0, len(files))
 	for _, f := range files {

--- a/repo/git.go
+++ b/repo/git.go
@@ -513,7 +513,6 @@ func AnnexAdd(localPath string) ([]string, error) {
 		// fmt.Printf("%d: %s\n", i, outStruct.File)
 	}
 
-	PrintChanges()
 	return added, nil
 }
 
@@ -542,7 +541,8 @@ func repoIndexPaths(localPath string) ([]string, error) {
 
 // PrintChanges ...
 func PrintChanges() {
-	// TODO: Nicer status strings for the (WT) bunch?
+	// TODO: Use git annex status instead
+	util.Die("CHANGE THIS FUNCTION")
 	statusStrings := map[git.Status]string{
 		git.StatusCurrent:         "Current",
 		git.StatusIndexNew:        "A",
@@ -560,7 +560,6 @@ func PrintChanges() {
 	}
 
 	repo, _ := getRepo(".")
-	// for _, p := range paths {
 	statusOpts := git.StatusOptions{
 		Show:     git.StatusShowIndexOnly,
 		Flags:    git.StatusOptIncludeUntracked | git.StatusOptRenamesHeadToIndex,
@@ -571,12 +570,15 @@ func PrintChanges() {
 	for i := 0; i < count; i++ {
 		entry, _ := status.ByIndex(i)
 		status := entry.Status
+
 		diffDelta := entry.HeadToIndex
-		statusLine := fmt.Sprintf("[%s] %s (%dB)", statusStrings[status], diffDelta.OldFile.Path, diffDelta.OldFile.Size)
+		statusLine := fmt.Sprintf("[%s]", statusStrings[status])
 		if diffDelta.OldFile.Path != diffDelta.NewFile.Path {
-			statusLine = fmt.Sprintf("%s -> %s (%dB)", statusLine, diffDelta.NewFile.Path, diffDelta.NewFile.Size)
+			statusLine = fmt.Sprintf("%s %s (%s) ->", statusLine, diffDelta.OldFile.Path, util.DataSize(diffDelta.OldFile.Size))
 		}
+		statusLine = fmt.Sprintf("%s %s (%s)", statusLine, diffDelta.NewFile.Path, util.DataSize(diffDelta.NewFile.Size))
 		fmt.Println(statusLine)
+
 	}
 	status.Free()
 }

--- a/repo/git.go
+++ b/repo/git.go
@@ -433,6 +433,21 @@ func AnnexPull(localPath string) error {
 	return nil
 }
 
+// AnnexSync synchronises the local repository with the remote.
+// (git annex sync --content)
+func AnnexSync(localPath string) error {
+	cmd := exec.Command("git", "-C", localPath, "annex", "sync", "--content")
+	if privKeyFile.Active {
+		cmd.Args = append(cmd.Args, "-c", privKeyFile.SSHOptString())
+	}
+	err := cmd.Run()
+
+	if err != nil {
+		return fmt.Errorf("Error synchronising files: %s", err.Error())
+	}
+	return nil
+}
+
 // AnnexPush uploads all annexed files.
 // (git annex sync --no-pull --content)
 func AnnexPush(localPath string) error {

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/G-Node/gin-cli/util"
 	"github.com/G-Node/gin-cli/web"
 	"github.com/G-Node/gin-repo/wire"
 )
@@ -81,6 +82,14 @@ func (repocl *Client) CreateRepo(name, description string) error {
 func (repocl *Client) UploadRepo(localPath string) error {
 	defer CleanUpTemp()
 
+	// oldEntries, err := repoIndexPaths(localPath)
+	// if err != nil {
+	// 	return err
+	// }
+	// for idx, e := range oldEntries {
+	// 	fmt.Printf("%d: %s\n", idx, e)
+	// }
+
 	added, err := AddPath(localPath)
 	if err != nil {
 		return err
@@ -92,13 +101,29 @@ func (repocl *Client) UploadRepo(localPath string) error {
 		// Should this be an error? Probably not
 		// return fmt.Errorf("Nothing to do")
 	}
+
+	// newEntries, err := repoIndexPaths(localPath)
+	// if err != nil {
+	// 	return err
+	// }
+	// for idx, e := range newEntries {
+	// 	fmt.Printf("%d: %s\n", idx, e)
+	// }
+
 	err = repocl.Connect(localPath, true)
 	if err != nil {
 		return err
 	}
 
+	for idx, fname := range added {
+		if util.PathExists(fname) {
+			added[idx] = fmt.Sprintf("+ %s", fname)
+		} else {
+			added[idx] = fmt.Sprintf("- %s", fname)
+		}
+	}
 	changes := fmt.Sprintf("gin upload\n\n%s", strings.Join(added, "\n"))
-	println("Changes:", changes)
+	// println("Changes:", changes)
 	err = AnnexPush(localPath, changes)
 	return err
 }

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -79,16 +79,19 @@ func (repocl *Client) CreateRepo(name, description string) error {
 // UploadRepo adds files to a repository and uploads them.
 func (repocl *Client) UploadRepo(localPath string) error {
 	defer CleanUpTemp()
+	println("Running UploadRepo")
 
 	_, err := AddPath(localPath)
 	if err != nil {
 		return err
 	}
 
+	println("Checking connection")
 	err = repocl.Connect(localPath, true)
 	if err != nil {
 		return err
 	}
+	println("ok")
 
 	err = AnnexPush(localPath)
 	return err

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -110,6 +110,7 @@ func (repocl *Client) UploadRepo(localPath string) error {
 	// 	fmt.Printf("%d: %s\n", idx, e)
 	// }
 
+	PrintChanges()
 	err = repocl.Connect(localPath, true)
 	if err != nil {
 		return err

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -94,13 +94,14 @@ func (repocl *Client) UploadRepo(localPath string) error {
 	if err != nil {
 		return err
 	}
+	println("DONE")
 
-	if len(added) == 0 {
-		// Nothing to upload
-		return nil
-		// Should this be an error? Probably not
-		// return fmt.Errorf("Nothing to do")
-	}
+	// if len(added) == 0 {
+	// Nothing to upload
+	// return nil
+	// Should this be an error? Probably not
+	// return fmt.Errorf("Nothing to do")
+	// }
 
 	// newEntries, err := repoIndexPaths(localPath)
 	// if err != nil {
@@ -110,12 +111,16 @@ func (repocl *Client) UploadRepo(localPath string) error {
 	// 	fmt.Printf("%d: %s\n", idx, e)
 	// }
 
-	PrintChanges()
+	err = PrintChanges(localPath)
+	if err != nil {
+		return err
+	}
 	err = repocl.Connect(localPath, true)
 	if err != nil {
 		return err
 	}
 
+	// Use changes list from PrintChanges function
 	for idx, fname := range added {
 		if util.PathExists(fname) {
 			added[idx] = fmt.Sprintf("+ %s", fname)

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -79,19 +79,16 @@ func (repocl *Client) CreateRepo(name, description string) error {
 // UploadRepo adds files to a repository and uploads them.
 func (repocl *Client) UploadRepo(localPath string) error {
 	defer CleanUpTemp()
-	println("Running UploadRepo")
 
 	_, err := AddPath(localPath)
 	if err != nil {
 		return err
 	}
 
-	println("Checking connection")
 	err = repocl.Connect(localPath, true)
 	if err != nil {
 		return err
 	}
-	println("ok")
 
 	err = AnnexPush(localPath)
 	return err

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"path"
+	"strings"
 
 	"github.com/G-Node/gin-cli/web"
 	"github.com/G-Node/gin-repo/wire"
@@ -80,17 +81,25 @@ func (repocl *Client) CreateRepo(name, description string) error {
 func (repocl *Client) UploadRepo(localPath string) error {
 	defer CleanUpTemp()
 
-	_, err := AddPath(localPath)
+	added, err := AddPath(localPath)
 	if err != nil {
 		return err
 	}
 
+	if len(added) == 0 {
+		// Nothing to upload
+		return nil
+		// Should this be an error? Probably not
+		// return fmt.Errorf("Nothing to do")
+	}
 	err = repocl.Connect(localPath, true)
 	if err != nil {
 		return err
 	}
 
-	err = AnnexPush(localPath)
+	changes := fmt.Sprintf("gin upload\n\n%s", strings.Join(added, "\n"))
+	println("Changes:", changes)
+	err = AnnexPush(localPath, changes)
 	return err
 }
 

--- a/util/files.go
+++ b/util/files.go
@@ -1,0 +1,26 @@
+package util
+
+import (
+	"fmt"
+	"os"
+)
+
+// PathExists returns true if the path exists
+func PathExists(path string) bool {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
+// DataSize returns the simplest representation of bytes as a string (with units)
+func DataSize(nbytes int) string {
+	units := []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"}
+
+	lastPositive := nbytes
+	unitIdx := 0
+	for b, c := nbytes, 0; b > 0 && c < len(units); b, c = b>>10, c+1 {
+		lastPositive, unitIdx = b, c
+	}
+	return fmt.Sprintf("%d %s", lastPositive, units[unitIdx])
+}


### PR DESCRIPTION
There's a lot of changes in this PR but the main change is the annex defaults.
As discussed in #37, when downloading a repository, the `AnnexInit` function now sets the annex mode to `v6` with `thin` enabled. It also sets the annex backend (the hash function for detecting changes) to WORM which is a simple metadata hash. This is necessary for very large files which we expect users to be uploading.

The second major change is that during the upload procedure, after a `git add` but before a `git commit` is performed, the staged changes are collected to make meaningful commit messages. This can also be used to inform the user of what they are uploading and perhaps request confirmation (can be added later).