### PR TITLE
Log error on annex push fails

### DIFF
--- a/repo/git.go
+++ b/repo/git.go
@@ -343,6 +343,7 @@ func AnnexPush(localPath, commitMsg string) error {
 
 	if err != nil {
 		util.LogWrite("Error during AnnexPush")
+		util.LogWrite("[Error]: %v", err)
 		util.LogWrite("[stdout]\r\n%s", out.String())
 		util.LogWrite("[stderr]\r\n%s", stderr.String())
 		return fmt.Errorf("Error uploading files")


### PR DESCRIPTION
Such that we don't miss things like
"exec /usr/bin/git-annex: argument list too long"

might be interesting to do that in general