### PR TITLE
Annex status bugfix and git command proxying

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BUILDLOC=build
 INSTLOC=$(GOPATH)/bin/$(GIN)
 
 # Build flags
-VERNUM=$(shell grep -o "[0-9\.]\+" version)
+VERNUM=$(shell grep -o -E '[0-9.]+(dev){0,1}' version)
 ncommits=$(shell git rev-list --count HEAD)
 BUILDNUM=$(shell printf '%06d' $(ncommits))
 COMMITHASH=$(shell git rev-parse HEAD)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 [![Build Status](https://travis-ci.org/G-Node/gin-cli.svg?branch=master)](https://travis-ci.org/G-Node/gin-cli)
 [![GoDoc](https://godoc.org/github.com/G-Node/gin-cli?status.svg)](http://godoc.org/github.com/G-Node/gin-cli)
 
+---
+
+[Tests](https://github.com/G-Node/gin-cli-test)
+
+[![Build Status](https://travis-ci.org/G-Node/gin-cli-test.svg?branch=master)](https://travis-ci.org/G-Node/gin-cli-test)
+
+---
+
 **G**-Node **In**frastructure command line client
 
 This package is a command line client for interfacing with repositories hosted on [GIN](https://gin.g-node.org).

--- a/dorelease.py
+++ b/dorelease.py
@@ -114,7 +114,8 @@ def build():
     with open(verfilename) as verfile:
         verinfo = verfile.read()
 
-    VERSION["version"] = re.search(r"version=([v0-9\.]+)", verinfo).group(1)
+    VERSION["version"] = re.search(r"version=([0-9\.]+(dev){0,1})",
+                                   verinfo).group(1)
     cmd = ["git", "rev-list", "--count", "HEAD"]
     VERSION["build"] = int(check_output(cmd).strip().decode())
     cmd = ["git", "rev-parse", "HEAD"]

--- a/dorelease.py
+++ b/dorelease.py
@@ -61,8 +61,7 @@ def download(url, fname=None):
     try:
         req = requests.get(url, stream=True)
     except ConnError:
-        print("Error while trying to download {}".format(url),
-              file=sys.stderr)
+        print("Error while trying to download {}".format(url), file=sys.stderr)
         print("Skipping.", file=sys.stderr)
         return
     size = int(req.headers.get("content-length"))
@@ -79,7 +78,7 @@ def download(url, fname=None):
         for chunk in req.iter_content(chunk_size=256):
             dlfile.write(chunk)
             prog += len(chunk)
-            print("\r{:2.1f}%".format(prog/size*100), end="", flush=True)
+            print("\r{:2.1f}%".format(prog / size * 100), end="", flush=True)
         print("\nDone!")
     print()
     return fname
@@ -127,9 +126,10 @@ def build():
                "-X main.build={build:06d} "
                "-X main.commit={commit}").format(**VERSION)
     output = os.path.join(DESTDIR, "{{.OS}}-{{.Arch}}", "gin")
-    cmd = ["gox", "-output={}".format(output),
-           "-osarch={}".format(" ".join(platforms)),
-           "-ldflags={}".format(ldflags)]
+    cmd = [
+        "gox", "-output={}".format(output), "-osarch={}".format(
+            " ".join(platforms)), "-ldflags={}".format(ldflags)
+    ]
     print("Running {}".format(" ".join(cmd)))
     if call(cmd) > 0:
         die("Build failed")
@@ -214,16 +214,15 @@ def debianize(binfiles, annexsa_archive):
     """
     debs = []
     with TemporaryDirectory(suffix="gin-linux") as tmpdir:
-        cmd = ["docker", "build",
-               "-t", "gin-deb", "debdock/."]
+        cmd = ["docker", "build", "-t", "gin-deb", "debdock/."]
         print("Preparing docker image for debian build")
         call(cmd)
 
         contdir = "/debbuild/"
-        cmd = ["docker", "run", "-i", "-v",
-               "{}:{}".format(tmpdir, contdir),
-               "--name", "gin-deb-build",
-               "-d", "gin-deb", "bash"]
+        cmd = [
+            "docker", "run", "-i", "-v", "{}:{}".format(tmpdir, contdir),
+            "--name", "gin-deb-build", "-d", "gin-deb", "bash"
+        ]
         print("Starting debian docker container")
         if call(cmd) > 0:
             print("Container start failed", file=sys.stderr)
@@ -281,8 +280,11 @@ def debianize(binfiles, annexsa_archive):
             shutil.copy(os.path.join(debmdsrc, "changelog.Debian"), docdir)
 
             # gzip changelog and changelog.Debian
-            cmd = ["gzip", "--best", os.path.join(docdir, "changelog"),
-                   os.path.join(docdir, "changelog.Debian")]
+            cmd = [
+                "gzip", "--best",
+                os.path.join(docdir, "changelog"),
+                os.path.join(docdir, "changelog.Debian")
+            ]
             if call(cmd) > 0:
                 print(f"Failed to gzip files in {docdir}", file=sys.stderr)
 
@@ -291,8 +293,7 @@ def debianize(binfiles, annexsa_archive):
             print("Running {}".format(" ".join(cmd)))
             if call(cmd) > 0:
                 print("Failed to extract git annex standalone [{}]".format(
-                    annexsa_archive, file=sys.stderr
-                ))
+                    annexsa_archive, file=sys.stderr))
                 continue
 
             dockerexec = ["docker", "exec", "-t", "gin-deb-build"]
@@ -301,17 +302,17 @@ def debianize(binfiles, annexsa_archive):
             print("Fixing permissions for build dir")
             call(cmd)
 
-            cmd = dockerexec + ["fakeroot",
-                                "dpkg-deb", "--build",
-                                os.path.join(contdir, pkgname)]
+            cmd = dockerexec + [
+                "fakeroot", "dpkg-deb", "--build",
+                os.path.join(contdir, pkgname)
+            ]
             print("Building deb package")
             if call(cmd) > 0:
                 print("Deb build failed", file=sys.stderr)
                 continue
 
             debfilename = f"{pkgname}.deb"
-            cmd = dockerexec + ["lintian",
-                                os.path.join(contdir, debfilename)]
+            cmd = dockerexec + ["lintian", os.path.join(contdir, debfilename)]
             print("Running lintian on new deb file")
             if call(cmd, stdout=open(os.devnull, "wb")) > 0:
                 print("Deb file check exited with errors")
@@ -383,15 +384,17 @@ def winbundle(binfiles, git_pkg, annex_pkg):
             cmd = ["7z", "x", "-o{}".format(gitdir), git_pkg]
             print("Running {}".format(" ".join(cmd)))
             if call(cmd, stdout=DEVNULL) > 0:
-                print("Failed to extract git archive [{}]".format(git_pkg),
-                      file=sys.stderr)
+                print(
+                    "Failed to extract git archive [{}]".format(git_pkg),
+                    file=sys.stderr)
                 continue
 
             cmd = ["7z", "x", "-o{}".format(gitdir), annex_pkg]
             print("Running {}".format(" ".join(cmd)))
             if call(cmd, stdout=DEVNULL) > 0:
-                print("Failed to extract git archive [{}]".format(annex_pkg),
-                      file=sys.stderr)
+                print(
+                    "Failed to extract git archive [{}]".format(annex_pkg),
+                    file=sys.stderr)
                 continue
             dirname, _ = os.path.split(binf)
             _, osarch = os.path.split(dirname)
@@ -408,8 +411,9 @@ def winbundle(binfiles, git_pkg, annex_pkg):
             cmd = ["zip", "-r", arc_abs, "."]
             print("Running {} (from {})".format(" ".join(cmd), pkgroot))
             if call(cmd, stdout=DEVNULL) > 0:
-                print("Failed to create archive [{}]".format(arc),
-                      file=sys.stderr)
+                print(
+                    "Failed to create archive [{}]".format(arc),
+                    file=sys.stderr)
                 os.chdir(oldwd)
                 continue
             os.chdir(oldwd)

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -472,13 +472,15 @@ func lfIndirect(paths ...string) (map[string]FileStatus, error) {
 	}
 
 	// Check if modified files are actually annex unlocked instead
-	mdfilestatus, err := AnnexStatus(modifiedfiles...)
-	if err != nil {
-		util.LogWrite("Error during annex status while searching for unlocked files")
-	}
-	for _, stat := range mdfilestatus {
-		if stat.Status == "T" {
-			statuses[stat.File] = Unlocked
+	if len(modifiedfiles) > 0 {
+		mdfilestatus, err := AnnexStatus(modifiedfiles...)
+		if err != nil {
+			util.LogWrite("Error during annex status while searching for unlocked files")
+		}
+		for _, stat := range mdfilestatus {
+			if stat.Status == "T" {
+				statuses[stat.File] = Unlocked
+			}
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -496,6 +497,32 @@ func checkAnnexVersion(verstring string) {
 	}
 }
 
+func gitrun(args []string) {
+	gincl := ginclient.NewClient(util.Config.GinHost)
+	err := gincl.LoadToken()
+	util.CheckError(err)
+
+	stdout, stderr, err := ginclient.RunGitCommand(args...)
+	fmt.Print(stdout.String())
+	fmt.Fprint(os.Stderr, stderr.String())
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func annexrun(args []string) {
+	gincl := ginclient.NewClient(util.Config.GinHost)
+	err := gincl.LoadToken()
+	util.CheckError(err)
+
+	stdout, stderr, err := ginclient.RunAnnexCommand(args...)
+	fmt.Print(stdout.String())
+	fmt.Fprint(os.Stderr, stderr.String())
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
 func init() {
 	if gincliversion == "" {
 		verstr = "GIN command line client [dev build]"
@@ -557,6 +584,10 @@ func main() {
 		logout(cmdArgs)
 	case "help":
 		help(cmdArgs)
+	case "git":
+		gitrun(cmdArgs)
+	case "annex":
+		annexrun(cmdArgs)
 	default:
 		util.Die(usage)
 	}

--- a/version
+++ b/version
@@ -1,1 +1,1 @@
-version=0.9
+version=0.10dev


### PR DESCRIPTION
## Version bump
`0.10dev`
From now on, the first pull request following a release should bump the version number and add the `dev` suffix.

## gin ls
Fix for bug where `gin ls` would run `git annex status` on the whole repository if there were no files that appeared as modified.
Fixes #113 

## git and annex command proxying
New commands: `gin git` and `gin annex`
Run the git or annex shell commands using the configured gin binaries and auth options.
Closes #95 