### PR TITLE
New command: List files

### DIFF
--- a/help.go
+++ b/help.go
@@ -12,17 +12,18 @@ Options:
 	--version    Client version
 
 Commands:
-	login
-	logout
-	create
-	get
-	upload
-	download
-	repos
-	info
-	keys
-	keys
-	help
+    login    [<username>]
+    logout
+    create   [<name>] [<description>]
+    get      <repopath>
+    ls       [<directory>]
+    upload
+    download
+    repos    [<username>]
+    info     [<username>]
+    keys     [-v | --verbose]
+    keys     --add <filename>
+    help     <command>
 
 Use 'help' followed by a command to see full description of the command.
 `
@@ -118,6 +119,16 @@ EXAMPLES
 		$ gin get peter/eegdata
 `
 
+const lsHelp = `USAGE
+
+	gin ls [<directory>]
+
+DESCRIPTION
+
+	List the contents of a directory (current directory by default) and the
+	status of the files within it.
+`
+
 const uploadHelp = `USAGE
 
 	gin upload
@@ -183,6 +194,9 @@ DESCRIPTION
 	Print user information. If no argument is provided, it will print the
 	information of the currently logged in user.
 
+	Using this command with no argument can also be used to check if a user is
+	currently logged in.
+
 ARGUMENTS
 
 	<username>
@@ -228,6 +242,7 @@ var cmdHelp = map[string]string{
 	"logout":   logoutHelp,
 	"create":   createHelp,
 	"get":      getHelp,
+	"ls":       lsHelp,
 	"upload":   uploadHelp,
 	"download": downloadHelp,
 	"repos":    reposHelp,

--- a/help.go
+++ b/help.go
@@ -121,12 +121,25 @@ EXAMPLES
 
 const lsHelp = `USAGE
 
-	gin ls [<directory>]
+	gin ls [<directory>]...
 
 DESCRIPTION
 
-	List the contents of a directory (current directory by default) and the
-	status of the files within it.
+	List the contents one or more directories and the status of the files
+	within it. With no arguments, lists the status of the files under the
+	current directory.
+
+	The meaning of the status abbreviations is as follows:
+		[OK] The file is part of the GIN repository and its contents are
+		synchronised with the server.
+		[..] ...
+		[??] The file is not under repository control.
+
+ARGUMENTS
+
+	<directory>
+		One or more directories or files to list.
+
 `
 
 const uploadHelp = `USAGE
@@ -249,3 +262,5 @@ var cmdHelp = map[string]string{
 	"info":     infoHelp,
 	"keys":     keysHelp,
 }
+
+// ex: set cc=80:

--- a/help.go
+++ b/help.go
@@ -125,15 +125,20 @@ const lsHelp = `USAGE
 
 DESCRIPTION
 
-	List the contents one or more directories and the status of the files
-	within it. With no arguments, lists the status of the files under the
-	current directory.
+	List the contents one or more files or directories and the status of the
+	files within it. With no arguments, lists the status of the files under the
+	current directory. Directory listings are performed recursively.
 
 	The meaning of the status abbreviations is as follows:
-		[OK] The file is part of the GIN repository and its contents are
+		OK: The file is part of the GIN repository and its contents are
 		synchronised with the server.
-		[..] ...
-		[??] The file is not under repository control.
+		NC: The local file is a placeholder and its contents have not been
+		downloaded.
+		MD: The file has been modified locally and the changes have not been
+		recorded yet.
+		LC: The file has been modified locally, the changes have been recorded
+		but they haven't been uploaded.
+		??: The file is not under repository control.
 
 ARGUMENTS
 

--- a/help.go
+++ b/help.go
@@ -125,7 +125,7 @@ const lsHelp = `USAGE
 
 DESCRIPTION
 
-	List the contents one or more files or directories and the status of the
+	List one or more files or the contents of directories and the status of the
 	files within it. With no arguments, lists the status of the files under the
 	current directory. Directory listings are performed recursively.
 

--- a/main.go
+++ b/main.go
@@ -141,6 +141,30 @@ func getRepo(args []string) {
 	util.CheckError(err)
 }
 
