### PR TITLE
Check annex version and default to private repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ install:
   - go get github.com/gogits/go-gogs-client
   - go get github.com/dustin/go-humanize
   - go get github.com/fatih/color
+  - go get github.com/hashicorp/go-version
   # import path symlink for forks
   - if [ ! -d ${GOPATH}/src/github.com/G-Node/gin-cli ]; then ln -vs $(pwd) ${GOPATH}/src/github.com/G-Node/gin-cli; fi
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,6 +39,7 @@ build_script:
   - go get github.com/gogits/go-gogs-client
   - go get github.com/dustin/go-humanize
   - go get github.com/fatih/color
+  - go get github.com/hashicorp/go-version
   - go vet ./...
   - gofmt -s -l .
   - golint github.com/G-Node/gin-cli...

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -784,3 +784,18 @@ func selectGitOrAnnex(paths []string) (gitpaths []string, annexpaths []string) {
 
 	return
 }
+
+// GetAnnexVersion returns the version string of the system's git-annex.
+func GetAnnexVersion() (string, error) {
+	stdout, stderr, err := RunAnnexCommand("version", "--raw")
+	if err != nil {
+		util.LogWrite("Error while checking git-annex version")
+		util.LogWrite("[stdout]\r\n%s", stdout.String())
+		util.LogWrite("[stderr]\r\n%s", stderr.String())
+		if strings.Contains(stderr.String(), "command not found") {
+			return "", fmt.Errorf("Error: git-annex command not found")
+		}
+		return "", err
+	}
+	return stdout.String(), nil
+}

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -96,7 +96,7 @@ func (gincl *Client) CreateRepo(name, description string) error {
 		return fmt.Errorf("[Create repository] This action requires login")
 	}
 
-	newrepo := gogs.Repository{Name: name, Description: description}
+	newrepo := gogs.Repository{Name: name, Description: description, Private: true}
 	util.LogWrite("Name: %s :: Description: %s", name, description)
 	res, err := gincl.Post("/api/v1/user/repos", newrepo)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -485,13 +485,14 @@ func help(args []string) {
 }
 
 func checkAnnexVersion(verstring string) {
+	errmsg := fmt.Sprintf("The GIN Client requires git-annex %s or newer", minAnnexVersion)
 	systemver, err := version.NewVersion(verstring)
 	if err != nil {
-		util.Die("Error while checking git-annex version. Is git-annex installed?")
+		util.Die(errmsg)
 	}
 	minver, _ := version.NewVersion(minAnnexVersion)
 	if systemver.LessThan(minver) {
-		util.Die(fmt.Sprintf("The GIN Client requires git-annex %s or newer", minver))
+		util.Die(errmsg)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -15,13 +15,15 @@ import (
 	"github.com/G-Node/gin-cli/util"
 	"github.com/docopt/docopt-go"
 	"github.com/fatih/color"
+	version "github.com/hashicorp/go-version"
 	"github.com/howeyc/gopass"
 )
 
-var version string
+var gincliversion string
 var build string
 var commit string
 var verstr string
+var minAnnexVersion = "6.20160126" // Introduction of git-annex add --json
 
 var green = color.New(color.FgGreen)
 
@@ -482,11 +484,22 @@ func help(args []string) {
 	fmt.Println(helptext)
 }
 
+func checkAnnexVersion(verstring string) {
+	systemver, err := version.NewVersion(verstring)
+	if err != nil {
+		util.Die("Error while checking git-annex version. Is git-annex installed?")
+	}
+	minver, _ := version.NewVersion(minAnnexVersion)
+	if systemver.LessThan(minver) {
+		util.Die(fmt.Sprintf("The GIN Client requires git-annex %s or newer", minver))
+	}
+}
+
 func init() {
-	if version == "" {
+	if gincliversion == "" {
 		verstr = "GIN command line client [dev build]"
 	} else {
-		verstr = fmt.Sprintf("GIN command line client %s Build %s (%s)", version, build, commit)
+		verstr = fmt.Sprintf("GIN command line client %s Build %s (%s)", gincliversion, build, commit)
 	}
 }
 
@@ -503,6 +516,10 @@ func main() {
 
 	err = util.LoadConfig()
 	util.CheckError(err)
+
+	annexver, err := ginclient.GetAnnexVersion()
+	util.CheckError(err)
+	checkAnnexVersion(annexver)
 
 	switch command {
 	case "login":

--- a/util/die.go
+++ b/util/die.go
@@ -12,7 +12,7 @@ var red = color.New(color.FgRed)
 
 //Die prints a message to stderr and exits the program.
 func Die(msg string) {
-	red.Fprintln(os.Stderr, "ERROR")
+	_, _ = red.Fprint(os.Stderr, "ERROR ")
 	fmt.Fprintln(os.Stderr, msg)
 	os.Exit(1)
 }

--- a/web/web.go
+++ b/web/web.go
@@ -121,8 +121,9 @@ func NewClient(host string) *Client {
 // LoadToken reads the username and auth token from the token file and sets the
 // values in the struct.
 func (ut *UserToken) LoadToken() error {
-	// TODO: Don't reload if already set
-	util.LogWrite("Loading token")
+	if ut.Username != "" && ut.Token != "" {
+		return nil
+	}
 	path, err := util.ConfigPath(false)
 	if err != nil {
 		return fmt.Errorf("Could not read token: Error accessing config directory.")


### PR DESCRIPTION
## Check git annex version
With this PR, the git-annex version is checked whenever a gin command is called. The client will stop execution with an error if the system git-annex version is < minversion (currently `6.20160126`).

Closes #102.

## Create repositories as private by default
Since we don't give the user a flag or way to change this from the command line, the client now defaults to creating gin repositories as private instead of public.

Closes #86.