### PR TITLE
Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,83 @@ It offers a simplified interface for downloading and uploading files from reposi
 
 ## Usage
 
-*Simple usage instructions*.
+The following is a description of the available commands in the GIN client.
+In the command line, you can view a basic list of commands by running 
 
-## Usage (advanced)
+    gin -h
 
-*Advanced explanation of commands, i.e., what `git` commands are executed for the `upload` and `download` commands*.
+You can also run
+
+    gin cmdhelp
+
+to get the following full descriptions:
+
+    login        Login to the GIN services
+
+                 If no <username> is specified on the command line, you will be
+                 prompted for it. The login command always prompts for a
+                 password.
+
+
+    logout       Logout of the GIN services
+
+
+    create       Create a new repository on the GIN server
+
+                 If no <name> is provided, you will be prompted for one.
+                 A repository <description> can only be specified on the
+                 command line after the <name>.
+                 Login required.
+
+
+    get          Download a remote repository to a new directory
+
+                 The repository path <repopath> must be specified on the
+                 command line. A repository path is the owner's username,
+                 followed by a "/" and the repository name
+                 (e.g., peter/eegdata).
+                 Login required.
+
+
+    upload       Upload local repository changes to the remote repository
+
+                 Uploads any changes made on the local data to the GIN server.
+                 The upload command should be run from inside the directory of
+                 an existing repository.
+
+
+    download     Download remote repository changes to the local repository
+
+                 Downloads any changes made to the data on the server to the
+                 local data directory.
+                 The download command should be run from inside the directory
+                 of an existing repository.
+
+
+    repos        List accessible repositories
+
+                 Without any argument, lists all the publicly accessible
+                 repositories on the GIN server.
+                 If a <username> is specified, this command will list the
+                 specified user's publicly accessible repositories.
+                 If you are logged in, it will also list any repositories
+                 owned by the user that you have access to.
+
+
+    info         Print user information
+
+                 Without argument, print the information of the currently
+                 logged in user or, if you are not logged in, prompt for a
+                 username to look up.
+                 If a <username> is specified, print the user's information.
+
+
+    keys         List or add SSH keys
+
+                 By default will list the keys (description and fingerprint)
+                 associated with the logged in user. The verbose flag will also
+                 print the full public keys.
+                 To add a new key, use the --add option and specify a pub key
+                 <filename>.
+                 Login required.
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ clone_folder: c:\gopath\src\github.com\G-Node\gin-cli
 
 environment:
   GOPATH: c:\gopath
+  BINDIR: bin
   # GO15VENDOREXPERIMENT: 1
 
   matrix:
@@ -39,11 +40,20 @@ build_script:
   - golint github.com/G-Node/gin-cli...
   - go test -v ./...
 
-# to disable automatic tests
-test: off
+test_script:
+  - go test -v ./...
+
+after_test:
+  - go build .
+  - md %BINDIR%
+  - copy *.exe %BINDIR%
 
 # to disable deployment
 deploy: off
+
+artifacts:
+  - path: $(BINDIR)\*
+    name: bin
 
 # Uncomment on_finish block to enable RDP
 # on_finish:

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -157,8 +157,8 @@ func (authcl *Client) Login(username, password, clientID, clientSecret string) e
 
 	authcl.Username = username
 	authcl.Token = authresp.AccessToken
-	util.LogWriteLine(fmt.Sprintf("Login successful. Username: %s", username))
-	util.LogWriteLine(fmt.Sprintf("Permissions granted: %s", strings.Replace(authresp.Scope, " ", ", ", -1)))
+	util.LogWrite("Login successful. Username: %s", username)
+	util.LogWrite("Permissions granted: %s", strings.Replace(authresp.Scope, " ", ", ", -1))
 
 	return authcl.StoreToken()
 }

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/url"
+	"strings"
 
+	"github.com/G-Node/gin-cli/util"
 	"github.com/G-Node/gin-cli/web"
 	"github.com/G-Node/gin-core/gin"
 )
@@ -155,6 +157,8 @@ func (authcl *Client) Login(username, password, clientID, clientSecret string) e
 
 	authcl.Username = username
 	authcl.Token = authresp.AccessToken
+	util.LogWriteLine(fmt.Sprintf("Login successful. Username: %s", username))
+	util.LogWriteLine(fmt.Sprintf("Permissions granted: %s\n", strings.Replace(authresp.Scope, " ", ", ", -1)))
 
 	return authcl.StoreToken()
 }

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -158,7 +158,7 @@ func (authcl *Client) Login(username, password, clientID, clientSecret string) e
 	authcl.Username = username
 	authcl.Token = authresp.AccessToken
 	util.LogWriteLine(fmt.Sprintf("Login successful. Username: %s", username))
-	util.LogWriteLine(fmt.Sprintf("Permissions granted: %s\n", strings.Replace(authresp.Scope, " ", ", ", -1)))
+	util.LogWriteLine(fmt.Sprintf("Permissions granted: %s", strings.Replace(authresp.Scope, " ", ", ", -1)))
 
 	return authcl.StoreToken()
 }