+func lsRepo(args []string) {
+	var dirs []string
+	if len(args) == 0 {
+		dirs = []string{"."}
+	} else {
+		dirs = args
+	}
+
+	multiarg := false
+	if len(dirs) > 1 {
+		multiarg = true
+	}
+
+	repocl := repo.NewClient(util.Config.RepoHost)
+	repocl.GitUser = util.Config.GitUser
+	repocl.GitHost = util.Config.GitHost
+	repocl.KeyHost = util.Config.AuthHost
+
+	var err error
+	for _, d := range dirs {
+		_ = repocl.ListFiles(d)
+	}
+}
+
 func upload(args []string) {
 	if len(args) > 0 {
 		util.Die(usage)
@@ -398,6 +422,8 @@ func main() {
 		createRepo(cmdArgs)
 	case "get":
 		getRepo(cmdArgs)
+	case "ls":
+		lsRepo(cmdArgs)
 	case "upload":
 		upload(cmdArgs)
 	case "download":

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -159,19 +160,37 @@ func lsRepo(args []string) {
 		multi = true
 	}
 
-	for _, d := range dirs {
+	maybeNewLine := func(idx int) {
+		if idx < len(dirs)-1 {
+			fmt.Println()
+		}
+	}
+
+	for idx, d := range dirs {
+		if multi {
+			fmt.Printf("%s:\n", d)
+		}
+		if filepath.Base(d) == ".git" {
+			fmt.Printf("Skipping directory '%s'\n", d)
+			maybeNewLine(idx)
+			continue
+		}
+		if !repo.IsRepo(d) {
+			fmt.Printf("Directory '%s' is not under gin control\n", d)
+			maybeNewLine(idx)
+			continue
+		}
 		filesStatus := make(map[string]repo.FileStatus)
 		err := repo.ListFiles(d, filesStatus)
 		if err != nil {
-			fmt.Printf("Error listing %s: %s\n", d, err.Error())
+			fmt.Printf("Error listing %s: %s\n\n", d, err.Error())
+			maybeNewLine(idx)
 			continue
-		}
-		if multi {
-			fmt.Printf("%s:\n", d)
 		}
 		for file, status := range filesStatus {
 			fmt.Printf("[%d] %s\n", status, file)
 		}
+		maybeNewLine(idx)
 	}
 
 }

--- a/main.go
+++ b/main.go
@@ -149,19 +149,23 @@ func lsRepo(args []string) {
 		dirs = args
 	}
 
-	multiarg := false
-	if len(dirs) > 1 {
-		multiarg = true
-	}
-
 	repocl := repo.NewClient(util.Config.RepoHost)
 	repocl.GitUser = util.Config.GitUser
 	repocl.GitHost = util.Config.GitHost
 	repocl.KeyHost = util.Config.AuthHost
 
-	var err error
+	filesStatus := make(map[string]repo.FileStatus)
+
 	for _, d := range dirs {
-		_ = repocl.ListFiles(d)
+		err := repo.ListFiles(d, filesStatus)
+		if err != nil {
+			fmt.Printf("Error listing %s: %s\n", d, err.Error())
+			continue
+		}
+	}
+
+	for file, status := range filesStatus {
+		fmt.Printf("[%d] %s\n", status, file)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 var version string
 var build string
 var commit string
+var verstr string
 
 // login requests credentials, performs login with auth server, and stores the token.
 func login(args []string) {
@@ -370,9 +371,15 @@ func help(args []string) {
 	fmt.Println(helptext)
 }
 
-func main() {
-	verstr := fmt.Sprintf("GIN command line client %s Build %s (%s)", version, build, commit)
+func init() {
+	if version == "" {
+		verstr = "GIN command line client [dev build]"
+	} else {
+		verstr = fmt.Sprintf("GIN command line client %s Build %s (%s)", version, build, commit)
+	}
+}
 
+func main() {
 	args, _ := docopt.Parse(usage, nil, true, verstr, true)
 	command := args["<command>"].(string)
 	cmdArgs := args["<args>"].([]string)

--- a/main.go
+++ b/main.go
@@ -188,7 +188,7 @@ func lsRepo(args []string) {
 			continue
 		}
 		for file, status := range filesStatus {
-			fmt.Printf("[%d] %s\n", status, file)
+			fmt.Printf("[%s] %s\n", status.Abbrev(), file)
 		}
 		maybeNewLine(idx)
 	}

--- a/main.go
+++ b/main.go
@@ -163,7 +163,8 @@ func lsRepo(args []string) {
 
 	// TODO: Handle file arguments
 	for idx, d := range dirs {
-		if len(dirs) > 1 {
+		path, filename := util.PathSplit(d)
+		if len(dirs) > 1 && filename == "." {
 			fmt.Printf("%s:\n", d)
 		}
 		if filepath.Base(d) == ".git" {
@@ -171,7 +172,7 @@ func lsRepo(args []string) {
 			maybeNewLine(idx)
 			continue
 		}
-		if !repo.IsRepo(d) {
+		if !repo.IsRepo(path) {
 			fmt.Printf("Directory '%s' is not under gin control\n", d)
 			maybeNewLine(idx)
 			continue

--- a/main.go
+++ b/main.go
@@ -154,19 +154,26 @@ func lsRepo(args []string) {
 	repocl.GitHost = util.Config.GitHost
 	repocl.KeyHost = util.Config.AuthHost
 
-	filesStatus := make(map[string]repo.FileStatus)
+	multi := false
+	if len(dirs) > 1 {
+		multi = true
+	}
 
 	for _, d := range dirs {
+		filesStatus := make(map[string]repo.FileStatus)
 		err := repo.ListFiles(d, filesStatus)
 		if err != nil {
 			fmt.Printf("Error listing %s: %s\n", d, err.Error())
 			continue
 		}
+		if multi {
+			fmt.Printf("%s:\n", d)
+		}
+		for file, status := range filesStatus {
+			fmt.Printf("[%d] %s\n", status, file)
+		}
 	}
 
-	for file, status := range filesStatus {
-		fmt.Printf("[%d] %s\n", status, file)
-	}
 }
 
 func upload(args []string) {

--- a/main.go
+++ b/main.go
@@ -155,19 +155,15 @@ func lsRepo(args []string) {
 	repocl.GitHost = util.Config.GitHost
 	repocl.KeyHost = util.Config.AuthHost
 
-	multi := false
-	if len(dirs) > 1 {
-		multi = true
-	}
-
 	maybeNewLine := func(idx int) {
 		if idx < len(dirs)-1 {
 			fmt.Println()
 		}
 	}
 
+	// TODO: Handle file arguments
 	for idx, d := range dirs {
-		if multi {
+		if len(dirs) > 1 {
 			fmt.Printf("%s:\n", d)
 		}
 		if filepath.Base(d) == ".git" {

--- a/repo/git.go
+++ b/repo/git.go
@@ -533,9 +533,10 @@ type AnnexStatusResult struct {
 
 // AnnexStatus returns the status of a file or files in a directory
 func AnnexStatus(path string) ([]AnnexStatusResult, error) {
+	dir, filename := util.PathSplit(path)
 	gitannexbin := util.Config.Bin.GitAnnex
-	cmd := exec.Command(gitannexbin, "status", "--json")
-	cmd.Dir = path
+	cmd := exec.Command(gitannexbin, "status", "--json", filename)
+	cmd.Dir = dir
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out

--- a/repo/git.go
+++ b/repo/git.go
@@ -57,6 +57,21 @@ func CleanUpTemp() {
 
 // **************** //
 
+const (
+	// SYNCED indicates that an annexed file is synced between local and remote
+	SYNCED = iota
+	// NOCONTENT indicates that a file represents an annexed file that has not had its contents synced yet
+	NOCONTENT
+	// MODIFIED indicates that a file has local modifications that have not been committed
+	MODIFIED
+	// LOCALUPDATES indicates that a file has local, committed modifications that have not been pushed
+	LOCALUPDATES
+	// REMOTEUPDATES indicates that a file has remote modifications that have not been pulled
+	REMOTEUPDATES
+	// UNTRACKED indicates that a file is not being tracked by neither git nor git annex
+	UNTRACKED
+)
+
 // ListFiles lists the files in the specified directory and their sync status.
 func ListFiles(path string) (map[string]string, error) {
 	var fileStatus map[string]string

--- a/repo/git.go
+++ b/repo/git.go
@@ -77,7 +77,7 @@ const (
 )
 
 // Abbrev returns the two-letter abbrevation of the file status
-// OK (Synced), NC (NoContent), MD (Modified), LU (LocalUpdates), RU (RemoteUpdates), ?? (Untracked)
+// OK (Synced), NC (NoContent), MD (Modified), LC (LocalUpdates), RC (RemoteUpdates), ?? (Untracked)
 func (fs FileStatus) Abbrev() string {
 	switch {
 	case fs == Synced:

--- a/repo/git.go
+++ b/repo/git.go
@@ -62,22 +62,43 @@ func CleanUpTemp() {
 type FileStatus uint8
 
 const (
-	// SYNCED indicates that an annexed file is synced between local and remote
-	SYNCED FileStatus = iota
-	// NOCONTENT indicates that a file represents an annexed file that has not had its contents synced yet
-	NOCONTENT
-	// MODIFIED indicates that a file has local modifications that have not been committed
-	MODIFIED
-	// LOCALUPDATES indicates that a file has local, committed modifications that have not been pushed
-	LOCALUPDATES
-	// REMOTEUPDATES indicates that a file has remote modifications that have not been pulled
-	REMOTEUPDATES
-	// UNTRACKED indicates that a file is not being tracked by neither git nor git annex
-	UNTRACKED
+	// Synced indicates that an annexed file is synced between local and remote
+	Synced FileStatus = iota
+	// NoContent indicates that a file represents an annexed file that has not had its contents synced yet
+	NoContent
+	// Modified indicatres that a file has local modifications that have not been committed
+	Modified
+	// LocalUpdates indicates that a file has local, committed modifications that have not been pushed
+	LocalUpdates
+	// RemoteUpdates indicates that a file has remote modifications that have not been pulled
+	RemoteUpdates
+	// Untracked indicates that a file is not being tracked by neither git nor git annex
+	Untracked
 )
 
+// Abbrev returns the two-letter abbrevation of the file status
+// TODO: List status abbreviations
+func (fs FileStatus) Abbrev() string {
+	switch {
+	case fs == Synced:
+		return "OK"
+	case fs == NoContent:
+		return "NC"
+	case fs == Modified:
+		return "MD"
+	case fs == LocalUpdates:
+		return "LC"
+	case fs == RemoteUpdates:
+		return "RU"
+	case fs == Untracked:
+		return "??"
+	default:
+		return "??"
+	}
+}
+
 func getFileStatus(filepath string) FileStatus {
-	return UNTRACKED
+	return Synced
 }
 
 // ListFiles lists the files in the specified directory and their sync status.

--- a/repo/git.go
+++ b/repo/git.go
@@ -57,6 +57,13 @@ func CleanUpTemp() {
 
 // **************** //
 
+// ListFiles lists the files in the specified directory and their sync status.
+func ListFiles(path string) (map[string]string, error) {
+	var fileStatus map[string]string
+
+	return fileStatus, nil
+}
+
 // Git commands
 
 // IsRepo checks whether a given path is a git repository.

--- a/repo/git.go
+++ b/repo/git.go
@@ -97,8 +97,22 @@ func (fs FileStatus) Abbrev() string {
 	}
 }
 
+// getFileStatus determines the state of the file at filepath and returns a FileStatus.
 func getFileStatus(filepath string) FileStatus {
-	return Synced
+	wiRes, err := AnnexWhereis(filepath)
+	if err != nil {
+		// File does not exist. Different status???
+		return Untracked
+	}
+	for _, wr := range wiRes {
+		for _, remote := range wr.Whereis {
+			if remote.Here {
+				return Synced
+			}
+		}
+		return NoContent
+	}
+	return Untracked
 }
 
 // ListFiles lists the files in the specified directory and their sync status.

--- a/repo/git.go
+++ b/repo/git.go
@@ -264,10 +264,10 @@ func buildAnnexCmd(args ...string) *exec.Cmd {
 
 // AnnexInit initialises the repository for annex
 // (git annex init)
-func AnnexInit(localPath string) error {
+func AnnexInit(localPath, description string) error {
 	gitbin := util.Config.Bin.Git
 	initError := fmt.Errorf("Repository annex initialisation failed.")
-	cmd := buildAnnexCmd("init", "--version=6")
+	cmd := buildAnnexCmd("init", description, "--version=6")
 	cmd.Dir = localPath
 	var out bytes.Buffer
 	var stderr bytes.Buffer

--- a/repo/git.go
+++ b/repo/git.go
@@ -491,26 +491,16 @@ type AnnexWhereisResult struct {
 
 // AnnexWhereis returns information about annexed files in the repository
 // (git annex whereis)
-func AnnexWhereis(localPath string) ([]AnnexWhereisResult, error) {
-	info, err := os.Stat(localPath)
-	if err != nil {
-		return nil, err
-	}
-	var filename string
-	switch mode := info.Mode(); {
-	case mode.IsRegular():
-		localPath, filename = filepath.Split(localPath)
-	case mode.IsDir():
-		filename = "."
-	}
+func AnnexWhereis(path string) ([]AnnexWhereisResult, error) {
+	dir, filename := util.PathSplit(path)
 	cmd := buildAnnexCmd("whereis", "--json", filename)
-	cmd.Dir = localPath
+	cmd.Dir = dir
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 	util.LogWrite("Running shell command: %s", strings.Join(cmd.Args, " "))
-	err = cmd.Run()
+	err := cmd.Run()
 
 	if err != nil {
 		util.LogWrite("Error during AnnexWhereis")

--- a/repo/git.go
+++ b/repo/git.go
@@ -68,16 +68,16 @@ const (
 	NoContent
 	// Modified indicatres that a file has local modifications that have not been committed
 	Modified
-	// LocalUpdates indicates that a file has local, committed modifications that have not been pushed
-	LocalUpdates
-	// RemoteUpdates indicates that a file has remote modifications that have not been pulled
-	RemoteUpdates
+	// LocalChanges indicates that a file has local, committed modifications that have not been pushed
+	LocalChanges
+	// RemoteChanges indicates that a file has remote modifications that have not been pulled
+	RemoteChanges
 	// Untracked indicates that a file is not being tracked by neither git nor git annex
 	Untracked
 )
 
 // Abbrev returns the two-letter abbrevation of the file status
-// TODO: List status abbreviations
+// OK (Synced), NC (NoContent), MD (Modified), LU (LocalUpdates), RU (RemoteUpdates), ?? (Untracked)
 func (fs FileStatus) Abbrev() string {
 	switch {
 	case fs == Synced:
@@ -86,10 +86,10 @@ func (fs FileStatus) Abbrev() string {
 		return "NC"
 	case fs == Modified:
 		return "MD"
-	case fs == LocalUpdates:
+	case fs == LocalChanges:
 		return "LC"
-	case fs == RemoteUpdates:
-		return "RU"
+	case fs == RemoteChanges:
+		return "RC"
 	case fs == Untracked:
 		return "??"
 	default:
@@ -146,7 +146,7 @@ func getFileStatus(filepath string) FileStatus {
 		return Untracked
 	}
 	if out.Len() > 0 {
-		return LocalUpdates
+		return LocalChanges
 	}
 
 	return Untracked

--- a/repo/git.go
+++ b/repo/git.go
@@ -104,14 +104,26 @@ func getFileStatus(filepath string) FileStatus {
 		// File does not exist. Different status???
 		return Untracked
 	}
-	for _, wr := range wiRes {
-		for _, remote := range wr.Whereis {
+
+	// function only runs for one file
+	if len(wiRes) > 0 {
+		for _, remote := range wiRes[0].Whereis {
 			if remote.Here {
 				return Synced
 			}
 		}
 		return NoContent
 	}
+
+	// not in annex, but AnnexStatus can still tell us the file status
+	anexStat, err := AnnexStatus(filepath)
+	switch stat := anexStat[0].Status; {
+	case stat == "M" || stat == "A":
+		return Modified
+	case stat == "?":
+		return Untracked
+	}
+
 	return Untracked
 }
 

--- a/repo/git.go
+++ b/repo/git.go
@@ -128,7 +128,7 @@ func getFileStatus(filepath string) FileStatus {
 
 	// committed but not pushed?
 	gitbin := util.Config.Bin.Git
-	// TODO: origin/master should be default remote/branch
+	// TODO: use default remote/branch
 	dir, filename := util.PathSplit(filepath)
 	cmd := exec.Command(gitbin, "diff", "--name-only", "origin/master", filename)
 	cmd.Dir = dir

--- a/repo/git.go
+++ b/repo/git.go
@@ -84,6 +84,9 @@ func getFileStatus(filepath string) FileStatus {
 func ListFiles(path string, filesStatus map[string]FileStatus) error {
 
 	walker := func(path string, info os.FileInfo, err error) error {
+		if filepath.Base(path) == ".git" {
+			return filepath.SkipDir
+		}
 		if info.Mode().IsRegular() {
 			filesStatus[path] = getFileStatus(path)
 		}

--- a/repo/git.go
+++ b/repo/git.go
@@ -119,7 +119,8 @@ func ListFiles(path string, filesStatus map[string]FileStatus) error {
 
 // Git commands
 
-// IsRepo checks whether a given path is a git repository.
+// IsRepo checks whether a given path is (in) a git repository.
+// This function assumes path is a directory and will return false for files.
 func IsRepo(path string) bool {
 	gitbin := util.Config.Bin.Git
 	cmd := exec.Command(gitbin, "status")

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/G-Node/gin-cli/auth"
 	"github.com/G-Node/gin-cli/util"
@@ -158,7 +159,13 @@ func (repocl *Client) CloneRepo(repoPath string) error {
 	fmt.Printf("done.\n")
 
 	// git annex init the clone and set defaults
-	err = AnnexInit(repoName)
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "localhost"
+	}
+	repocl.LoadToken()
+	description := fmt.Sprintf("%s@%s", repocl.Username, hostname)
+	err = AnnexInit(localPath, description)
 	if err != nil {
 		return err
 	}

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -165,7 +165,7 @@ func (repocl *Client) CloneRepo(repoPath string) error {
 	}
 	repocl.LoadToken()
 	description := fmt.Sprintf("%s@%s", repocl.Username, hostname)
-	err = AnnexInit(localPath, description)
+	err = AnnexInit(repoName, description)
 	if err != nil {
 		return err
 	}

--- a/util/files.go
+++ b/util/files.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 // PathExists returns true if the path exists
@@ -11,6 +12,24 @@ func PathExists(path string) bool {
 		return false
 	}
 	return true
+}
+
+// PathSplit returns the directory path separated from the filename. If the
+// argument is a directory, the filename "." is returned. Errors are ignored.
+func PathSplit(path string) (string, string) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return path, "."
+	}
+	var dir, filename string
+	switch mode := info.Mode(); {
+	case mode.IsRegular():
+		dir, filename = filepath.Split(path)
+	case mode.IsDir():
+		dir = path
+		filename = "."
+	}
+	return dir, filename
 }
 
 // DataSize returns the simplest representation of bytes as a string (with units)


### PR DESCRIPTION
First step towards implementing selective download and upload.

This PR implements a new command `gin ls`. it produces a full, recursive listing of files in a directory. It takes multiple (or no) arguments and provides an `ls`-like listing, prefixing each filename by a status code.

Two notes:
- I don't know if I like the status codes. They're not very meaningful (other than maybe `OK` and `??`). I'd like some feedback and maybe some ideas about changing them.
- The implementation of `ls` runs `git annex whereis` on each individual file recursively. Theoretically, it could run `whereis` on each argument, significantly reducing `exec.Command` calls, but I wanted the command to show all files, even untracked ones.