### PR TITLE
New repos command behaviour

### DIFF
--- a/help.go
+++ b/help.go
@@ -3,26 +3,26 @@ package main
 const usage = `
 GIN command line client
 
-Usage: gin <command> [<args>...]
-       gin --help
-       gin --version
+Usage:	gin <command> [<args>...]
+	gin --help
+	gin --version
 
 Options:
-    -h --help    This help screen
-    --version    Client version
+	-h --help    This help screen
+	--version    Client version
 
 Commands:
-    login    [<username>]
-    logout
-    create   [<name>] [<description>]
-    get      <repopath>
-    upload
-    download
-    repos    [<username>]
-    info     [<username>]
-    keys     [-v | --verbose]
-    keys     --add <filename>
-    help     <command>
+	login
+	logout
+	create
+	get
+	upload
+	download
+	repos
+	info
+	keys
+	keys
+	help
 
 Use 'help' followed by a command to see full description of the command.
 `
@@ -151,24 +151,28 @@ DESCRIPTION
 const reposHelp = `USAGE
 
 	gin repos [<username>]
+	gin repos -s, --shared-with-me
+	gin repos -p, --public
 
 
 DESCRIPTION
 
 	List repositories on the server that provide read access. If no argument is
-	provided, it will list all publicly accessible repositories on the GIN
-	server.
+	provided, it will list the repositories owned by the logged in user. If no
+	user is logged in, it will list all public repositories.
 
 ARGUMENTS
 
+	-s, --shared-with-me
+		List all repositories shared with the logged in user.
+
+	-p, --public
+		List all public repositories.
+
 	<username>
-		The name of the user whose repositories should be listed. This can be
-		the username of the currently logged in user (YOU), in which case the
-		command will list all repositories owned by YOU. If it is the username
-		of a different user, it will list all the repositories owned by the
-		specified user that YOU have access to. This consists of public
-		repositories and repositories shared with YOU.
-`
+		The name of the user whose repositories should be listed.  This
+		consists of public repositories and repositories shared with the logged
+		in user.  `
 
 const infoHelp = `USAGE
 
@@ -204,16 +208,16 @@ DESCRIPTION
 
 ARGUMENTS
 
-	--verbose, -v
+	-v, --verbose
 		Verbose printing. Prints the entire public key when listing.
 
 	--add <filename>
 		Specify a filename which contains a public key to be added to the GIN
 		server.
 
-EXAMPLES 
+EXAMPLES
 
-	Add a public key to your account, as generated from the default ssh-keygen 
+	Add a public key to your account, as generated from the default ssh-keygen
 	command
 
 		$ gin keys --add ~/.ssh/id_rsa.pub

