### PR TITLE
Add small files to git in direct mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
   - go get golang.org/x/crypto/ssh
   - go get github.com/gogits/go-gogs-client
   - go get github.com/dustin/go-humanize
+  - go get github.com/fatih/color
   # import path symlink for forks
   - if [ ! -d ${GOPATH}/src/github.com/G-Node/gin-cli ]; then ln -vs $(pwd) ${GOPATH}/src/github.com/G-Node/gin-cli; fi
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,6 +38,7 @@ build_script:
   - go get golang.org/x/crypto/ssh
   - go get github.com/gogits/go-gogs-client
   - go get github.com/dustin/go-humanize
+  - go get github.com/fatih/color
   - go vet ./...
   - gofmt -s -l .
   - golint github.com/G-Node/gin-cli...

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -486,13 +486,13 @@ func DescribeIndexShort() (string, error) {
 	}
 	var changesBuffer bytes.Buffer
 	if statusmap["A"] > 0 {
-		_, _ = changesBuffer.WriteString(fmt.Sprintf("New files: %d", statusmap["A"]))
+		_, _ = changesBuffer.WriteString(fmt.Sprintf("New files: %d\n", statusmap["A"]))
 	}
 	if statusmap["M"] > 0 {
-		_, _ = changesBuffer.WriteString(fmt.Sprintf("Modified files: %d", statusmap["M"]))
+		_, _ = changesBuffer.WriteString(fmt.Sprintf("Modified files: %d\n", statusmap["M"]))
 	}
 	if statusmap["D"] > 0 {
-		_, _ = changesBuffer.WriteString(fmt.Sprintf("Deleted files: %d", statusmap["D"]))
+		_, _ = changesBuffer.WriteString(fmt.Sprintf("Deleted files: %d\n", statusmap["D"]))
 	}
 	return changesBuffer.String(), nil
 }

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -232,8 +232,7 @@ func (gincl *Client) CloneRepo(repoPath string) (string, error) {
 		if ierr != nil {
 			name = gincl.Username
 		}
-		// NOTE: Add user email too?
-		ierr = SetGitUser(name, "")
+		ierr = SetGitUser(name, info.Email)
 		if ierr != nil {
 			util.LogWrite("Failed to set local git user configuration")
 		}

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -10,10 +10,13 @@ import (
 
 	"github.com/G-Node/gin-cli/util"
 	"github.com/G-Node/gin-cli/web"
+	"github.com/fatih/color"
 	"github.com/gogits/go-gogs-client"
 	// its a bit unfortunate that we have that import now
 	// but its only temporary...
 )
+
+var green = color.New(color.FgGreen)
 
 // MakeSessionKey creates a private+public key pair.
 // The private key is saved in the user's configuration directory, to be used for git commands.
@@ -203,7 +206,9 @@ func (gincl *Client) CloneRepo(repoPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	fmt.Printf("done.\n")
+	green.Println("OK")
+
+	fmt.Printf("Initialising local storage... ")
 
 	err = gincl.LoadToken()
 	if err != nil {
@@ -253,6 +258,7 @@ func (gincl *Client) CloneRepo(repoPath string) (string, error) {
 			return "", err
 		}
 	}
+	green.Println("OK")
 
 	return repoName, nil
 }

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -388,6 +388,15 @@ func lfDirect(paths ...string) (map[string]FileStatus, error) {
 		}
 	}
 
