### PR TITLE
Nicer error messages

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -58,11 +58,11 @@ func (authcl *Client) GetUserKeys() ([]gin.SSHKey, error) {
 func (authcl *Client) RequestAccount(name string) (gin.Account, error) {
 	var acc gin.Account
 
-	res, err := authcl.Get("/api/accounts/" + name)
+	res, err := authcl.Get(fmt.Sprintf("/api/accounts/%s", name))
 	if err != nil {
 		return acc, err
 	} else if res.StatusCode != 200 {
-		return acc, fmt.Errorf("[Account retrieval] Failed. Server returned %s", res.Status)
+		return acc, fmt.Errorf("User '%s' does not exist", name)
 	}
 
 	defer web.CloseRes(res.Body)

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -61,8 +61,10 @@ func (authcl *Client) RequestAccount(name string) (gin.Account, error) {
 	res, err := authcl.Get(fmt.Sprintf("/api/accounts/%s", name))
 	if err != nil {
 		return acc, err
-	} else if res.StatusCode != 200 {
+	} else if res.StatusCode == 404 {
 		return acc, fmt.Errorf("User '%s' does not exist", name)
+	} else if res.StatusCode != 200 {
+		return acc, fmt.Errorf("Unknown error during user lookup for '%s'\nThe server returned '%s'", name, res.Status)
 	}
 
 	defer web.CloseRes(res.Body)

--- a/main.go
+++ b/main.go
@@ -318,6 +318,14 @@ func listRepos(args []string) {
 	repos, err := repocl.GetRepos(username)
 	util.CheckError(err)
 
+	if username == "" {
+		fmt.Print("Listing all public repositories\n\n")
+	} else {
+		err = repocl.LoadToken()
+		if err != nil {
+			fmt.Printf("You are not logged in.\nListing only public repositories owned by '%s'.\n\n", username)
+		}
+	}
 	for idx, repoInfo := range repos {
 		fmt.Printf("%d: %s/%s\n", idx+1, repoInfo.Owner, repoInfo.Name)
 		fmt.Printf("Description: %s\n", strings.Trim(repoInfo.Description, "\n"))

--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ func logout(args []string) {
 	err = web.DeleteToken()
 	util.CheckErrorMsg(err, "Error deleting user token.")
 	util.LogWrite("Logged out. Token deleted.")
+	fmt.Println("You have been logged out.")
 }
 
 func createRepo(args []string) {

--- a/main.go
+++ b/main.go
@@ -119,7 +119,7 @@ func getRepo(args []string) {
 	}
 
 	if !isValidRepoPath(repostr) {
-		util.Die(fmt.Sprintf("Invalid repository path [%s]. Full repository name should be the owner's username followed by the repository name, separated by a '/'.\nType 'gin help get' for information and examples.", repostr))
+		util.Die(fmt.Sprintf("Invalid repository path '%s'. Full repository name should be the owner's username followed by the repository name, separated by a '/'.\nType 'gin help get' for information and examples.", repostr))
 	}
 
 	repocl := repo.NewClient(util.Config.RepoHost)
@@ -272,7 +272,7 @@ func printAccountInfo(args []string) {
 
 	var outBuffer bytes.Buffer
 
-	_, _ = outBuffer.WriteString(fmt.Sprintf("User [%s]\nName: %s\n", info.Login, fullnameBuffer.String()))
+	_, _ = outBuffer.WriteString(fmt.Sprintf("User %s\nName: %s\n", info.Login, fullnameBuffer.String()))
 
 	if info.Email != nil && info.Email.Email != "" {
 		_, _ = outBuffer.WriteString(fmt.Sprintf("Email: %s", info.Email.Email))

--- a/main.go
+++ b/main.go
@@ -106,6 +106,10 @@ func createRepo(args []string) {
 	util.CheckError(err)
 }
 
+func isValidRepoPath(path string) bool {
+	return strings.Contains(path, "/")
+}
+
 func getRepo(args []string) {
 	var repostr string
 	if len(args) != 1 {
@@ -113,6 +117,11 @@ func getRepo(args []string) {
 	} else {
 		repostr = args[0]
 	}
+
+	if !isValidRepoPath(repostr) {
+		util.Die(fmt.Sprintf("Invalid repository path [%s]. Full repository name should be the owner's username followed by the repository name, separated by a '/'.\nType 'gin help get' for information and examples.", repostr))
+	}
+
 	repocl := repo.NewClient(util.Config.RepoHost)
 	repocl.GitUser = util.Config.GitUser
 	repocl.GitHost = util.Config.GitHost

--- a/repo/git.go
+++ b/repo/git.go
@@ -176,6 +176,8 @@ func (repocl *Client) Clone(repoPath string) error {
 			return fmt.Errorf("Error retrieving repository.\nPlease make sure you typed the repository path correctly.\nType 'gin repos %s' to see if the repository exists and if you have access to it.", repoOwner)
 		} else if strings.Contains(stderr.String(), "already exists and is not an empty directory") {
 			return fmt.Errorf("Error retrieving repository.\nDirectory '%s' already exists and is not empty.", repoName)
+		} else {
+			return fmt.Errorf("Error retrieving repository.\nAn unknown error occured.")
 		}
 	}
 	return nil

--- a/repo/git.go
+++ b/repo/git.go
@@ -141,11 +141,18 @@ func (repocl *Client) Connect() error {
 	return nil
 }
 
+func splitRepoParts(repoPath string) (repoOwner, repoName string) {
+	repoPathParts := strings.SplitN(repoPath, "/", 2)
+	repoOwner = repoPathParts[0]
+	repoName = repoPathParts[1]
+	return
+}
+
 // Clone downloads a repository and sets the remote fetch and push urls.
 // (git clone ...)
-func (repocl *Client) Clone(repopath string) error {
+func (repocl *Client) Clone(repoPath string) error {
 	gitbin := util.Config.Bin.Git
-	remotePath := fmt.Sprintf("ssh://%s@%s/%s", repocl.GitUser, repocl.GitHost, repopath)
+	remotePath := fmt.Sprintf("ssh://%s@%s/%s", repocl.GitUser, repocl.GitHost, repoPath)
 	var cmd *exec.Cmd
 	cmd = exec.Command(gitbin)
 	if privKeyFile.Active {
@@ -163,8 +170,13 @@ func (repocl *Client) Clone(repopath string) error {
 		util.LogWrite("Error during clone command")
 		util.LogWrite("[stdout]\r\n%s", out.String())
 		util.LogWrite("[stderr]\r\n%s", stderr.String())
-		repoOwner := strings.SplitN(repopath, "/", 2)[0]
-		return fmt.Errorf("Error retrieving repository.\nPlease make sure you have the correct access rights and the repository exists.\nType 'gin repos %s' to see if the repository exists and if you have access to it.", repoOwner)
+		repoOwner, repoName := splitRepoParts(repoPath)
+
+		if strings.Contains(stderr.String(), "Server returned non-OK status: 404") {
+			return fmt.Errorf("Error retrieving repository.\nPlease make sure you typed the repository path correctly.\nType 'gin repos %s' to see if the repository exists and if you have access to it.", repoOwner)
+		} else if strings.Contains(stderr.String(), "already exists and is not an empty directory") {
+			return fmt.Errorf("Error retrieving repository.\nDirectory '%s' already exists and is not empty.", repoName)
+		}
 	}
 	return nil
 }

--- a/repo/git.go
+++ b/repo/git.go
@@ -163,7 +163,7 @@ func (repocl *Client) Clone(repopath string) error {
 		util.LogWrite("Error during clone command")
 		util.LogWrite("[stdout]\r\n%s", out.String())
 		util.LogWrite("[stderr]\r\n%s", stderr.String())
-		return fmt.Errorf("Error retrieving repository")
+		return fmt.Errorf("Error retrieving repository.\nPlease make sure you have the correct access rights and the repository exists.")
 	}
 	return nil
 }

--- a/repo/git.go
+++ b/repo/git.go
@@ -175,7 +175,7 @@ func (repocl *Client) Clone(repoPath string) error {
 		if strings.Contains(stderr.String(), "Server returned non-OK status: 404") {
 			return fmt.Errorf("Error retrieving repository.\nPlease make sure you typed the repository path correctly.\nType 'gin repos %s' to see if the repository exists and if you have access to it.", repoOwner)
 		} else if strings.Contains(stderr.String(), "already exists and is not an empty directory") {
-			return fmt.Errorf("Error retrieving repository.\nDirectory '%s' already exists and is not empty.", repoName)
+			return fmt.Errorf("Error retrieving repository.\n'%s' already exists in the current directory and is not empty.", repoName)
 		} else {
 			return fmt.Errorf("Error retrieving repository.\nAn unknown error occured.")
 		}

--- a/repo/git.go
+++ b/repo/git.go
@@ -173,9 +173,13 @@ func (repocl *Client) Clone(repoPath string) error {
 		repoOwner, repoName := splitRepoParts(repoPath)
 
 		if strings.Contains(stderr.String(), "Server returned non-OK status: 404") {
-			return fmt.Errorf("Error retrieving repository.\nPlease make sure you typed the repository path correctly.\nType 'gin repos %s' to see if the repository exists and if you have access to it.", repoOwner)
+			return fmt.Errorf("Error retrieving repository.\n"+
+				"Please make sure you typed the repository path correctly.\n"+
+				"Type 'gin repos %s' to see if the repository exists and if you have access to it.",
+				repoOwner)
 		} else if strings.Contains(stderr.String(), "already exists and is not an empty directory") {
-			return fmt.Errorf("Error retrieving repository.\n'%s' already exists in the current directory and is not empty.", repoName)
+			return fmt.Errorf("Error retrieving repository.\n"+
+				"'%s' already exists in the current directory and is not empty.", repoName)
 		} else {
 			return fmt.Errorf("Error retrieving repository.\nAn unknown error occured.")
 		}

--- a/repo/git.go
+++ b/repo/git.go
@@ -163,7 +163,8 @@ func (repocl *Client) Clone(repopath string) error {
 		util.LogWrite("Error during clone command")
 		util.LogWrite("[stdout]\r\n%s", out.String())
 		util.LogWrite("[stderr]\r\n%s", stderr.String())
-		return fmt.Errorf("Error retrieving repository.\nPlease make sure you have the correct access rights and the repository exists.")
+		repoOwner := strings.SplitN(repopath, "/", 2)[0]
+		return fmt.Errorf("Error retrieving repository.\nPlease make sure you have the correct access rights and the repository exists.\nType 'gin repos %s' to see if the repository exists and if you have access to it.", repoOwner)
 	}
 	return nil
 }

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/G-Node/gin-cli/auth"
 	"github.com/G-Node/gin-cli/util"
 	"github.com/G-Node/gin-cli/web"
 	"github.com/G-Node/gin-repo/wire"
@@ -47,7 +48,13 @@ func (repocl *Client) GetRepos(user string) ([]wire.Repo, error) {
 	if err != nil {
 		return repoList, err
 	} else if res.StatusCode == 404 {
-		return repoList, fmt.Errorf("Server returned empty result. Either user does not exist or has no accessible repositories.")
+		// Check if user exists
+		authcl := auth.NewClient(util.Config.AuthHost)
+		_, raErr := authcl.RequestAccount(user)
+		if raErr == nil {
+			return repoList, fmt.Errorf("User '%s' exists but does not appear to have accessible repositories.", user)
+		}
+		return repoList, fmt.Errorf("Error: No such user '%s'.", user)
 	} else if res.StatusCode != 200 {
 		return repoList, fmt.Errorf("[Repository request] Failed. Server returned: %s", res.Status)
 	}

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"path"
 
 	"github.com/G-Node/gin-cli/util"
 	"github.com/G-Node/gin-cli/web"
@@ -138,8 +137,8 @@ func (repocl *Client) CloneRepo(repoPath string) error {
 		return err
 	}
 
-	localPath := path.Base(repoPath)
-	fmt.Printf("Fetching repository '%s'... ", localPath)
+	_, repoName := splitRepoParts(repoPath)
+	fmt.Printf("Fetching repository '%s'... ", repoPath)
 	err = repocl.Clone(repoPath)
 	if err != nil {
 		return err
@@ -147,12 +146,12 @@ func (repocl *Client) CloneRepo(repoPath string) error {
 	fmt.Printf("done.\n")
 
 	// git annex init the clone and set defaults
-	err = AnnexInit(localPath)
+	err = AnnexInit(repoName)
 	if err != nil {
 		return err
 	}
 
-	annexFiles, err := AnnexWhereis(localPath)
+	annexFiles, err := AnnexWhereis(repoName)
 	if err != nil {
 		return err
 	}
@@ -161,7 +160,7 @@ func (repocl *Client) CloneRepo(repoPath string) error {
 	}
 
 	fmt.Printf("Downloading files... ")
-	err = AnnexPull(localPath)
+	err = AnnexPull(repoName)
 	if err != nil {
 		return err
 	}

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -48,7 +48,7 @@ func (repocl *Client) GetRepos(user string) ([]wire.Repo, error) {
 		authcl := auth.NewClient(util.Config.AuthHost)
 		_, raErr := authcl.RequestAccount(user)
 		if raErr == nil {
-			return repoList, fmt.Errorf("User '%s' exists but does not appear to have accessible repositories.", user)
+			return repoList, fmt.Errorf("User '%s' does not appear to have accessible repositories.", user)
 		}
 		return repoList, fmt.Errorf("Error: No such user '%s'.", user)
 	} else if res.StatusCode != 200 {

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -26,7 +26,7 @@ func NewClient(host string) *Client {
 
 // GetRepos gets a list of repositories (public or user specific)
 func (repocl *Client) GetRepos(user string) ([]wire.Repo, error) {
-	util.LogWrite("Retrieving repos")
+	util.LogWrite("Retrieving repo list")
 	var repoList []wire.Repo
 	var res *http.Response
 	var err error
@@ -39,7 +39,7 @@ func (repocl *Client) GetRepos(user string) ([]wire.Repo, error) {
 		util.LogWrite("User: %s", user)
 		err = repocl.LoadToken()
 		if err != nil {
-			fmt.Print("You are not logged in - Showing public repositories\n\n")
+			fmt.Printf("You are not logged in.\nListing only public repositories owned by '%s'.\n\n", user)
 		}
 		res, err = repocl.Get(fmt.Sprintf("/users/%s/repos", user))
 	}

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -35,13 +35,9 @@ func (repocl *Client) GetRepos(user string) ([]wire.Repo, error) {
 	if user == "" {
 		util.LogWrite("User: public")
 		res, err = repocl.Get("/repos/public")
-		fmt.Print("Listing all public repositories\n\n")
 	} else {
 		util.LogWrite("User: %s", user)
 		err = repocl.LoadToken()
-		if err != nil {
-			fmt.Printf("You are not logged in.\nListing only public repositories owned by '%s'.\n\n", user)
-		}
 		res, err = repocl.Get(fmt.Sprintf("/users/%s/repos", user))
 	}
 


### PR DESCRIPTION
Generally makes error messages nicer and more informative:
- Detects invalid repositories early (before running `git clone` command) and informs the user to check `gin help get`.
- On `gin get` failure
  - if the error internally is 404, instructs the user to check owner repo listing by running `gin repos <username>`, where `<username>` is inferred from the repo path supplied to the command by the user.
  - if it was because the local directory already exists (a common mistake), informs the user appropriately
  - otherwise, it informs the user that an unknown error occured (not nice, but probably necessary).
- On `gin repos <username>` failure (404), checks if `<username>` exists and informs the user appropriately. If the user does exist, it assumes the user doesn't have publicly accessible repositories, or repositories shared with the current, logged in user.
- Nicer error when user doesn't exist on `gin info <username>`.
- Prints a message on successful logout.