--- a/main.go
+++ b/main.go
@@ -338,7 +338,7 @@ func listRepos(args []string) {
 	if arg == "" || arg == "--public" {
 		fmt.Print("Listing all public repositories:\n\n")
 	} else if arg == "--shared-with-me" {
-		fmt.Print("Listing all accissible shared repositories:\n\n")
+		fmt.Print("Listing all accessible shared repositories:\n\n")
 	} else {
 		if repocl.Username == "" {
 			fmt.Printf("You are not logged in.\nListing only public repositories owned by '%s':\n\n", arg)

--- a/main.go
+++ b/main.go
@@ -326,6 +326,11 @@ func listRepos(args []string) {
 		}
 	} else {
 		arg = args[0]
+		if arg == "-p" {
+			arg = "--public"
+		} else if arg == "-s" {
+			arg = "--shared-with-me"
+		}
 	}
 	repos, err := repocl.GetRepos(arg)
 	util.CheckError(err)

--- a/main.go
+++ b/main.go
@@ -332,7 +332,7 @@ func listRepos(args []string) {
 
 	if arg == "" || arg == "--public" {
 		fmt.Print("Listing all public repositories:\n\n")
-	} else if arg == "--shared" {
+	} else if arg == "--shared-with-me" {
 		fmt.Print("Listing all accissible shared repositories:\n\n")
 	} else {
 		if repocl.Username == "" {

--- a/main.go
+++ b/main.go
@@ -38,7 +38,6 @@ func login(args []string) {
 	}
 
 	// prompt for password
-	password = ""
 	fmt.Print("Password: ")
 	pwbytes, err := gopass.GetPasswdMasked()
 	fmt.Println()
@@ -320,9 +319,11 @@ func listRepos(args []string) {
 	}
 	var username string
 	repocl := repo.NewClient(util.Config.RepoHost)
-
+	err := repocl.LoadToken()
 	if len(args) == 0 {
-		username = ""
+		if err == nil {
+			username = repocl.Username
+		}
 	} else {
 		username = args[0]
 	}
@@ -330,11 +331,14 @@ func listRepos(args []string) {
 	util.CheckError(err)
 
 	if username == "" {
-		fmt.Print("Listing all public repositories\n\n")
+		fmt.Print("Listing all public repositories:\n\n")
 	} else {
-		err = repocl.LoadToken()
-		if err != nil {
-			fmt.Printf("You are not logged in.\nListing only public repositories owned by '%s'.\n\n", username)
+		if repocl.Username == "" {
+			fmt.Printf("You are not logged in.\nListing only public repositories owned by '%s':\n\n", username)
+		} else if username == repocl.Username {
+			fmt.Print("Listing your repositories:\n\n")
+		} else {
+			fmt.Printf("Listing accessible repositories owned by '%s':\n\n", username)
 		}
 	}
 	for idx, repoInfo := range repos {

--- a/main.go
+++ b/main.go
@@ -317,28 +317,30 @@ func listRepos(args []string) {
 	if len(args) > 1 {
 		util.Die(usage)
 	}
-	var username string
+	var arg string
 	repocl := repo.NewClient(util.Config.RepoHost)
 	err := repocl.LoadToken()
 	if len(args) == 0 {
 		if err == nil {
-			username = repocl.Username
+			arg = repocl.Username
 		}
 	} else {
-		username = args[0]
+		arg = args[0]
 	}
-	repos, err := repocl.GetRepos(username)
+	repos, err := repocl.GetRepos(arg)
 	util.CheckError(err)
 
-	if username == "" {
+	if arg == "" || arg == "--public" {
 		fmt.Print("Listing all public repositories:\n\n")
+	} else if arg == "--shared" {
+		fmt.Print("Listing all accissible shared repositories:\n\n")
 	} else {
 		if repocl.Username == "" {
-			fmt.Printf("You are not logged in.\nListing only public repositories owned by '%s':\n\n", username)
-		} else if username == repocl.Username {
+			fmt.Printf("You are not logged in.\nListing only public repositories owned by '%s':\n\n", arg)
+		} else if arg == repocl.Username {
 			fmt.Print("Listing your repositories:\n\n")
 		} else {
-			fmt.Printf("Listing accessible repositories owned by '%s':\n\n", username)
+			fmt.Printf("Listing accessible repositories owned by '%s':\n\n", arg)
 		}
 	}
 	for idx, repoInfo := range repos {

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -32,7 +32,7 @@ func (repocl *Client) GetRepos(user string) ([]wire.Repo, error) {
 	var res *http.Response
 	var err error
 
-	if user == "" {
+	if user == "" || user == "--public" {
 		util.LogWrite("User: public")
 		res, err = repocl.Get("/repos/public")
 	} else {

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -43,7 +43,7 @@ func (repocl *Client) GetRepos(user string) ([]wire.Repo, error) {
 			return nil, fmt.Errorf(msg)
 		}
 		util.LogWrite("Shared with user: %s", repocl.Username)
-		res, err = repocl.Get("repos/shared")
+		res, err = repocl.Get("/repos/shared")
 	} else {
 		util.LogWrite("User: %s", user)
 		repocl.LoadToken()

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -33,11 +33,20 @@ func (repocl *Client) GetRepos(user string) ([]wire.Repo, error) {
 	var err error
 
 	if user == "" || user == "--public" {
-		util.LogWrite("User: public")
+		util.LogWrite("Public")
 		res, err = repocl.Get("/repos/public")
+	} else if user == "--shared-with-me" {
+		err = repocl.LoadToken()
+		if err != nil {
+			msg := fmt.Sprintf("Error loading token: %s", err.Error())
+			util.LogWrite(msg)
+			return nil, fmt.Errorf(msg)
+		}
+		util.LogWrite("Shared with user: %s", repocl.Username)
+		res, err = repocl.Get("repos/shared")
 	} else {
 		util.LogWrite("User: %s", user)
-		err = repocl.LoadToken()
+		repocl.LoadToken()
 		res, err = repocl.Get(fmt.Sprintf("/users/%s/repos", user))
 	}
 

--- a/util/die.go
+++ b/util/die.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"os"
+	"strings"
 )
 
 //Die prints a message to stderr and exits the program.
@@ -12,12 +13,14 @@ func Die(msg string) {
 }
 
 // CheckError exits the program if an error is passed to the function.
-// Before exiting, the error message is printed to stderr.
-// The function should be used to avoid constantly checking if `err != nil` and
-// returning errors up the stack when all that needs to be done is to stop execution.
+// The error message is checked for known error messages and an informative message is printed.
+// Otherwise, the error message is printed to stderr.
 func CheckError(err error) {
 	if err != nil {
 		LogWrite(err.Error())
+		if strings.Contains(err.Error(), "Error loading user token") {
+			Die("This operation requires login.")
+		}
 		Die(err.Error())
 	}
 }

--- a/web/web.go
+++ b/web/web.go
@@ -100,6 +100,7 @@ func NewClient(address string) *Client {
 // LoadToken reads the username and auth token from the token file and sets the
 // values in the struct.
 func (ut *UserToken) LoadToken() error {
+	// TODO: Don't reload if already set
 	util.LogWrite("Loading token")
 	path, err := util.ConfigPath(false)
 	if err != nil {


### PR DESCRIPTION
This PR changes the default behaviour of the `gin repos` command as described in issue #73.

New behaviour:
- By default, lists logged in user's repositories.
- If no user is logged in, lists public repositories.
- If a username is specified, lists accessible (public or shared) repositories owned by that user.
- New flag `--public` or short `-p` lists public repositories.
- New flag `--shared-with-me` or short `-s` lists repositories shared with logged in user.

Help updated, cleaned up, and realigned.

Closes #73.