### PR TITLE
Do not use git status to determine if CWD is a repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GIN=gin
 BUILDLOC=build
 
 # Install location
-INSTLOC=$(GOPATH)/bin/$(GIN)
+INSTLOC=$(GOPATH)/bin/
 
 # Build flags
 VERNUM=$(shell grep -o -E '[0-9.]+(dev){0,1}' version)
@@ -18,7 +18,7 @@ gin:
 	go build $(LDFLAGS) -o $(BUILDLOC)/$(GIN)
 
 install: gin
-	install $(BUILDLOC)/$(GIN) $(INSTLOC)
+	install $(BUILDLOC)/$(GIN) $(INSTLOC)/$(GIN)
 
 allplatforms: linux windows macos
 
@@ -35,4 +35,4 @@ clean:
 	rm -r $(BUILDLOC)
 
 uninstall:
-	rm $(INSTLOC)
+	rm $(INSTLOC)/$(GIN)

--- a/gin-client/gin.go
+++ b/gin-client/gin.go
@@ -207,7 +207,7 @@ func (gincl *Client) Logout() {
 	hostname, err := os.Hostname()
 	if err != nil {
 		util.LogWrite("Could not retrieve hostname")
-		hostname = "(unknown)"
+		hostname = defaultHostname
 	}
 
 	currentkeyname := fmt.Sprintf("%s@%s", gincl.Username, hostname)

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -69,9 +69,9 @@ func CommitIfNew() (bool, error) {
 // Setting the Workingdir package global affects the working directory in which the command is executed.
 func IsRepo() bool {
 	util.LogWrite("IsRepo '%s'?", Workingdir)
-	_, _, err := RunGitCommand("rev-parse")
+	_, err := util.FindRepoRoot(Workingdir)
 	yes := err == nil
-	util.LogWrite("IsRepo: %v", yes)
+	util.LogWrite("%v", yes)
 	return yes
 }
 

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -69,13 +69,8 @@ func CommitIfNew() (bool, error) {
 // Setting the Workingdir package global affects the working directory in which the command is executed.
 func IsRepo() bool {
 	util.LogWrite("IsRepo '%s'?", Workingdir)
-	_, _, err := RunGitCommand("status")
+	_, _, err := RunGitCommand("rev-parse")
 	yes := err == nil
-	if !yes {
-		// Maybe it's an annex repo in direct mode?
-		_, _, err = RunAnnexCommand("status")
-		yes = err == nil
-	}
 	util.LogWrite("IsRepo: %v", yes)
 	return yes
 }

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -51,7 +51,7 @@ func CommitIfNew() (bool, error) {
 	// Create an empty initial commit and run annex sync to synchronise everything
 	hostname, err := os.Hostname()
 	if err != nil {
-		hostname = "(unknown)"
+		hostname = defaultHostname
 	}
 	commitargs := []string{"commit", "--allow-empty", "-m", fmt.Sprintf("Initial commit: Repository initialised on %s", hostname)}
 	stdout, stderr, err := RunGitCommand(commitargs...)

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -17,6 +17,7 @@ import (
 )
 
 var green = color.New(color.FgGreen)
+var defaultHostname = "(unknown)"
 
 // MakeSessionKey creates a private+public key pair.
 // The private key is saved in the user's configuration directory, to be used for git commands.
@@ -30,7 +31,7 @@ func (gincl *Client) MakeSessionKey() error {
 	hostname, err := os.Hostname()
 	if err != nil {
 		util.LogWrite("Could not retrieve hostname")
-		hostname = "(unknown)"
+		hostname = defaultHostname
 	}
 	description := fmt.Sprintf("%s@%s", gincl.Username, hostname)
 	pubkey := fmt.Sprintf("%s %s", strings.TrimSpace(keyPair.Public), description)
@@ -156,7 +157,7 @@ func (gincl *Client) Upload(paths []string) error {
 	hostname, err := os.Hostname()
 	if err != nil {
 		util.LogWrite("Could not retrieve hostname")
-		hostname = "(unknown)"
+		hostname = defaultHostname
 	}
 	if changes == "" {
 		changes = "No changes recorded"
@@ -219,7 +220,7 @@ func (gincl *Client) CloneRepo(repoPath string) (string, error) {
 	Workingdir = repoName
 	hostname, err := os.Hostname()
 	if err != nil {
-		hostname = "(unknown)"
+		hostname = defaultHostname
 	}
 	description := fmt.Sprintf("%s@%s", gincl.Username, hostname)
 

--- a/util/config.go
+++ b/util/config.go
@@ -82,9 +82,6 @@ func LoadConfig() error {
 	Config.Annex.Exclude = viper.GetStringSlice("annex.exclude")
 	Config.Annex.MinSize = viper.GetString("annex.minsize")
 
-	// ginAddress := viper.GetString("gin.address")
-	// ginPort := viper.GetInt("gin.port")
-
 	var oldConfigHost string
 	if viper.IsSet("auth.address") || viper.IsSet("auth.port") {
 		fmt.Fprintln(os.Stderr, "Auth server address configuration is no longer used. Use gin.address and gin.port instead.")

--- a/util/config.go
+++ b/util/config.go
@@ -49,7 +49,15 @@ func LoadConfig() error {
 	viper.SetDefault("annex.minsize", "10M")
 
 	viper.SetConfigName("config")
-	// prioritise config files in the directory of the executable
+
+	// Highest priority config file is in the repository root
+	reporoot, err := FindRepoRoot(".")
+	if err == nil {
+		viper.AddConfigPath(reporoot)
+		LogWrite("Config path added %s", reporoot)
+	}
+
+	// Second prio config files in the directory of the executable
 	// this is useful for portable packaging
 	execloc, err := os.Executable()
 	execpath, _ := path.Split(execloc)
@@ -58,9 +66,9 @@ func LoadConfig() error {
 		LogWrite("Config path added %s", execpath)
 	}
 
-	configpath, _ := ConfigPath(false)
-	viper.AddConfigPath(configpath)
-	LogWrite("Config path added %s", configpath)
+	xdgconfpath, _ := ConfigPath(false)
+	viper.AddConfigPath(xdgconfpath)
+	LogWrite("Config path added %s", xdgconfpath)
 
 	err = viper.ReadInConfig()
 	if err != nil {
@@ -68,7 +76,6 @@ func LoadConfig() error {
 			LogError(err)
 		}
 	}
-	LogError(err)
 	fileused := viper.ConfigFileUsed()
 	if fileused != "" {
 		LogWrite("Loading config file %s", viper.ConfigFileUsed())

--- a/util/config.go
+++ b/util/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/spf13/viper"
 )
@@ -62,6 +63,11 @@ func LoadConfig() error {
 	LogWrite("Config path added %s", configpath)
 
 	err = viper.ReadInConfig()
+	if err != nil {
+		if !strings.Contains(err.Error(), "Not Found") {
+			LogError(err)
+		}
+	}
 	LogError(err)
 	fileused := viper.ConfigFileUsed()
 	if fileused != "" {

--- a/util/config.go
+++ b/util/config.go
@@ -36,10 +36,8 @@ func LoadConfig() error {
 	viper.SetDefault("bin.ssh", "ssh")
 
 	// Hosts
-	// Disabling default gin.address for now and handling it manually in order to present deprecation message
-	// viper.SetDefault("gin.address", "https://web.gin.g-node.org")
+	viper.SetDefault("gin.address", "https://web.gin.g-node.org")
 	viper.SetDefault("gin.port", "443")
-	defaultHost := "https://web.gin.g-node.org"
 
 	viper.SetDefault("git.address", "gin.g-node.org")
 	viper.SetDefault("git.port", "22")
@@ -89,29 +87,9 @@ func LoadConfig() error {
 	Config.Annex.Exclude = viper.GetStringSlice("annex.exclude")
 	Config.Annex.MinSize = viper.GetString("annex.minsize")
 
-	var oldConfigHost string
-	if viper.IsSet("auth.address") || viper.IsSet("auth.port") {
-		fmt.Fprintln(os.Stderr, "Auth server address configuration is no longer used. Use gin.address and gin.port instead.")
-		oldConfigHost = fmt.Sprintf("%s:%d", viper.GetString("auth.address"), viper.GetInt("auth.port"))
-	}
-
-	if viper.IsSet("repo.address") || viper.IsSet("repo.port") {
-		fmt.Fprintln(os.Stderr, "Repo server address configuration is no longer used. Use gin.address and gin.port instead.")
-		oldConfigHost = fmt.Sprintf("%s:%d", viper.GetString("repo.address"), viper.GetInt("repo.port"))
-	}
-
-	// If the gin host is set use it. If it's not but an old config value is set, use that.
-	// If neither is set, use the bulit-in default.
-	if viper.IsSet("gin.address") {
-		ginAddress := viper.GetString("gin.address")
-		ginPort := viper.GetInt("gin.port")
-		Config.GinHost = fmt.Sprintf("%s:%d", ginAddress, ginPort)
-	} else if oldConfigHost != "" {
-		Config.GinHost = oldConfigHost
-		fmt.Fprintf(os.Stderr, "Using deprecated configuration value: %s. This will change in a future release.\n", oldConfigHost)
-	} else {
-		Config.GinHost = fmt.Sprintf("%s:%d", defaultHost, viper.GetInt("gin.port"))
-	}
+	ginAddress := viper.GetString("gin.address")
+	ginPort := viper.GetInt("gin.port")
+	Config.GinHost = fmt.Sprintf("%s:%d", ginAddress, ginPort)
 
 	gitAddress := viper.GetString("git.address")
 	gitPort := viper.GetInt("git.port")

--- a/util/files.go
+++ b/util/files.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -82,4 +83,22 @@ func FilterPaths(paths, excludes []string) (filtered []string) {
 		}
 	}
 	return
+}
+
+// FindRepoRoot starts from a given directory and searches upwards through a directory structure looking for the root of a repository, indicated by the existence of a .git directory.
+// A path to the repository root is returned, or an error if the root of the filesystem is reached first.
+// The returned path is absolute.
+func FindRepoRoot(path string) (string, error) {
+	path, _ = filepath.Abs(path)
+	gitdir := filepath.Join(path, ".git")
+	if PathExists(gitdir) {
+		return path, nil
+	}
+	updir := filepath.Dir(path)
+	if updir == path {
+		// root reached
+		return "", fmt.Errorf("Not a repository")
+	}
+
+	return FindRepoRoot(updir)
 }

--- a/version
+++ b/version
@@ -1,1 +1,1 @@
-version=0.11dev
+version=0.11

--- a/version
+++ b/version
@@ -1,1 +1,1 @@
-version=0.10
+version=0.11dev


### PR DESCRIPTION
## Use git rev-parse for checking if CWD is git repo

Previously we used git status which didn't work for bare repositories (annex direct mode). When that failed, we would try git annex status. This caused unnecessary checks since the annex state of all files in the repository was being determined by the command. This makes any command very slow in large repositories in direct mode.

Using git rev-parse works in both direct and indirect mode and is irrespective of repository size, since it simply searches for a .git directory up the directory tree.

Closes #113 