--- a/main.go
+++ b/main.go
@@ -21,23 +21,28 @@ import (
 const usage = `
 GIN command line client
 
-Usage: gin [--version] <command> [<args>...]
+Usage: gin <command> [<args>...]
+       gin --help
+       gin --version
 
 Options:
     -h --help    This help screen
     --version    Client version
 
 Commands:
-    gin login    [<username>]
-    gin logout
-    gin create   [<name>] [<description>]
-    gin get      <repopath>
-    gin upload
-    gin download
-    gin repos    [<username>]
-    gin info     [<username>]
-    gin keys     [-v | --verbose]
-    gin keys     --add <filename>
+    login    [<username>]
+    logout
+    create   [<name>] [<description>]
+    get      <repopath>
+    upload
+    download
+    repos    [<username>]
+    info     [<username>]
+    keys     [-v | --verbose]
+    keys     --add <filename>
+    cmdhelp
+
+Use 'cmdhelp' to see full description of individual commands.
 `
 
 const cmdUsage = `
@@ -410,8 +415,7 @@ func listRepos(args []string) {
 }
 
 func main() {
-	fullUsage := usage + "\n" + cmdUsage
-	args, _ := docopt.Parse(fullUsage, nil, true, "GIN command line client v0.1", true)
+	args, _ := docopt.Parse(usage, nil, true, "GIN command line client v0.1", true)
 	command := args["<command>"].(string)
 	cmdArgs := args["<args>"].([]string)
 
@@ -438,6 +442,9 @@ func main() {
 		listRepos(cmdArgs)
 	case "logout":
 		logout(cmdArgs)
+	case "cmdhelp":
+		fullUsage := usage + "\n" + cmdUsage
+		fmt.Print(fullUsage)
 	default:
 		util.Die(usage)
 	}

--- a/main.go
+++ b/main.go
@@ -415,7 +415,7 @@ func listRepos(args []string) {
 }
 
 func main() {
-	args, _ := docopt.Parse(usage, nil, true, "GIN command line client v0.1", true)
+	args, _ := docopt.Parse(usage, nil, true, "GIN command line client v0.2", true)
 	command := args["<command>"].(string)
 	cmdArgs := args["<args>"].([]string)
 

--- a/main.go
+++ b/main.go
@@ -159,7 +159,10 @@ func login(args []string) {
 	authcl := auth.NewClient(authhost)
 	err = authcl.Login(username, password, "gin-cli", "97196a1c-silly-biscuit3-d161ea15a676")
 	util.CheckError(err)
-	fmt.Printf("[Login success] You are now logged in as %s\n", username)
+	info, err := authcl.RequestAccount(username)
+	util.CheckError(err)
+	fmt.Printf("Hello %s. You are now logged in.\n", info.FirstName)
+	// fmt.Printf("[Login success] You are now logged in as %s\n", username)
 }
 
 func logout(args []string) {

--- a/main.go
+++ b/main.go
@@ -182,7 +182,7 @@ func logout(args []string) {
 
 	err = web.DeleteToken()
 	util.CheckErrorMsg(err, "Error deleting user token.")
-	util.LogWriteLine("Logged out. Token deleted.")
+	util.LogWrite("Logged out. Token deleted.")
 }
 
 func createRepo(args []string) {

--- a/main.go
+++ b/main.go
@@ -160,7 +160,6 @@ func login(args []string) {
 	err = authcl.Login(username, password, "gin-cli", "97196a1c-silly-biscuit3-d161ea15a676")
 	util.CheckError(err)
 	fmt.Printf("[Login success] You are now logged in as %s\n", username)
-	// fmt.Printf("You have been granted the following permissions: %v\n", strings.Replace(authresp.Scope, " ", ", ", -1))
 }
 
 func logout(args []string) {
@@ -175,6 +174,7 @@ func logout(args []string) {
 
 	err = web.DeleteToken()
 	util.CheckErrorMsg(err, "Error deleting user token.")
+	util.LogWriteLine("Logged out. Token deleted.")
 }
 
 func createRepo(args []string) {
@@ -411,6 +411,10 @@ func main() {
 	args, _ := docopt.Parse(fullUsage, nil, true, "GIN command line client v0.1", true)
 	command := args["<command>"].(string)
 	cmdArgs := args["<args>"].([]string)
+
+	err := util.LogInit()
+	util.CheckError(err)
+	defer util.LogClose()
 
 	switch command {
 	case "login":

--- a/repo/git.go
+++ b/repo/git.go
@@ -23,7 +23,7 @@ import (
 
 // Temporary (SSH key) file handling
 
-var privKeyFile util.TempFile
+var privKeyFile *util.TempFile
 
 // MakeTempKeyPair creates a temporary key pair and stores it in a temporary directory.
 // It also sets the global tempFile for use by the annex commands. The key pair is returned directly.
@@ -41,12 +41,7 @@ func (repocl *Client) MakeTempKeyPair() (*util.KeyPair, error) {
 		return tempKeyPair, err
 	}
 
-	privKeyFile, err = util.MakeTempFile("priv")
-	if err != nil {
-		return tempKeyPair, err
-	}
-
-	err = privKeyFile.Write(tempKeyPair.Private)
+	privKeyFile, err = util.SaveTempKeyFile(tempKeyPair.Private)
 	if err != nil {
 		return tempKeyPair, err
 	}
@@ -155,10 +150,11 @@ func (repocl *Client) Clone(repopath string) error {
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
+	util.LogWriteLine(fmt.Sprintf("Running shell command: %s", strings.Join(cmd.Args, " ")))
 	err := cmd.Run()
 	if err != nil {
-		fmt.Println()
-		return fmt.Errorf("Error retrieving repository: %s", stderr.String())
+		util.LogWriteLine(fmt.Sprintf("Error during clone command. [stderr] %s", stderr.String()))
+		return fmt.Errorf("Error retrieving repository")
 	}
 	return nil
 }
@@ -175,12 +171,17 @@ func AnnexInit(localPath string) error {
 	if privKeyFile.Active {
 		cmd.Args = append(cmd.Args, "-c", privKeyFile.AnnexSSHOpt())
 	}
+	util.LogWriteLine(fmt.Sprintf("Running shell command: %s", strings.Join(cmd.Args, " ")))
 	err := cmd.Run()
 	if err != nil {
+		// TODO: Collect and print stderr
+		util.LogWriteLine(fmt.Sprintf("%s [stderr] %s", initError, ""))
 		return initError
 	}
 
-	err = exec.Command("git", "-C", localPath, "config", "annex.addunlocked", "true").Run()
+	cmd = exec.Command("git", "-C", localPath, "config", "annex.addunlocked", "true")
+	util.LogWriteLine(fmt.Sprintf("Running shell command: %s", strings.Join(cmd.Args, " ")))
+	err = cmd.Run()
 	if err != nil {
 		return initError
 	}
@@ -194,15 +195,21 @@ func AnnexInit(localPath string) error {
 	}
 	sizethreshold := "10M"
 	lfvalue := fmt.Sprintf("largerthan=%s and not (%s)", sizethreshold, strings.Join(includes, " or "))
-	err = exec.Command("git", "-C", localPath, "config", "annex.largefiles", lfvalue).Run()
+	cmd = exec.Command("git", "-C", localPath, "config", "annex.largefiles", lfvalue)
+	util.LogWriteLine(fmt.Sprintf("Running shell command: %s", strings.Join(cmd.Args, " ")))
+	err = cmd.Run()
 	if err != nil {
 		return initError
 	}
-	err = exec.Command("git", "-C", localPath, "config", "annex.backends", "WORM").Run()
+	cmd = exec.Command("git", "-C", localPath, "config", "annex.backends", "WORM")
+	util.LogWriteLine(fmt.Sprintf("Running shell command: %s", strings.Join(cmd.Args, " ")))
+	err = cmd.Run()
 	if err != nil {
 		return initError
 	}
-	err = exec.Command("git", "-C", localPath, "config", "annex.thin", "true").Run()
+	cmd = exec.Command("git", "-C", localPath, "config", "annex.thin", "true")
+	util.LogWriteLine(fmt.Sprintf("Running shell command: %s", strings.Join(cmd.Args, " ")))
+	err = cmd.Run()
 	if err != nil {
 		return initError
 	}
@@ -216,10 +223,13 @@ func AnnexPull(localPath string) error {
 	if privKeyFile.Active {
 		cmd.Args = append(cmd.Args, "-c", privKeyFile.AnnexSSHOpt())
 	}
-	out, err := cmd.Output()
+	util.LogWriteLine(fmt.Sprintf("Running shell command: %s", strings.Join(cmd.Args, " ")))
+	err := cmd.Run()
 
 	if err != nil {
-		return fmt.Errorf("Error downloading files: %s", out)
+		// TODO: Collect and print stderr to log
+		util.LogWriteLine(fmt.Sprintf("Error during AnnexPull. [stderr] %s", ""))
+		return fmt.Errorf("Error downloading files")
 	}
 	return nil
 }
@@ -231,10 +241,13 @@ func AnnexSync(localPath string) error {
 	if privKeyFile.Active {
 		cmd.Args = append(cmd.Args, "-c", privKeyFile.AnnexSSHOpt())
 	}
+	util.LogWriteLine(fmt.Sprintf("Running shell command: %s", strings.Join(cmd.Args, " ")))
 	err := cmd.Run()
 
 	if err != nil {
-		return fmt.Errorf("Error synchronising files: %s", err.Error())
+		// TODO: Collect and print stderr to log
+		util.LogWriteLine(fmt.Sprintf("Error during AnnexSync. [stderr] %s", ""))
+		return fmt.Errorf("Error synchronising files")
 	}
 	return nil
 }
@@ -250,10 +263,12 @@ func AnnexPush(localPath, commitMsg string) error {
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
+	util.LogWriteLine(fmt.Sprintf("Running shell command: %s", strings.Join(cmd.Args, " ")))
 	err := cmd.Run()
 
 	if err != nil {
-		return fmt.Errorf("Error uploading files: %s", stderr.String())
+		util.LogWriteLine(fmt.Sprintf("Error during AnnexPush. [stderr] %s", stderr.String()))
+		return fmt.Errorf("Error uploading files")
 	}
 	return nil
 }
@@ -274,10 +289,12 @@ func AnnexAdd(localPath string) ([]string, error) {
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
+	util.LogWriteLine(fmt.Sprintf("Running shell command: %s", strings.Join(cmd.Args, " ")))
 	err := cmd.Run()
 
 	if err != nil {
-		return nil, fmt.Errorf("Error adding files to repository: %s", stderr.String())
+		util.LogWriteLine(fmt.Sprintf("Error during AnnexAdd. [stderr] %s", stderr.String()))
+		return nil, fmt.Errorf("Error adding files to repository.")
 	}
 
 	var outStruct AnnexAddResult
@@ -300,6 +317,7 @@ func AnnexAdd(localPath string) ([]string, error) {
 	return added, nil
 }
 
+// AnnexWhereisResult holds the JSON output of a "git annex whereis" command
 type AnnexWhereisResult struct {
 	File      string   `json:"file"`
 	Command   string   `json:"command"`
@@ -326,10 +344,12 @@ func AnnexWhereis(localPath string) ([]AnnexWhereisResult, error) {
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
+	util.LogWriteLine(fmt.Sprintf("Running shell command: %s", strings.Join(cmd.Args, " ")))
 	err := cmd.Run()
 
 	if err != nil {
-		return nil, fmt.Errorf("Error getting file status from server: %s", stderr.String())
+		util.LogWriteLine(fmt.Sprintf("Error during AnnexWhereis. [stderr] %s", stderr.String()))
+		return nil, fmt.Errorf("Error getting file status from server")
 	}
 
 	resultsJSON := bytes.Split(out.Bytes(), []byte("\n"))
@@ -363,10 +383,12 @@ func DescribeChanges(localPath string) (string, error) {
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
+	util.LogWriteLine(fmt.Sprintf("Running shell command: %s", strings.Join(cmd.Args, " ")))
 	err := cmd.Run()
 
 	if err != nil {
-		return "", fmt.Errorf("Error retrieving file status: %s", stderr.String())
+		util.LogWriteLine(fmt.Sprintf("Error during DescribeChanges. [stderr] %s", stderr.String()))
+		return "", fmt.Errorf("Error retrieving file status")
 	}
 
 	var outStruct AnnexStatusResult

--- a/repo/git.go
+++ b/repo/git.go
@@ -150,10 +150,10 @@ func (repocl *Client) Clone(repopath string) error {
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
-	util.LogWriteLine(fmt.Sprintf("Running shell command: %s", strings.Join(cmd.Args, " ")))
+	util.LogWrite("Running shell command: %s", strings.Join(cmd.Args, " "))
 	err := cmd.Run()
 	if err != nil {
-		util.LogWriteLine(fmt.Sprintf("Error during clone command. [stderr] %s", stderr.String()))
+		util.LogWrite("Error during clone command. [stderr] %s", stderr.String())
 		return fmt.Errorf("Error retrieving repository")
 	}
 	return nil
@@ -171,16 +171,16 @@ func AnnexInit(localPath string) error {
 	if privKeyFile.Active {
 		cmd.Args = append(cmd.Args, "-c", privKeyFile.AnnexSSHOpt())
 	}
-	util.LogWriteLine(fmt.Sprintf("Running shell command: %s", strings.Join(cmd.Args, " ")))
+	util.LogWrite("Running shell command: %s", strings.Join(cmd.Args, " "))
 	err := cmd.Run()
 	if err != nil {
 		// TODO: Collect and print stderr
-		util.LogWriteLine(fmt.Sprintf("%s [stderr] %s", initError, ""))
+		util.LogWrite("%s [stderr] %s", initError, "")
 		return initError
 	}
 
 	cmd = exec.Command("git", "-C", localPath, "config", "annex.addunlocked", "true")
-	util.LogWriteLine(fmt.Sprintf("Running shell command: %s", strings.Join(cmd.Args, " ")))
+	util.LogWrite("Running shell command: %s", strings.Join(cmd.Args, " "))
 	err = cmd.Run()
 	if err != nil {
 		return initError
@@ -196,19 +196,19 @@ func AnnexInit(localPath string) error {
 	sizethreshold := "10M"
 	lfvalue := fmt.Sprintf("largerthan=%s and not (%s)", sizethreshold, strings.Join(includes, " or "))
 	cmd = exec.Command("git", "-C", localPath, "config", "annex.largefiles", lfvalue)
-	util.LogWriteLine(fmt.Sprintf("Running shell command: %s", strings.Join(cmd.Args, " ")))
+	util.LogWrite("Running shell command: %s", strings.Join(cmd.Args, " "))
 	err = cmd.Run()
 	if err != nil {
 		return initError
 	}
 	cmd = exec.Command("git", "-C", localPath, "config", "annex.backends", "WORM")
-	util.LogWriteLine(fmt.Sprintf("Running shell command: %s", strings.Join(cmd.Args, " ")))
+	util.LogWrite("Running shell command: %s", strings.Join(cmd.Args, " "))
 	err = cmd.Run()
 	if err != nil {
 		return initError
 	}
 	cmd = exec.Command("git", "-C", localPath, "config", "annex.thin", "true")
-	util.LogWriteLine(fmt.Sprintf("Running shell command: %s", strings.Join(cmd.Args, " ")))
+	util.LogWrite("Running shell command: %s", strings.Join(cmd.Args, " "))
 	err = cmd.Run()
 	if err != nil {
 		return initError
@@ -223,12 +223,12 @@ func AnnexPull(localPath string) error {
 	if privKeyFile.Active {
 		cmd.Args = append(cmd.Args, "-c", privKeyFile.AnnexSSHOpt())
 	}
-	util.LogWriteLine(fmt.Sprintf("Running shell command: %s", strings.Join(cmd.Args, " ")))
+	util.LogWrite("Running shell command: %s", strings.Join(cmd.Args, " "))
 	err := cmd.Run()
 
 	if err != nil {
 		// TODO: Collect and print stderr to log
-		util.LogWriteLine(fmt.Sprintf("Error during AnnexPull. [stderr] %s", ""))
+		util.LogWrite("Error during AnnexPull. [stderr] %s", "")
 		return fmt.Errorf("Error downloading files")
 	}
 	return nil
@@ -241,12 +241,12 @@ func AnnexSync(localPath string) error {
 	if privKeyFile.Active {
 		cmd.Args = append(cmd.Args, "-c", privKeyFile.AnnexSSHOpt())
 	}
-	util.LogWriteLine(fmt.Sprintf("Running shell command: %s", strings.Join(cmd.Args, " ")))
+	util.LogWrite("Running shell command: %s", strings.Join(cmd.Args, " "))
 	err := cmd.Run()
 
 	if err != nil {
 		// TODO: Collect and print stderr to log
-		util.LogWriteLine(fmt.Sprintf("Error during AnnexSync. [stderr] %s", ""))
+		util.LogWrite("Error during AnnexSync. [stderr] %s", "")
 		return fmt.Errorf("Error synchronising files")
 	}
 	return nil
@@ -263,11 +263,11 @@ func AnnexPush(localPath, commitMsg string) error {
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
-	util.LogWriteLine(fmt.Sprintf("Running shell command: %s", strings.Join(cmd.Args, " ")))
+	util.LogWrite("Running shell command: %s", strings.Join(cmd.Args, " "))
 	err := cmd.Run()
 
 	if err != nil {
-		util.LogWriteLine(fmt.Sprintf("Error during AnnexPush. [stderr] %s", stderr.String()))
+		util.LogWrite("Error during AnnexPush. [stderr] %s", stderr.String())
 		return fmt.Errorf("Error uploading files")
 	}
 	return nil
@@ -289,11 +289,11 @@ func AnnexAdd(localPath string) ([]string, error) {
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
-	util.LogWriteLine(fmt.Sprintf("Running shell command: %s", strings.Join(cmd.Args, " ")))
+	util.LogWrite("Running shell command: %s", strings.Join(cmd.Args, " "))
 	err := cmd.Run()
 
 	if err != nil {
-		util.LogWriteLine(fmt.Sprintf("Error during AnnexAdd. [stderr] %s", stderr.String()))
+		util.LogWrite("Error during AnnexAdd. [stderr] %s", stderr.String())
 		return nil, fmt.Errorf("Error adding files to repository.")
 	}
 
@@ -344,11 +344,11 @@ func AnnexWhereis(localPath string) ([]AnnexWhereisResult, error) {
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
-	util.LogWriteLine(fmt.Sprintf("Running shell command: %s", strings.Join(cmd.Args, " ")))
+	util.LogWrite("Running shell command: %s", strings.Join(cmd.Args, " "))
 	err := cmd.Run()
 
 	if err != nil {
-		util.LogWriteLine(fmt.Sprintf("Error during AnnexWhereis. [stderr] %s", stderr.String()))
+		util.LogWrite("Error during AnnexWhereis. [stderr] %s", stderr.String())
 		return nil, fmt.Errorf("Error getting file status from server")
 	}
 
@@ -383,11 +383,11 @@ func DescribeChanges(localPath string) (string, error) {
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
-	util.LogWriteLine(fmt.Sprintf("Running shell command: %s", strings.Join(cmd.Args, " ")))
+	util.LogWrite("Running shell command: %s", strings.Join(cmd.Args, " "))
 	err := cmd.Run()
 
 	if err != nil {
-		util.LogWriteLine(fmt.Sprintf("Error during DescribeChanges. [stderr] %s", stderr.String()))
+		util.LogWrite("Error during DescribeChanges. [stderr] %s", stderr.String())
 		return "", fmt.Errorf("Error retrieving file status")
 	}
 

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"path"
 
+	"github.com/G-Node/gin-cli/util"
 	"github.com/G-Node/gin-cli/web"
 	"github.com/G-Node/gin-repo/wire"
 )
@@ -26,14 +27,17 @@ func NewClient(host string) *Client {
 
 // GetRepos gets a list of repositories (public or user specific)
 func (repocl *Client) GetRepos(user string) ([]wire.Repo, error) {
+	util.LogWrite("Retrieving repos")
 	var repoList []wire.Repo
 	var res *http.Response
 	var err error
 
 	if user == "" {
+		util.LogWriteLine("User: public")
 		res, err = repocl.Get("/repos/public")
 		fmt.Print("Listing all public repositories\n\n")
 	} else {
+		util.LogWriteLine(fmt.Sprintf("User: %s", user))
 		err = repocl.LoadToken()
 		if err != nil {
 			fmt.Print("You are not logged in - Showing public repositories\n\n")
@@ -60,12 +64,14 @@ func (repocl *Client) GetRepos(user string) ([]wire.Repo, error) {
 
 // CreateRepo creates a repository on the server.
 func (repocl *Client) CreateRepo(name, description string) error {
+	util.LogWrite("Creating repository")
 	err := repocl.LoadToken()
 	if err != nil {
 		return fmt.Errorf("[Create repository] This action requires login")
 	}
 
 	data := wire.Repo{Name: name, Description: description}
+	util.LogWrite("Name: %s :: Description: %s", name, description)
 	res, err := repocl.Post(fmt.Sprintf("/users/%s/repos", repocl.Username), data)
 	if err != nil {
 		return err
@@ -73,12 +79,14 @@ func (repocl *Client) CreateRepo(name, description string) error {
 		return fmt.Errorf("[Create repository] Failed. Server returned %s", res.Status)
 	}
 	web.CloseRes(res.Body)
+	util.LogWrite("Repository created")
 	return nil
 }
 
 // UploadRepo adds files to a repository and uploads them.
 func (repocl *Client) UploadRepo(localPath string) error {
 	defer CleanUpTemp()
+	util.LogWrite("UploadRepo")
 
 	err := repocl.Connect()
 	if err != nil {
@@ -110,6 +118,7 @@ func (repocl *Client) UploadRepo(localPath string) error {
 // DownloadRepo downloads the files in an already checked out repository.
 func (repocl *Client) DownloadRepo(localPath string) error {
 	defer CleanUpTemp()
+	util.LogWrite("DownloadRepo")
 
 	err := repocl.Connect()
 	if err != nil {
@@ -122,6 +131,7 @@ func (repocl *Client) DownloadRepo(localPath string) error {
 // CloneRepo downloads the files of a given repository.
 func (repocl *Client) CloneRepo(repoPath string) error {
 	defer CleanUpTemp()
+	util.LogWrite("CloneRepo")
 
 	err := repocl.Connect()
 	if err != nil {

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -33,11 +33,11 @@ func (repocl *Client) GetRepos(user string) ([]wire.Repo, error) {
 	var err error
 
 	if user == "" {
-		util.LogWriteLine("User: public")
+		util.LogWrite("User: public")
 		res, err = repocl.Get("/repos/public")
 		fmt.Print("Listing all public repositories\n\n")
 	} else {
-		util.LogWriteLine(fmt.Sprintf("User: %s", user))
+		util.LogWrite("User: %s", user)
 		err = repocl.LoadToken()
 		if err != nil {
 			fmt.Print("You are not logged in - Showing public repositories\n\n")

--- a/util/die.go
+++ b/util/die.go
@@ -17,7 +17,7 @@ func Die(msg string) {
 // returning errors up the stack when all that needs to be done is to stop execution.
 func CheckError(err error) {
 	if err != nil {
-		// TODO: Print error to log
+		LogWriteLine(err.Error())
 		Die(err.Error())
 	}
 }
@@ -26,7 +26,7 @@ func CheckError(err error) {
 // Before exiting, the given msg string is printed to stderr.
 func CheckErrorMsg(err error, msg string) {
 	if err != nil {
-		// TODO: Print actual error to log
+		LogWriteLine(fmt.Sprintf("The following error occured:\n%sExiting with message: %s", err.Error(), msg))
 		Die(msg)
 	}
 }

--- a/util/die.go
+++ b/util/die.go
@@ -17,7 +17,7 @@ func Die(msg string) {
 // returning errors up the stack when all that needs to be done is to stop execution.
 func CheckError(err error) {
 	if err != nil {
-		LogWriteLine(err.Error())
+		LogWrite(err.Error())
 		Die(err.Error())
 	}
 }
@@ -26,7 +26,7 @@ func CheckError(err error) {
 // Before exiting, the given msg string is printed to stderr.
 func CheckErrorMsg(err error, msg string) {
 	if err != nil {
-		LogWriteLine(fmt.Sprintf("The following error occured:\n%sExiting with message: %s", err.Error(), msg))
+		LogWrite("The following error occured:\n%sExiting with message: %s", err.Error(), msg)
 		Die(msg)
 	}
 }

--- a/util/keygen.go
+++ b/util/keygen.go
@@ -28,7 +28,7 @@ type TempFile struct {
 
 // MakeKeyPair generates and returns a private-public key pair.
 func MakeKeyPair() (*KeyPair, error) {
-	LogWriteLine("Creating temporary key pair")
+	LogWrite("Creating temporary key pair")
 	privkey, err := rsa.GenerateKey(rand.Reader, 2048) // TODO: Key size as parameter
 	if err != nil {
 		return nil, fmt.Errorf("Error generating key pair: %s", err)
@@ -85,7 +85,7 @@ func SaveTempKeyFile(key string) (*TempFile, error) {
 	if err != nil {
 		return nil, err
 	}
-	LogWriteLine(fmt.Sprintf("Saved key in temporary directory %s", newfile.Dir))
+	LogWrite("Saved key in temporary directory %s", newfile.Dir)
 	return &newfile, nil
 
 }
@@ -102,7 +102,7 @@ func (tf TempFile) Write(content string) error {
 func (tf TempFile) Delete() {
 	_ = os.RemoveAll(tf.Dir)
 	tf.Active = false
-	LogWriteLine(fmt.Sprintf("Deleted temporary key directory %s", tf.Dir))
+	LogWrite("Deleted temporary key directory %s", tf.Dir)
 }
 
 // FullPath returns the full path to the temporary file.

--- a/util/keygen.go
+++ b/util/keygen.go
@@ -28,6 +28,7 @@ type TempFile struct {
 
 // MakeKeyPair generates and returns a private-public key pair.
 func MakeKeyPair() (*KeyPair, error) {
+	LogWriteLine("Creating temporary key pair")
 	privkey, err := rsa.GenerateKey(rand.Reader, 2048) // TODO: Key size as parameter
 	if err != nil {
 		return nil, fmt.Errorf("Error generating key pair: %s", err)
@@ -84,6 +85,7 @@ func SaveTempKeyFile(key string) (*TempFile, error) {
 	if err != nil {
 		return nil, err
 	}
+	LogWriteLine(fmt.Sprintf("Saved key in temporary directory %s", newfile.Dir))
 	return &newfile, nil
 
 }
@@ -100,6 +102,7 @@ func (tf TempFile) Write(content string) error {
 func (tf TempFile) Delete() {
 	_ = os.RemoveAll(tf.Dir)
 	tf.Active = false
+	LogWriteLine(fmt.Sprintf("Deleted temporary key directory %s", tf.Dir))
 }
 
 // FullPath returns the full path to the temporary file.

--- a/util/log.go
+++ b/util/log.go
@@ -7,37 +7,45 @@ import (
 	"path"
 )
 
-// LogFile embeds log.Logger for writing out to a log file and also provides other convenience functions.
-type LogFile struct {
-	File *os.File
-	*log.Logger
-}
+var logfile *os.File
+var logger *log.Logger
 
-// LogInit initialises the log file.
-func LogInit() (*LogFile, error) {
+// LogInit initialises the log file and logger.
+func LogInit() error {
 	dataPath, err := DataPath(true)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// TODO: Log rotation
 	fullPath := path.Join(dataPath, "gin.log")
-	file, err := os.OpenFile(fullPath, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0666)
+	logfile, err = os.OpenFile(fullPath, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0666)
 	if err != nil {
-		return nil, fmt.Errorf("Error creating file %s", fullPath)
+		return fmt.Errorf("Error creating file %s", fullPath)
 	}
 
 	flags := log.Ldate | log.Ltime | log.LUTC
-	logger := log.New(file, "", flags)
+	logger = log.New(logfile, "", flags)
 
-	lf := LogFile{
-		File:   file,
-		Logger: logger,
-	}
-	return &lf, nil
+	return nil
 }
 
-// Close the log file.
-func (lf *LogFile) Close() error {
-	return lf.File.Close()
+// LogWrite writes a string to the log file. Nothing happens if the log file is not initialised (see LogInit).
+func LogWrite(text string) {
+	if logger != nil {
+		logger.Print(text)
+
+	}
+}
+
+// LogWriteLine writes a string to the log file and terminates with new line. Nothing happens if the log file is not initialised (see LogInit).
+func LogWriteLine(text string) {
+	if logger != nil {
+		logger.Println(text)
+	}
+}
+
+// LogClose closes the log file.
+func LogClose() error {
+	return logfile.Close()
 }

--- a/util/log.go
+++ b/util/log.go
@@ -27,7 +27,7 @@ func LogInit() error {
 	flags := log.Ldate | log.Ltime | log.LUTC
 	logger = log.New(logfile, "", flags)
 
-	LogWriteLine("---")
+	LogWrite("---")
 
 	return nil
 }
@@ -39,13 +39,6 @@ func LogWrite(fmtstr string, args ...interface{}) {
 		logger.Print(fmtstr)
 	} else {
 		logger.Printf(fmtstr, args...)
-	}
-}
-
-// LogWriteLine writes a string to the log file and terminates with new line. Nothing happens if the log file is not initialised (see LogInit).
-func LogWriteLine(text string) {
-	if logger != nil {
-		logger.Println(text)
 	}
 }
 

--- a/util/log.go
+++ b/util/log.go
@@ -35,6 +35,9 @@ func LogInit() error {
 // LogWrite writes a string to the log file. Nothing happens if the log file is not initialised (see LogInit).
 // Depending on the number of arguments passed, LogWrite either behaves as a Print or a Printf. The first argument must always be a string. If more than one argument is given, the function behaves as Printf.
 func LogWrite(fmtstr string, args ...interface{}) {
+	if logger == nil {
+		return
+	}
 	if len(args) == 0 {
 		logger.Print(fmtstr)
 	} else {

--- a/util/log.go
+++ b/util/log.go
@@ -27,14 +27,18 @@ func LogInit() error {
 	flags := log.Ldate | log.Ltime | log.LUTC
 	logger = log.New(logfile, "", flags)
 
+	LogWriteLine("---")
+
 	return nil
 }
 
 // LogWrite writes a string to the log file. Nothing happens if the log file is not initialised (see LogInit).
-func LogWrite(text string) {
-	if logger != nil {
-		logger.Print(text)
-
+// Depending on the number of arguments passed, LogWrite either behaves as a Print or a Printf. The first argument must always be a string. If more than one argument is given, the function behaves as Printf.
+func LogWrite(fmtstr string, args ...interface{}) {
+	if len(args) == 0 {
+		logger.Print(fmtstr)
+	} else {
+		logger.Printf(fmtstr, args...)
 	}
 }
 

--- a/util/log.go
+++ b/util/log.go
@@ -1,0 +1,43 @@
+package util
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+)
+
+// LogFile embeds log.Logger for writing out to a log file and also provides other convenience functions.
+type LogFile struct {
+	File *os.File
+	*log.Logger
+}
+
+// LogInit initialises the log file.
+func LogInit() (*LogFile, error) {
+	dataPath, err := DataPath(true)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Log rotation
+	fullPath := path.Join(dataPath, "gin.log")
+	file, err := os.OpenFile(fullPath, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0666)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating file %s", fullPath)
+	}
+
+	flags := log.Ldate | log.Ltime | log.LUTC
+	logger := log.New(file, "", flags)
+
+	lf := LogFile{
+		File:   file,
+		Logger: logger,
+	}
+	return &lf, nil
+}
+
+// Close the log file.
+func (lf *LogFile) Close() error {
+	return lf.File.Close()
+}

--- a/util/xdg.go
+++ b/util/xdg.go
@@ -37,3 +37,31 @@ func ConfigPath(create bool) (string, error) {
 	}
 	return path, err
 }
+
+// DataPath returns the data path where gin data files (such as transaction logs) should be stored.
+func DataPath(create bool) (string, error) {
+	// TODO: Handle Windows paths
+	var path string
+	var err error
+
+	xdgdata := os.Getenv("XDG_DATA_HOME")
+	if xdgdata != "" {
+		path = filepath.Join(xdgdata, suffix)
+	} else {
+		usr, err := user.Current()
+		if err != nil {
+			return "", fmt.Errorf("Error getting user home dir")
+		}
+		homedir := usr.HomeDir
+		path = filepath.Join(homedir, ".local/share", suffix)
+	}
+
+	if create {
+		err = os.MkdirAll(path, 0777)
+		if err != nil {
+			return "", fmt.Errorf("Error creating directory %s", path)
+		}
+	}
+
+	return path, err
+}

--- a/util/xdg.go
+++ b/util/xdg.go
@@ -10,14 +10,6 @@ import (
 
 var suffix = "gin"
 
-func makePath(path string) error {
-	err := os.MkdirAll(path, 0777)
-	if err != nil {
-		return fmt.Errorf("Error accessing directory %s\n", path)
-	}
-	return nil
-}
-
 // ConfigPath returns the configuration path where configuration files should be stored.
 func ConfigPath(create bool) (string, error) {
 	// TODO: OS dependent paths
@@ -33,9 +25,9 @@ func ConfigPath(create bool) (string, error) {
 		path = filepath.Join(homedir, ".config", suffix)
 	}
 	if create {
-		err = makePath(path)
+		err = os.MkdirAll(path, 0777)
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("Error accessing directory %s\n", path)
 		}
 	}
 	return path, err

--- a/util/xdg.go
+++ b/util/xdg.go
@@ -5,6 +5,7 @@ package util
 import (
 	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
 )
 
@@ -12,22 +13,26 @@ var suffix = "gin"
 
 // ConfigPath returns the configuration path where configuration files should be stored.
 func ConfigPath(create bool) (string, error) {
-	// TODO: OS dependent paths
-	xdghome := os.Getenv("XDG_CONFIG_HOME")
-	homedir := os.Getenv("HOME")
-
+	// TODO: Handle Windows paths
 	var path string
 	var err error
 
-	if xdghome != "" {
-		path = filepath.Join(xdghome, suffix)
+	xdgconfig := os.Getenv("XDG_CONFIG_HOME")
+	if xdgconfig != "" {
+		path = filepath.Join(xdgconfig, suffix)
 	} else {
+		usr, err := user.Current()
+		if err != nil {
+			return "", fmt.Errorf("Error getting user home dir")
+		}
+		homedir := usr.HomeDir
 		path = filepath.Join(homedir, ".config", suffix)
 	}
+
 	if create {
 		err = os.MkdirAll(path, 0777)
 		if err != nil {
-			return "", fmt.Errorf("Error accessing directory %s\n", path)
+			return "", fmt.Errorf("Error creating directory %s", path)
 		}
 	}
 	return path, err

--- a/web/web.go
+++ b/web/web.go
@@ -50,7 +50,9 @@ func (cl *Client) Get(address string) (*http.Response, error) {
 	}
 	if cl.Token != "" {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", cl.Token))
+		util.LogWriteLine("Added bearer tokent to GET")
 	}
+	util.LogWriteLine(fmt.Sprintf("Performing GET: %s", req.URL))
 	return cl.web.Do(req)
 }
 
@@ -69,7 +71,9 @@ func (cl *Client) Post(address string, data interface{}) (*http.Response, error)
 
 	if cl.Token != "" {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", cl.Token))
+		util.LogWriteLine("Added bearer tokent to POST")
 	}
+	util.LogWriteLine(fmt.Sprintf("Performing POST: %s", req.URL))
 	return cl.web.Do(req)
 }
 
@@ -84,6 +88,7 @@ func (cl *Client) PostForm(address string, data url.Values) (*http.Response, err
 		return nil, err
 	}
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	util.LogWriteLine(fmt.Sprintf("Performing POST (with form data): %s", req.URL))
 	return cl.web.Do(req)
 }
 
@@ -95,6 +100,7 @@ func NewClient(address string) *Client {
 // LoadToken reads the username and auth token from the token file and sets the
 // values in the struct.
 func (ut *UserToken) LoadToken() error {
+	util.LogWrite("Loading token. ")
 	path, err := util.ConfigPath(false)
 	if err != nil {
 		return fmt.Errorf("Could not read token: Error accessing config directory.")
@@ -107,11 +113,18 @@ func (ut *UserToken) LoadToken() error {
 	defer closeFile(file)
 
 	decoder := gob.NewDecoder(file)
-	return decoder.Decode(ut)
+	util.LogWrite("Loaded. Decoding. ")
+	err = decoder.Decode(ut)
+	if err != nil {
+		return err
+	}
+	util.LogWriteLine("Decoded")
+	return nil
 }
 
 // StoreToken saves the username and auth token to the token file.
 func (ut *UserToken) StoreToken() error {
+	util.LogWrite("Saving token. ")
 	path, err := util.ConfigPath(true)
 	if err != nil {
 		return fmt.Errorf("Could not save token: Error creating or accessing config directory.")
@@ -124,7 +137,12 @@ func (ut *UserToken) StoreToken() error {
 	defer closeFile(file)
 
 	encoder := gob.NewEncoder(file)
-	return encoder.Encode(ut)
+	err = encoder.Encode(ut)
+	if err != nil {
+		return err
+	}
+	util.LogWriteLine("Saved")
+	return nil
 }
 
 // DeleteToken deletes the token file if it exists. It essentially logs out the user.
@@ -134,7 +152,12 @@ func DeleteToken() error {
 		return fmt.Errorf("Could not delete token: Error accessing config directory.")
 	}
 	filepath := filepath.Join(path, "token")
-	return os.Remove(filepath)
+	err = os.Remove(filepath)
+	if err != nil {
+		return err
+	}
+	util.LogWriteLine("Token deleted")
+	return nil
 }
 
 // CloseRes closes a given result buffer (for use with defer).

--- a/web/web.go
+++ b/web/web.go
@@ -50,9 +50,9 @@ func (cl *Client) Get(address string) (*http.Response, error) {
 	}
 	if cl.Token != "" {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", cl.Token))
-		util.LogWriteLine("Added bearer tokent to GET")
+		util.LogWrite("Added bearer tokent to GET")
 	}
-	util.LogWriteLine(fmt.Sprintf("Performing GET: %s", req.URL))
+	util.LogWrite("Performing GET: %s", req.URL)
 	return cl.web.Do(req)
 }
 
@@ -71,9 +71,9 @@ func (cl *Client) Post(address string, data interface{}) (*http.Response, error)
 
 	if cl.Token != "" {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", cl.Token))
-		util.LogWriteLine("Added bearer tokent to POST")
+		util.LogWrite("Added bearer tokent to POST")
 	}
-	util.LogWriteLine(fmt.Sprintf("Performing POST: %s", req.URL))
+	util.LogWrite("Performing POST: %s", req.URL)
 	return cl.web.Do(req)
 }
 
@@ -88,7 +88,7 @@ func (cl *Client) PostForm(address string, data url.Values) (*http.Response, err
 		return nil, err
 	}
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	util.LogWriteLine(fmt.Sprintf("Performing POST (with form data): %s", req.URL))
+	util.LogWrite("Performing POST (with form data): %s", req.URL)
 	return cl.web.Do(req)
 }
 
@@ -118,7 +118,7 @@ func (ut *UserToken) LoadToken() error {
 	if err != nil {
 		return err
 	}
-	util.LogWriteLine("Decoded")
+	util.LogWrite("Decoded")
 	return nil
 }
 
@@ -141,7 +141,7 @@ func (ut *UserToken) StoreToken() error {
 	if err != nil {
 		return err
 	}
-	util.LogWriteLine("Saved")
+	util.LogWrite("Saved")
 	return nil
 }
 
@@ -156,7 +156,7 @@ func DeleteToken() error {
 	if err != nil {
 		return err
 	}
-	util.LogWriteLine("Token deleted")
+	util.LogWrite("Token deleted")
 	return nil
 }
 


### PR DESCRIPTION
New logging functions in `util` package for printing events to a log file.
The log file is saved in the `XDG_DATA_HOME` directory (default `~/.local/share/gin`). For Windows, this will be changed but currently it creates the same paths (same for config path).

The logger needs to be initialised for messages to be saved. If it is not initialised, the logger calls have no effect.

Event logging has been added to all operations to help with troubleshooting, both during development and during use.

Minor changes:
- Appveyor saves compiled binaries in artifacts to be downloaded for use.
- Command line help text can be obtained by running `gin cmdhelp`.
- Bumped version to v0.2.

Closes #44