+	// Unmodified files that are checked into git (not annex) do not show up
+	// Need to unset 'bare' and run git ls-files and add only files that haven't been added yet
+	filelist, _ := GitLsFiles(paths)
+	for _, fname := range filelist {
+		if _, ok := statuses[fname]; !ok {
+			statuses[fname] = Synced
+		}
+	}
+
 	return statuses, nil
 }
 

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -403,37 +403,21 @@ func lfDirect(paths ...string) (map[string]FileStatus, error) {
 func lfIndirect(paths ...string) (map[string]FileStatus, error) {
 	statuses := make(map[string]FileStatus)
 
-	gitlsfiles := func(option string) []string {
-		gitargs := []string{"ls-files", option}
-		gitargs = append(gitargs, paths...)
-		stdout, stderr, err := RunGitCommand(gitargs...)
-		if err != nil {
-			util.LogWrite("Error during git ls-files %s", option)
-			util.LogWrite("[stdout]\r\n%s", stdout.String())
-			util.LogWrite("[stderr]\r\n%s", stderr.String())
-			// ignoring error and continuing
-		}
-		var fnames []string
-		for _, fname := range strings.Split(stdout.String(), "\n") {
-			// filter out emtpty lines
-			if len(fname) > 0 {
-				fnames = append(fnames, fname)
-			}
-		}
-		return fnames
-	}
-
 	// Collect checked in files
-	cachedfiles := gitlsfiles("--cached")
+	lsfilesargs := append([]string{"--cached"}, paths...)
+	cachedfiles, _ := GitLsFiles(lsfilesargs)
 
 	// Collect modified files
-	modifiedfiles := gitlsfiles("--modified")
+	lsfilesargs = append([]string{"--modified"}, paths...)
+	modifiedfiles, _ := GitLsFiles(lsfilesargs)
 
 	// Collect untracked files
-	untrackedfiles := gitlsfiles("--others")
+	lsfilesargs = append([]string{"--others"}, paths...)
+	untrackedfiles, _ := GitLsFiles(lsfilesargs)
 
 	// Collect deleted files
-	deletedfiles := gitlsfiles("--deleted")
+	lsfilesargs = append([]string{"--deleted"}, paths...)
+	deletedfiles, _ := GitLsFiles(lsfilesargs)
 
 	// Run whereis on cached files
 	wiResults, err := AnnexWhereis(cachedfiles)

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	ginclient "github.com/G-Node/gin-cli/gin-client"
 	"github.com/G-Node/gin-cli/util"
 	"github.com/docopt/docopt-go"
+	"github.com/fatih/color"
 	"github.com/howeyc/gopass"
 )
 
@@ -21,6 +22,8 @@ var version string
 var build string
 var commit string
 var verstr string
+
+var green = color.New(color.FgGreen)
 
 // login requests credentials, performs login with auth server, and stores the token.
 func login(args []string) {
@@ -102,11 +105,11 @@ func createRepo(args []string) {
 	gincl.GitHost = util.Config.GitHost
 	gincl.GitUser = util.Config.GitUser
 	repoPath := fmt.Sprintf("%s/%s", gincl.Username, repoName)
-	fmt.Printf("Creating repository '%s'...", repoPath)
+	fmt.Printf("Creating repository '%s'... ", repoPath)
 	err = gincl.CreateRepo(repoName, repoDesc)
 	// Parse error message and make error nicer
 	util.CheckError(err)
-	fmt.Println(" done.")
+	green.Println("OK")
 
 	// Clone repository after creation
 	getRepo([]string{repoPath})
@@ -258,11 +261,11 @@ func upload(args []string) {
 		fmt.Printf("To upload all files under the current directory, use:\n\n\tgin upload .\n\n")
 	}
 
-	fmt.Print("Uploading...")
+	fmt.Print("Uploading... ")
 
 	err = gincl.Upload(args)
 	util.CheckError(err)
-	fmt.Println("done!")
+	green.Println("OK")
 }
 
 func download(args []string) {
@@ -285,7 +288,7 @@ func download(args []string) {
 	gincl.GitUser = util.Config.GitUser
 	fmt.Print("Downloading...")
 	err = gincl.DownloadRepo(content)
-	fmt.Println("done!")
+	green.Println("OK")
 	util.CheckError(err)
 }
 

--- a/util/die.go
+++ b/util/die.go
@@ -4,10 +4,15 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/fatih/color"
 )
+
+var red = color.New(color.FgRed)
 
 //Die prints a message to stderr and exits the program.
 func Die(msg string) {
+	red.Fprintln(os.Stderr, "ERROR")
 	fmt.Fprintln(os.Stderr, msg)
 	os.Exit(1)
 }

--- a/util/files.go
+++ b/util/files.go
@@ -48,3 +48,38 @@ func ExpandGlobs(paths []string) (globexppaths []string, err error) {
 	}
 	return
 }
+
+func stringInSlice(element string, strlist []string) bool {
+	for _, str := range strlist {
+		if element == str {
+			return true
+		}
+	}
+	return false
+}
+
+// FilterPaths takes path descriptions (full paths, relative paths, files, or directories) and returns a slice of filepaths (as strings) excluding the files listed in excludes.
+func FilterPaths(paths, excludes []string) (filtered []string) {
+
+	// walker adds files to filtered if they don't match excludes
+	walker := func(path string, info os.FileInfo, err error) error {
+		if filepath.Base(path) == ".git" {
+			return filepath.SkipDir
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if !stringInSlice(path, excludes) {
+			filtered = append(filtered, path)
+		}
+		return nil
+	}
+
+	for _, p := range paths {
+		err := filepath.Walk(p, walker)
+		if err != nil {
+			LogWrite("Error occured during path filtering: %s", err.Error())
+		}
+	}
+	return
+}


### PR DESCRIPTION
## git add in direct mode

Followup to PR #100 for direct mode repositories.

This PR handles the case where a repository is in direct mode due to (what git annex calls) a *crippled filesystem* (which happens on Windows with NTFS). When in this mode the repository is also marked as `bare`. To add files to git, the client temporarily switches the bare flag off, adds the file to git, and reverts the flag switch.

It does the same temporary toggling for running `git ls-files` in direct mode when performing the `gin ls` function. This is the only way to list files checked into git since git-annex isn't aware of these files.

Closes #101.

## Other changes and fixes
- Added some small colourised output. Successful operations (download, upload, init) print a bright green "OK" and failed operations print a red "ERROR".
- Fixed an issue with commit messages describing changes on a single line.
- `gin ls` now also shows deleted files (if they were tracked by git and git-annex).