### PR TITLE
Delete repository command

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -45,7 +45,7 @@ func (authcl *Client) GetUserKeys() ([]gogs.PublicKey, error) {
 	res, err := authcl.Get("/api/v1/user/keys")
 	if err != nil {
 		return keys, fmt.Errorf("Request for keys returned error")
-	} else if res.StatusCode != 200 {
+	} else if res.StatusCode != http.StatusOK {
 		return keys, fmt.Errorf("[Keys request error] Server returned: %s", res.Status)
 	}
 
@@ -66,9 +66,9 @@ func (authcl *Client) RequestAccount(name string) (gin.Account, error) {
 	res, err := authcl.Get(fmt.Sprintf("/api/v1/users/%s", name))
 	if err != nil {
 		return acc, err
-	} else if res.StatusCode == 404 {
+	} else if res.StatusCode == http.StatusNotFound {
 		return acc, fmt.Errorf("User '%s' does not exist", name)
-	} else if res.StatusCode != 200 {
+	} else if res.StatusCode != http.StatusOK {
 		return acc, fmt.Errorf("Unknown error during user lookup for '%s'\nThe server returned '%s'", name, res.Status)
 	}
 
@@ -95,7 +95,7 @@ func (authcl *Client) SearchAccount(query string) ([]gin.Account, error) {
 	res, err := authcl.Get(address)
 	if err != nil {
 		return accs, err
-	} else if res.StatusCode != 200 {
+	} else if res.StatusCode != http.StatusOK {
 		return accs, fmt.Errorf("[Account search] Failed. Server returned: %s", res.Status)
 	}
 

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -60,9 +60,8 @@ func (authcl *Client) GetUserKeys() ([]gogs.PublicKey, error) {
 }
 
 // RequestAccount requests a specific account by name.
-func (authcl *Client) RequestAccount(name string) (gin.Account, error) {
-	var acc gin.Account
-	gogsUser := GINUser{}
+func (authcl *Client) RequestAccount(name string) (gogs.User, error) {
+	var acc gogs.User
 	res, err := authcl.Get(fmt.Sprintf("/api/v1/users/%s", name))
 	if err != nil {
 		return acc, err
@@ -75,13 +74,10 @@ func (authcl *Client) RequestAccount(name string) (gin.Account, error) {
 	defer web.CloseRes(res.Body)
 
 	b, err := ioutil.ReadAll(res.Body)
-	if err := json.Unmarshal(b, &gogsUser); err != nil {
-		return gin.Account{}, err
+	if err != nil {
+		return acc, err
 	}
-	acc.LastName = gogsUser.FullName
-	acc.Login = gogsUser.UserName
-	acc.Email = &gin.Email{Email: gogsUser.Email}
-
+	err = json.Unmarshal(b, &acc)
 	return acc, err
 }
 

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -123,7 +123,7 @@ func (authcl *Client) AddKey(key, description string, temp bool) error {
 }
 
 // Login requests a token from the auth server and stores the username and token to file.
-func (authcl *Client) Login(username, password, clientID, clientSecret string) error {
+func (authcl *Client) Login(username, password, clientID string) error {
 	tokenCreate := &gogs.CreateAccessTokenOption{Name: "gin-cli"}
 	address := fmt.Sprintf("/api/v1/users/%s/tokens", username)
 	resp, err := authcl.PostBasicAuth(address, username, password, tokenCreate)

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -6,28 +6,30 @@ import (
 	"io/ioutil"
 	"net/url"
 
+	"net/http"
+	"path"
+
 	"github.com/G-Node/gin-cli/util"
 	"github.com/G-Node/gin-cli/web"
 	"github.com/G-Node/gin-core/gin"
-	"net/http"
-	"encoding/base64"
-	"path"
+	gogs "github.com/gogits/go-gogs-client"
 )
 
+// PublicKey is used to represent the information of the public part of a key pair.
 type PublicKey struct {
-	ID    int64     `json:"id"`
-	Key   string    `json:"key"`
-	URL   string    `json:"url,omitempty"`
-	Title string    `json:"title,omitempty"`
+	ID    int64  `json:"id"`
+	Key   string `json:"key"`
+	URL   string `json:"url,omitempty"`
+	Title string `json:"title,omitempty"`
 }
 
-// User represents a API user.
-type GogsUser struct {
+// GINUser represents a API user.
+type GINUser struct {
 	ID        int64  `json:"id"`
 	UserName  string `json:"login"`
 	FullName  string `json:"full_name"`
 	Email     string `json:"email"`
-	AvatarUrl string `json:"avatar_url"`
+	AvatarURL string `json:"avatar_url"`
 }
 
 // Client is a client interface to the auth server. Embeds web.Client.
@@ -47,9 +49,10 @@ type NewKey struct {
 	Temporary   bool   `json:"temporary"`
 }
 
+// GogsPublicKey is used to represent the information of the public part of a key pair (Gogs API only).
 type GogsPublicKey struct {
-	Key   string    `json:"key"`
-	Title string    `json:"title,omitempty"`
+	Key   string `json:"key"`
+	Title string `json:"title,omitempty"`
 }
 
 // GetUserKeys fetches the public keys that the user has added to the auth server.
@@ -84,7 +87,7 @@ func (authcl *Client) GetUserKeys() ([]gin.SSHKey, error) {
 // RequestAccount requests a specific account by name.
 func (authcl *Client) RequestAccount(name string) (gin.Account, error) {
 	var acc gin.Account
-	gogsUser := GogsUser{}
+	gogsUser := GINUser{}
 	res, err := authcl.Get(fmt.Sprintf("/api/v1/users/%s", name))
 	if err != nil {
 		return acc, err

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -265,30 +265,3 @@ func TestSearchAccount(t *testing.T) {
 		t.Errorf("[Search account] Bad server account search returned non-empty account info. [%+v]", accs)
 	}
 }
-
-func loginHandler(w http.ResponseWriter, r *http.Request) {
-	goodURL := "/oauth/token"
-	goodFormData := `client_id=clientid&client_secret=clientsecret&grant_type=password&password=alicepw&scope=repo-read+repo-write+account-read+account-write&username=alice`
-	brokenFormData := `client_id=clientid&client_secret=clientsecret&grant_type=password&password=BREAK&scope=repo-read+repo-write+account-read+account-write&username=BREAK`
-	resp := `{"token_type":"Bearer","scope":"account-read account-write repo-read repo-write","access_token":"THETOKEN","refresh_token":null}`
-	badAuthResp := `{"code":401,"error":"Unauthorized","message":"Wront username or password","reasons":null}`
-	err := r.ParseForm()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error while parsing form in request handler for Login test")
-	}
-
-	if r.URL.Path == goodURL {
-		if r.Form.Encode() == goodFormData {
-			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, resp)
-		} else if r.Form.Encode() == brokenFormData {
-			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, "not_json_response")
-		} else {
-			w.WriteHeader(http.StatusUnauthorized)
-			fmt.Fprint(w, badAuthResp)
-		}
-	} else {
-		w.WriteHeader(http.StatusNotFound)
-	}
-}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/G-Node/gin-cli/web"
-	"github.com/G-Node/gin-core/gin"
 	gogs "github.com/gogits/go-gogs-client"
 )
 
@@ -55,7 +54,7 @@ func TestRequestAccount(t *testing.T) {
 		t.Errorf("[Account lookup: alice] Request returned error [%s] when it should have succeeded.", err.Error())
 	}
 
-	respOK := acc.Login == "alice"
+	respOK := acc.UserName == "alice"
 
 	if !respOK {
 		t.Error("[Account lookup: alice] Test failed. Response does not match expected values.")
@@ -67,7 +66,7 @@ func TestRequestAccount(t *testing.T) {
 		t.Error("[Account lookup] Non existent account request succeeded when it should have failed.")
 	}
 
-	var emptyAcc gin.Account
+	var emptyAcc gogs.User
 	if acc != emptyAcc {
 		t.Errorf("[Account lookup] Non existent account request returned non-empty account info. [%+v]", acc)
 	}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/G-Node/gin-cli/web"
 	"github.com/G-Node/gin-core/gin"
+	gogs "github.com/gogits/go-gogs-client"
 )
 
 func TestMain(m *testing.M) {
@@ -117,7 +118,7 @@ func TestRequestKeys(t *testing.T) {
 	}
 
 	respOK := keys[0].Key == "ssh-rsa SSHKEY12344567 name@host" &&
-		keys[0].Description == "name@host"
+		keys[0].Title == "name@host"
 
 	if !respOK {
 		t.Error("[Key retrieval] Test failed. Response does not match expected values.")
@@ -167,7 +168,7 @@ func addKeyHandler(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(os.Stderr, "Error in request handler for AddKey test")
 	}
 
-	newKey := &PublicKey{}
+	newKey := &gogs.PublicKey{}
 	if r.URL.Path == goodURL {
 		err := json.Unmarshal(b, newKey)
 		if err != nil {
@@ -195,7 +196,6 @@ func TestAddKey(t *testing.T) {
 		t.Errorf("[Add key] Function returned error: %s", err.Error())
 	}
 }
-
 
 func searchAccountHandler(w http.ResponseWriter, r *http.Request) {
 	goodURL := "/api/accounts?q=alice"
@@ -293,4 +293,3 @@ func loginHandler(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}
 }
-

--- a/dorelease.py
+++ b/dorelease.py
@@ -184,7 +184,7 @@ def package_linux_plain(binfiles):
         _, osarch = os.path.split(d)
         # simple binary archive
         shutil.copy("README.md", d)
-        arc = "gin-cli_{}-{}.tar.gz".format(version["version"], osarch)
+        arc = "gin-cli-{}-{}.tar.gz".format(version["version"], osarch)
         arc = os.path.join(pkgdir, arc)
         cmd = ["tar", "-czf", arc, "-C", d, f, "README.md"]
         print("Running {}".format(" ".join(cmd)))
@@ -215,7 +215,7 @@ def debianize(binfiles, annexsa_archive):
 
             # TODO: Update Debian control file version automatically
 
-            pkgname = "gin-cli_{}".format(version["version"])
+            pkgname = "gin-cli-{}".format(version["version"])
             build_dir = os.path.join(tmp_dir, pkgname)
             opt_dir = os.path.join(build_dir, "opt")
             opt_gin_dir = os.path.join(opt_dir, "gin")
@@ -311,7 +311,7 @@ def package_mac_plain(binfiles):
         osarch = osarch.replace("darwin", "macos")
         # simple binary archive
         shutil.copy("README.md", d)
-        arc = "gin-cli_{}-{}.tar.gz".format(version["version"], osarch)
+        arc = "gin-cli-{}-{}.tar.gz".format(version["version"], osarch)
         arc = os.path.join(pkgdir, arc)
         cmd = ["tar", "-czf", arc, "-C", d, f, "README.md"]
         print("Running {}".format(" ".join(cmd)))
@@ -360,7 +360,7 @@ def winbundle(binfiles, git_pkg, annex_pkg):
             d, f = os.path.split(bf)
             _, osarch = os.path.split(d)
 
-            arc = "gin-cli_{}-{}.zip".format(version["version"], osarch)
+            arc = "gin-cli-{}-{}.zip".format(version["version"], osarch)
             arc = os.path.join(pkgdir, arc)
             print("Creating Windows zip file")
             # need to change paths before making zip file
@@ -411,23 +411,34 @@ def main():
     def printlist(lst):
         print("".join("> " + l + "\n" for l in lst))
 
+    def link_latest(lst):
+        for l in lst:
+            latestname = l.replace(version["version"], "latest")
+            print("Linking {} to {}".format(l, latestname))
+            os.link(l, latestname)
+
     print("------------------------------------------------")
     print("The following archives and packages were created")
     print("------------------------------------------------")
     print("Linux tarballs:")
     printlist(linux_pkgs)
+    link_latest(linux_pkgs)
 
     print("Debian packages:")
     printlist(deb_pkgs)
+    link_latest(deb_pkgs)
 
     print("RPM packages:")
     printlist(rpm_pkgs)
+    link_latest(rpm_pkgs)
 
     print("macOS packages:")
     printlist(mac_pkgs)
+    link_latest(mac_pkgs)
 
     print("Windows packages:")
     printlist(win_pkgs)
+    link_latest(win_pkgs)
 
 
 if __name__ == "__main__":

--- a/main.go
+++ b/main.go
@@ -65,8 +65,7 @@ func login(args []string) {
 	util.CheckError(err)
 	info, err := authcl.RequestAccount(username)
 	util.CheckError(err)
-	fmt.Printf("Hello %s. You are now logged in.\n", info.Login)
-	// fmt.Printf("[Login success] You are now logged in as %s\n", username)
+	fmt.Printf("Hello %s. You are now logged in.\n", info.UserName)
 }
 
 func logout(args []string) {
@@ -371,39 +370,14 @@ func printAccountInfo(args []string) {
 
 	var fullnameBuffer bytes.Buffer
 
-	condAppend(&fullnameBuffer, info.Title)
-	condAppend(&fullnameBuffer, &info.FirstName)
-	condAppend(&fullnameBuffer, info.MiddleName)
-	condAppend(&fullnameBuffer, &info.LastName)
+	condAppend(&fullnameBuffer, &info.FullName)
 
 	var outBuffer bytes.Buffer
 
-	_, _ = outBuffer.WriteString(fmt.Sprintf("User %s\nName: %s\n", info.Login, fullnameBuffer.String()))
+	_, _ = outBuffer.WriteString(fmt.Sprintf("User %s\nName: %s\n", info.UserName, fullnameBuffer.String()))
 
-	if info.Email != nil && info.Email.Email != "" {
-		_, _ = outBuffer.WriteString(fmt.Sprintf("Email: %s", info.Email.Email))
-		if info.Email.IsPublic && info.Login == authcl.Username {
-			_, _ = outBuffer.WriteString(fmt.Sprintf(" (publicly visible)"))
-		}
-		_, _ = outBuffer.WriteString(fmt.Sprintf("\n"))
-	}
-
-	if info.Affiliation != nil {
-		var affiliationBuffer bytes.Buffer
-		affiliation := info.Affiliation
-
-		condAppend(&affiliationBuffer, &affiliation.Department)
-		condAppend(&affiliationBuffer, &affiliation.Institute)
-		condAppend(&affiliationBuffer, &affiliation.City)
-		condAppend(&affiliationBuffer, &affiliation.Country)
-
-		if affiliationBuffer.Len() > 0 {
-			_, _ = outBuffer.WriteString(fmt.Sprintf("Affiliation: %s", affiliationBuffer.String()))
-			if info.Affiliation.IsPublic && info.Login == authcl.Username {
-				_, _ = outBuffer.WriteString(fmt.Sprintf(" (publicly visible)"))
-			}
-			_, _ = outBuffer.WriteString(fmt.Sprintf("\n"))
-		}
+	if info.Email != "" {
+		_, _ = outBuffer.WriteString(fmt.Sprintf("Email: %s\n", info.Email))
 	}
 
 	fmt.Println(outBuffer.String())

--- a/main.go
+++ b/main.go
@@ -155,21 +155,25 @@ func lsRepo(args []string) {
 	repocl.GitHost = util.Config.GitHost
 	repocl.KeyHost = util.Config.AuthHost
 
+	var err error
 	var fileStatusBuffer, dirStatusBuffer, skipped bytes.Buffer
 	for _, d := range dirs {
 		path, filename := util.PathSplit(d)
 		if filepath.Base(d) == ".git" {
-			skipped.WriteString(fmt.Sprintf("Skipping directory '%s'\n", d))
+			_, err = skipped.WriteString(fmt.Sprintf("Skipping directory '%s'\n", d))
+			util.LogError(err)
 			continue
 		}
 		if !repo.IsRepo(path) {
-			skipped.WriteString(fmt.Sprintf("'%s' is not under gin control\n", d))
+			_, err = skipped.WriteString(fmt.Sprintf("'%s' is not under gin control\n", d))
+			util.LogError(err)
 			continue
 		}
 		filesStatus := make(map[string]repo.FileStatus)
 		err := repo.ListFiles(d, filesStatus)
 		if err != nil {
-			skipped.WriteString(fmt.Sprintf("Error listing %s: %s\n", d, err.Error()))
+			_, err = skipped.WriteString(fmt.Sprintf("Error listing %s: %s\n", d, err.Error()))
+			util.LogError(err)
 			continue
 		}
 
@@ -177,11 +181,13 @@ func lsRepo(args []string) {
 		if filename == "." {
 			currentBuffer = &dirStatusBuffer
 			if len(dirs) > 1 {
-				dirStatusBuffer.WriteString(fmt.Sprintf("\n%s:\n", d))
+				_, err = dirStatusBuffer.WriteString(fmt.Sprintf("\n%s:\n", d))
+				util.LogError(err)
 			}
 		}
 		for file, status := range filesStatus {
-			currentBuffer.WriteString(fmt.Sprintf("%s %s\n", status.Abbrev(), file))
+			_, err = currentBuffer.WriteString(fmt.Sprintf("%s %s\n", status.Abbrev(), file))
+			util.LogError(err)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func login(args []string) {
 	}
 
 	authcl := auth.NewClient(util.Config.AuthHost)
-	err = authcl.Login(username, password, "gin-cli", util.Config.Secret)
+	err = authcl.Login(username, password, "gin-cli")
 	util.CheckError(err)
 	info, err := authcl.RequestAccount(username)
 	util.CheckError(err)

--- a/main.go
+++ b/main.go
@@ -266,8 +266,7 @@ func printKeys(args []string) {
 	}
 	fmt.Printf("You have %s key%s associated with your account.\n\n", nkeysStr, plural)
 	for idx, key := range keys {
-		fmt.Printf("[%v] \"%s\" ", idx+1, key.Description)
-		fmt.Printf("(Fingerprint: %s)\n", key.Fingerprint)
+		fmt.Printf("[%v] \"%s\"\n", idx+1, key.Title)
 		if printFull {
 			fmt.Printf("--- Key ---\n%s\n", key.Key)
 		}

--- a/main.go
+++ b/main.go
@@ -370,7 +370,7 @@ func printAccountInfo(args []string) {
 	fmt.Println(outBuffer.String())
 }
 
-func listRepos(args []string) {
+func repos(args []string) {
 	if len(args) > 1 {
 		util.Die(usage)
 	}
@@ -389,7 +389,7 @@ func listRepos(args []string) {
 			arg = "--shared-with-me"
 		}
 	}
-	repos, err := repocl.GetRepos(arg)
+	repolist, err := repocl.GetRepos(arg)
 	util.CheckError(err)
 
 	if arg == "" || arg == "--public" {
@@ -405,7 +405,7 @@ func listRepos(args []string) {
 			fmt.Printf("Listing accessible repositories owned by '%s':\n\n", arg)
 		}
 	}
-	for idx, repoInfo := range repos {
+	for idx, repoInfo := range repolist {
 		fmt.Printf("%d: %s/%s\n", idx+1, repoInfo.Owner, repoInfo.Name)
 		fmt.Printf("Description: %s\n", strings.Trim(repoInfo.Description, "\n"))
 		if repoInfo.Public {
@@ -465,7 +465,7 @@ func main() {
 	case "keys":
 		keys(cmdArgs)
 	case "repos":
-		listRepos(cmdArgs)
+		repos(cmdArgs)
 	case "logout":
 		logout(cmdArgs)
 	case "help":

--- a/main.go
+++ b/main.go
@@ -444,9 +444,9 @@ func repos(args []string) {
 		}
 	}
 	for idx, repoInfo := range repolist {
-		fmt.Printf("%d: %s/%s\n", idx+1, repoInfo.Owner, repoInfo.Name)
+		fmt.Printf("%d: %s\n", idx+1, repoInfo.FullName)
 		fmt.Printf("Description: %s\n", strings.Trim(repoInfo.Description, "\n"))
-		if repoInfo.Public {
+		if !repoInfo.Private {
 			fmt.Println("[This repository is public]")
 		}
 		fmt.Println()

--- a/main.go
+++ b/main.go
@@ -149,11 +149,12 @@ func deleteRepo(args []string) {
 
 	if repoinfo.FullName == confirmation && repostr == confirmation {
 		err = repocl.DelRepo(repostr)
-		util.CheckErrorMsg(err, fmt.Sprintf("Error deleting repository. Server returned: %s", err.Error()))
+		util.CheckError(err)
 	} else {
 		util.Die("Confirmation does not match repository name. Cancelling.")
 	}
 
+	fmt.Printf("Repository %s has been deleted!\n", repostr)
 }
 
 func isValidRepoPath(path string) bool {

--- a/repo/git.go
+++ b/repo/git.go
@@ -177,10 +177,7 @@ func IsRepo(path string) bool {
 	cmd := exec.Command(gitbin, "status")
 	cmd.Dir = path
 	err := cmd.Run()
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }
 
 func publicKeyFile(file string) ssh.AuthMethod {
@@ -265,8 +262,7 @@ func splitRepoParts(repoPath string) (repoOwner, repoName string) {
 func (repocl *Client) Clone(repoPath string) error {
 	gitbin := util.Config.Bin.Git
 	remotePath := fmt.Sprintf("ssh://%s@%s/%s", repocl.GitUser, repocl.GitHost, repoPath)
-	var cmd *exec.Cmd
-	cmd = exec.Command(gitbin)
+	cmd := exec.Command(gitbin)
 	if privKeyFile.Active {
 		env := os.Environ()
 		cmd.Env = append(env, privKeyFile.GitSSHEnv())

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -89,6 +89,11 @@ func (repocl *Client) CreateRepo(name, description string) error {
 	return nil
 }
 
+// DelRepo deletes a repository from the server.
+func (repocl *Client) DelRepo(name string) error {
+	return fmt.Errorf("NOT IMPLEMENTED YET")
+}
+
 // UploadRepo adds files to a repository and uploads them.
 func (repocl *Client) UploadRepo(localPath string) error {
 	defer CleanUpTemp()

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -32,7 +32,7 @@ func (repocl *Client) GetRepo(repoPath string) (gogs.Repository, error) {
 	util.LogWrite("GetRepo")
 	var repo gogs.Repository
 
-	res, err := repocl.Get(fmt.Sprintf("/repos/%s", repoPath))
+	res, err := repocl.Get(fmt.Sprintf("/api/v1/repos/%s", repoPath))
 	if err != nil {
 		return repo, err
 	}

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -77,9 +77,9 @@ func (repocl *Client) CreateRepo(name, description string) error {
 		return fmt.Errorf("[Create repository] This action requires login")
 	}
 
-	gogsRepo := gogs.Repository{Name: name, Description: description}
+	newrepo := gogs.Repository{Name: name, Description: description}
 	util.LogWrite("Name: %s :: Description: %s", name, description)
-	res, err := repocl.Post("/api/v1/user/repos", gogsRepo)
+	res, err := repocl.Post("/api/v1/user/repos", newrepo)
 	if err != nil {
 		return err
 	} else if res.StatusCode != 201 {
@@ -92,7 +92,21 @@ func (repocl *Client) CreateRepo(name, description string) error {
 
 // DelRepo deletes a repository from the server.
 func (repocl *Client) DelRepo(name string) error {
-	return fmt.Errorf("NOT IMPLEMENTED YET")
+	util.LogWrite("Deleting repository")
+	err := repocl.LoadToken()
+	if err != nil {
+		return fmt.Errorf("[Delete repository] This action requires login")
+	}
+
+	res, err := repocl.Delete(fmt.Sprintf("/api/v1/repos/%s", name))
+	if err != nil {
+		return err
+	} else if res.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("[Delete repository] Failed. Server returned %s", res.Status)
+	}
+	web.CloseRes(res.Body)
+	util.LogWrite("Repository deleted")
+	return nil
 }
 
 // UploadRepo adds files to a repository and uploads them.

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -20,6 +20,7 @@ type Client struct {
 	GitHost string
 	GitUser string
 }
+
 // NewClient returns a new client for the repo server.
 func NewClient(host string) *Client {
 	return &Client{Client: web.NewClient(host)}
@@ -42,7 +43,7 @@ func (repocl *Client) GetRepos(user string) ([]wire.Repo, error) {
 		return repoList, err
 	}
 	err = json.Unmarshal(b, &gogsRepos)
-	for _, repo := range (gogsRepos) {
+	for _, repo := range gogsRepos {
 		repoList = append(repoList, wire.Repo{Name: repo.Name, Description: repo.Description, Owner: repo.Owner.FullName})
 	}
 	return repoList, err
@@ -137,7 +138,10 @@ func (repocl *Client) CloneRepo(repoPath string) error {
 	if err != nil {
 		hostname = "localhost"
 	}
-	repocl.LoadToken()
+	err = repocl.LoadToken()
+	if err != nil {
+		return err
+	}
 	description := fmt.Sprintf("%s@%s", repocl.Username, hostname)
 	err = AnnexInit(repoName, description)
 	if err != nil {

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -82,7 +82,7 @@ func (repocl *Client) CreateRepo(name, description string) error {
 	res, err := repocl.Post("/api/v1/user/repos", newrepo)
 	if err != nil {
 		return err
-	} else if res.StatusCode != 201 {
+	} else if res.StatusCode != http.StatusCreated {
 		return fmt.Errorf("[Create repository] Failed. Server returned %s", res.Status)
 	}
 	web.CloseRes(res.Body)

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -115,7 +115,7 @@ func (repocl *Client) DownloadRepo(localPath string) error {
 	return err
 }
 
-// CloneRepo downloads the files of a given repository.
+// CloneRepo clones a remote repository and initialises anex init with the options specified in the config file.
 func (repocl *Client) CloneRepo(repoPath string) error {
 	defer CleanUpTemp()
 	util.LogWrite("CloneRepo")
@@ -143,24 +143,5 @@ func (repocl *Client) CloneRepo(repoPath string) error {
 		return err
 	}
 	description := fmt.Sprintf("%s@%s", repocl.Username, hostname)
-	err = AnnexInit(repoName, description)
-	if err != nil {
-		return err
-	}
-
-	annexFiles, err := AnnexWhereis(repoName)
-	if err != nil {
-		return err
-	}
-	if len(annexFiles) == 0 {
-		return nil
-	}
-
-	fmt.Printf("Downloading files... ")
-	err = AnnexPull(repoName)
-	if err != nil {
-		return err
-	}
-	fmt.Printf("done.\n")
-	return nil
+	return AnnexInit(repoName, description)
 }

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -35,6 +35,12 @@ func (repocl *Client) GetRepo(repoPath string) (gogs.Repository, error) {
 	res, err := repocl.Get(fmt.Sprintf("/api/v1/repos/%s", repoPath))
 	if err != nil {
 		return repo, err
+	} else if res.StatusCode == http.StatusNotFound {
+		return repo, fmt.Errorf("Not found. Check repository owner and name.")
+	} else if res.StatusCode == http.StatusUnauthorized {
+		return repo, fmt.Errorf("You are not authorised to access repository.")
+	} else if res.StatusCode != http.StatusOK {
+		return repo, fmt.Errorf("Server returned %s", res.Body)
 	}
 	defer web.CloseRes(res.Body)
 	b, err := ioutil.ReadAll(res.Body)

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/G-Node/gin-cli/util"
 	"github.com/G-Node/gin-cli/web"
-	"github.com/G-Node/gin-repo/wire"
 	"github.com/gogits/go-gogs-client"
 )
 
@@ -52,10 +51,9 @@ func (repocl *Client) GetRepo(repoPath string) (gogs.Repository, error) {
 }
 
 // GetRepos gets a list of repositories (public or user specific)
-func (repocl *Client) GetRepos(user string) ([]wire.Repo, error) {
+func (repocl *Client) GetRepos(user string) ([]gogs.Repository, error) {
 	util.LogWrite("Retrieving repo list")
-	gogsRepos := []gogs.Repository{}
-	var repoList []wire.Repo
+	var repoList []gogs.Repository
 	var res *http.Response
 	var err error
 	res, err = repocl.Get("/api/v1/user/repos")
@@ -67,10 +65,7 @@ func (repocl *Client) GetRepos(user string) ([]wire.Repo, error) {
 	if err != nil {
 		return repoList, err
 	}
-	err = json.Unmarshal(b, &gogsRepos)
-	for _, repo := range gogsRepos {
-		repoList = append(repoList, wire.Repo{Name: repo.Name, Description: repo.Description, Owner: repo.Owner.FullName})
-	}
+	err = json.Unmarshal(b, &repoList)
 	return repoList, err
 }
 

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -26,6 +26,25 @@ func NewClient(host string) *Client {
 	return &Client{Client: web.NewClient(host)}
 }
 
+// GetRepo retrieves the information of a repository.
+func (repocl *Client) GetRepo(repoPath string) (gogs.Repository, error) {
+	defer CleanUpTemp()
+	util.LogWrite("GetRepo")
+	var repo gogs.Repository
+
+	res, err := repocl.Get(fmt.Sprintf("/repos/%s", repoPath))
+	if err != nil {
+		return repo, err
+	}
+	defer web.CloseRes(res.Body)
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return repo, err
+	}
+	err = json.Unmarshal(b, &repo)
+	return repo, err
+}
+
 // GetRepos gets a list of repositories (public or user specific)
 func (repocl *Client) GetRepos(user string) ([]wire.Repo, error) {
 	util.LogWrite("Retrieving repo list")

--- a/util/config.go
+++ b/util/config.go
@@ -22,7 +22,6 @@ type conf struct {
 		Exclude []string
 		MinSize string
 	}
-	Secret string
 }
 
 // Config makes the configuration options available after LoadConfig is called
@@ -43,7 +42,6 @@ func LoadConfig() error {
 	viper.SetDefault("git.address", "gin.g-node.org")
 	viper.SetDefault("git.port", "22")
 	viper.SetDefault("git.user", "git")
-	viper.SetDefault("secret", "97196a1c-silly-biscuit3-d161ea15a676")
 
 	// annex filters
 	viper.SetDefault("annex.exclude", [...]string{"*.md", "*.rst", "*.txt", "*.c", "*.cpp", "*.h", "*.hpp", "*.py", "*.go"})
@@ -94,9 +92,6 @@ func LoadConfig() error {
 
 	LogWrite("Configuration values")
 	LogWrite("%+v", Config)
-
-	// Set secret after printing configuration to log file
-	Config.Secret = viper.GetString("secret")
 
 	return nil
 }

--- a/util/config.go
+++ b/util/config.go
@@ -13,7 +13,7 @@ type conf struct {
 	RepoHost string
 	GitHost  string
 	GitUser  string
-	Bin struct {
+	Bin      struct {
 		Git      string
 		GitAnnex string
 		SSH      string
@@ -63,7 +63,8 @@ func LoadConfig() error {
 	viper.AddConfigPath(configpath)
 	LogWrite("Config path added %s", configpath)
 
-	viper.ReadInConfig()
+	err = viper.ReadInConfig()
+	LogError(err)
 	fileused := viper.ConfigFileUsed()
 	if fileused != "" {
 		LogWrite("Loading config file %s", viper.ConfigFileUsed())

--- a/util/die.go
+++ b/util/die.go
@@ -33,3 +33,11 @@ func CheckErrorMsg(err error, msg string) {
 		Die(msg)
 	}
 }
+
+// LogError prints err to the logfile and returns, effectively ignoring the error.
+// No logging is performed if err == nil.
+func LogError(err error) {
+	if err != nil {
+		LogWrite("The following error occured:\n%s", err.Error())
+	}
+}

--- a/util/keygen.go
+++ b/util/keygen.go
@@ -103,7 +103,6 @@ func (tf TempFile) Write(content string) error {
 // Delete the temporary file and its diirectory.
 func (tf TempFile) Delete() {
 	_ = os.RemoveAll(tf.Dir)
-	tf.Active = false
 	LogWrite("Deleted temporary key directory %s", tf.Dir)
 }
 

--- a/util/log.go
+++ b/util/log.go
@@ -46,6 +46,6 @@ func LogWrite(fmtstr string, args ...interface{}) {
 }
 
 // LogClose closes the log file.
-func LogClose() error {
-	return logfile.Close()
+func LogClose() {
+	_ = logfile.Close()
 }

--- a/version
+++ b/version
@@ -1,2 +1,2 @@
-version=0.5
+version=0.6
 build=00007

--- a/version
+++ b/version
@@ -1,2 +1,2 @@
 version=0.6
-build=00008
+build=00009

--- a/version
+++ b/version
@@ -1,2 +1,2 @@
 version=0.6
-build=00007
+build=00008

--- a/web/web.go
+++ b/web/web.go
@@ -11,11 +11,9 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
-
-	"github.com/gogits/go-gogs-client"
 
 	"github.com/G-Node/gin-cli/util"
+	gogs "github.com/gogits/go-gogs-client"
 )
 
 // UserToken struct for username and token

--- a/web/web.go
+++ b/web/web.go
@@ -97,9 +97,25 @@ func (cl *Client) PostBasicAuth(address, username, password string, data interfa
 	return cl.web.Do(req)
 }
 
+// Delete sends a DELETE request to address.
+func (cl *Client) Delete(address string) (*http.Response, error) {
+	requrl := urlJoin(cl.Host, address)
+	req, err := http.NewRequest("DELETE", requrl, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("content-type", "application/jsonAuthorization")
+	if cl.Token != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("token %s", cl.Token))
+		util.LogWrite("Added token to DELETE")
+	}
+	util.LogWrite("Performing DELETE: %s", req.URL)
+	return cl.web.Do(req)
+}
+
 // NewClient creates a new client for a given host.
-func NewClient(address string) *Client {
-	return &Client{Host: address, web: &http.Client{}}
+func NewClient(host string) *Client {
+	return &Client{Host: host, web: &http.Client{}}
 }
 
 // LoadToken reads the username and auth token from the token file and sets the

--- a/web/web.go
+++ b/web/web.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+
 	"github.com/gogits/go-gogs-client"
 
 	"github.com/G-Node/gin-cli/util"
@@ -27,7 +28,7 @@ type UserToken struct {
 type Client struct {
 	Host string
 	UserToken
-	web  *http.Client
+	web *http.Client
 }
 
 func urlJoin(parts ...string) string {
@@ -96,16 +97,6 @@ func (cl *Client) PostForm(address string, data url.Values) (*http.Response, err
 }
 
 func (cl *Client) GLogin(username, password string) (*http.Response, error) {
-	// The struct below will be used when we switch token request to using json post data on auth
-	// See https://github.com/G-Node/gin-auth/issues/112
-	// params := gin.LoginRequest{
-	// 	Scope:        "repo-read repo-write account-read account-write",
-	// 	Username:     username,
-	// 	Password:     password,
-	// 	GrantType:    "password",
-	// 	ClientID:     clientID,
-	// 	ClientSecret: clientSecret,
-	// }
 	bd, _ := json.Marshal(&gogs.CreateAccessTokenOption{Name: "gin-cli"})
 	requrl := urlJoin(cl.Host, fmt.Sprintf("/api/v1/users/%s/tokens", username))
 	req, _ := http.NewRequest(http.MethodPost, requrl, bytes.NewReader(bd))
@@ -116,7 +107,7 @@ func (cl *Client) GLogin(username, password string) (*http.Response, error) {
 		return nil, fmt.Errorf("[Login] Failed Basic Auth request %v", err)
 	}
 	if resp.StatusCode != http.StatusCreated {
-		return nil, fmt.Errorf("[Login] Failed to login. May be credentials wrong: %s", resp.Status)
+		return nil, fmt.Errorf("[Login] Failed. Check username and password: %s", resp.Status)
 	}
 	return resp, nil
 }

--- a/web/web.go
+++ b/web/web.go
@@ -79,35 +79,22 @@ func (cl *Client) Post(address string, data interface{}) (*http.Response, error)
 	return cl.web.Do(req)
 }
 
-// PostForm sends a POST request to address with the provided data.
-// The address is appended to the client host, so it should be specified without the host prefix.
-// Unlike the Post method, the data in this case is sent as x-www-form-urlencoded.
-func (cl *Client) PostForm(address string, data url.Values) (*http.Response, error) {
-
-	requrl := urlJoin(cl.Host, address)
-	req, err := http.NewRequest("POST", requrl, strings.NewReader(data.Encode()))
+// PostBasicAuth sends a POST request to address with the provided data.
+// The username and password are used to perform Basic authentication.
+func (cl *Client) PostBasicAuth(address, username, password string, data interface{}) (*http.Response, error) {
+	datajson, err := json.Marshal(data)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	util.LogWrite("Performing POST (with form data): %s", req.URL)
-	return cl.web.Do(req)
-}
-
-func (cl *Client) GLogin(username, password string) (*http.Response, error) {
-	bd, _ := json.Marshal(&gogs.CreateAccessTokenOption{Name: "gin-cli"})
-	requrl := urlJoin(cl.Host, fmt.Sprintf("/api/v1/users/%s/tokens", username))
-	req, _ := http.NewRequest(http.MethodPost, requrl, bytes.NewReader(bd))
-	req.Header.Set("content-type", "application/json")
-	req.Header.Set("Authorization", "Basic "+gogs.BasicAuthEncode(username, password))
-	resp, err := cl.web.Do(req)
+	requrl := urlJoin(cl.Host, address)
+	req, err := http.NewRequest("POST", requrl, bytes.NewReader(datajson))
 	if err != nil {
-		return nil, fmt.Errorf("[Login] Failed Basic Auth request %v", err)
+		return nil, err
 	}
-	if resp.StatusCode != http.StatusCreated {
-		return nil, fmt.Errorf("[Login] Failed. Check username and password: %s", resp.Status)
-	}
-	return resp, nil
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", gogs.BasicAuthEncode(username, password)))
+	util.LogWrite("Performing POST: %s", req.URL)
+	return cl.web.Do(req)
 }
 
 // NewClient creates a new client for a given host.


### PR DESCRIPTION
While working towards annexed content handling, I implemented a command for deleting repositories on the server. Like the web interface, this command warns the user that the action is irreversible, that it will delete data, and asks the user to type in the full repository name (`owner/name`) to confirm the operation.

This PR also includes some cleanup and simplifications. Gogs structs are used wherever necessary to retrieve or send data to the server, importing directly from the gogs client. I also changes all HTTP status code checks to compare against the `http.StatusX` constants instead of integer literals.