### PR TITLE
[util] Client secret can be configured

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func login(args []string) {
 	}
 
 	authcl := auth.NewClient(util.Config.AuthHost)
-	err = authcl.Login(username, password, "gin-cli", "97196a1c-silly-biscuit3-d161ea15a676")
+	err = authcl.Login(username, password, "gin-cli", util.Config.Secret)
 	util.CheckError(err)
 	info, err := authcl.RequestAccount(username)
 	util.CheckError(err)

--- a/util/config.go
+++ b/util/config.go
@@ -22,6 +22,7 @@ type conf struct {
 		Exclude []string
 		MinSize string
 	}
+	Secret string
 }
 
 // Config makes the configuration options available after LoadConfig is called
@@ -42,6 +43,7 @@ func LoadConfig() error {
 	viper.SetDefault("git.address", "gin.g-node.org")
 	viper.SetDefault("git.port", "22")
 	viper.SetDefault("git.user", "git")
+	viper.SetDefault("secret", "97196a1c-silly-biscuit3-d161ea15a676")
 
 	// annex filters
 	viper.SetDefault("annex.exclude", [...]string{"*.md", "*.rst", "*.txt", "*.c", "*.cpp", "*.h", "*.hpp", "*.py", "*.go"})
@@ -91,6 +93,9 @@ func LoadConfig() error {
 
 	LogWrite("Configuration values")
 	LogWrite("%+v", Config)
+
+	// Set secret after printing configuration to log file
+	Config.Secret = viper.GetString("secret")
 
 	return nil
 }


### PR DESCRIPTION
New config option: "secret"
Sets the client secret and defaults to the gin.g-node server value (the
previous built-in).

Closes #75