### PR TITLE
File transfer progress output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GIN=gin
 BUILDLOC=build
 
 # Install location
-INSTLOC=$(GOPATH)/bin/
+INSTLOC=$(GOPATH)/bin
 
 # Build flags
 VERNUM=$(shell grep -o -E '[0-9.]+(dev){0,1}' version)

--- a/dorelease.py
+++ b/dorelease.py
@@ -221,6 +221,8 @@ def debianize(binfiles, annexsa_archive):
         cmd = ["docker", "container", "rm", "gin-deb-build"]
         call(cmd)
 
+    docker_cleanup()
+
     # The default temporary root on macOS is /var/folders
     # Docker currently has issues mounting directories under /var
     # Forcing temporary directory to be rooted at /tmp instead

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -100,7 +100,8 @@ func splitRepoParts(repoPath string) (repoOwner, repoName string) {
 func (gincl *Client) Clone(repoPath string) error {
 	remotePath := fmt.Sprintf("ssh://%s@%s/%s", gincl.GitUser, gincl.GitHost, repoPath)
 	cmd, err := RunGitCommand("clone", remotePath)
-	if err != nil {
+	// TODO: Parse output and print progress
+	if err != nil || cmd.Wait() != nil {
 		util.LogWrite("Error during clone command")
 		cmd.LogStdOutErr()
 		repoOwner, repoName := splitRepoParts(repoPath)

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -832,8 +832,6 @@ func AnnexLock(filepaths []string, lockchan chan<- RepoFileStatus) {
 
 	if len(unlockedfiles) == 0 {
 		util.LogWrite("No files to lock")
-		status.State = "Nothing to do"
-		lockchan <- status
 		return
 	}
 	cmdargs := []string{"add", "--json"}

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -202,7 +202,7 @@ func AnnexSync(content bool) error {
 }
 
 type PushStatus struct {
-	Filename string
+	FileName string
 	Progress string
 	Rate     string
 	Err      error
@@ -252,7 +252,7 @@ func AnnexPush(paths []string, commitMsg string, outchan chan<- PushStatus) erro
 		}
 		if strings.HasPrefix(line, "copy") {
 			words := strings.Split(line, " ")
-			status.Filename = strings.TrimSpace(words[1])
+			status.FileName = strings.TrimSpace(words[1])
 			// new file - reset Progress and Rate
 			status.Progress = ""
 			status.Rate = ""

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/G-Node/gin-cli/util"
@@ -239,10 +238,6 @@ func AnnexPush(paths []string, commitMsg string, outchan chan<- string) error {
 	outchan <- "Uploading\n"
 	var ulfilename string
 
-	cleanmultispace := func(str string) string {
-		re := regexp.MustCompile(`\s+`)
-		return re.ReplaceAllString(strings.TrimSpace(str), " ")
-	}
 	for {
 		line, rerr := cmd.OutPipe.ReadLine()
 		if rerr != nil {
@@ -253,7 +248,7 @@ func AnnexPush(paths []string, commitMsg string, outchan chan<- string) error {
 			ulfilename = strings.TrimSpace(words[1])
 			outchan <- fmt.Sprintf("Uploading %s\n", ulfilename)
 		} else if strings.Contains(line, "%") {
-			line = cleanmultispace(line)
+			line = util.CleanSpaces(line)
 			words := strings.Split(line, " ")
 			progress := words[1]
 			rate := words[2]

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -426,6 +426,7 @@ func AnnexDrop(filepaths []string, dropchan chan<- RepoFileStatus) {
 			util.LogWrite("Error dropping %s", annexDropRes.File)
 			status.Err = fmt.Errorf("Failed")
 		}
+		status.Progress = "100%"
 		dropchan <- status
 	}
 	if err = cmd.Wait(); err != nil {
@@ -543,6 +544,7 @@ func GitAdd(filepaths []string, addchan chan<- RepoFileStatus) {
 		status.FileName = fname
 		util.LogWrite("%s added to git", fname)
 		// Error conditions?
+		status.Progress = "100%"
 		addchan <- status
 	}
 	if err = cmd.Wait(); err != nil {
@@ -618,6 +620,7 @@ func AnnexAdd(filepaths []string, addchan chan<- RepoFileStatus) {
 			util.LogWrite("Error adding %s", annexAddRes.File)
 			status.Err = fmt.Errorf("Failed")
 		}
+		status.Progress = "100%"
 		addchan <- status
 	}
 	if err = cmd.Wait(); err != nil {

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -246,16 +246,14 @@ func AnnexPush(paths []string, commitMsg string, outchan chan<- string) error {
 		if strings.HasPrefix(line, "copy") {
 			words := strings.Split(line, " ")
 			ulfilename = strings.TrimSpace(words[1])
-			outchan <- fmt.Sprintf("Uploading %s\n", ulfilename)
+			outchan <- fmt.Sprintf("FILE %s", ulfilename)
 		} else if strings.Contains(line, "%") {
 			line = util.CleanSpaces(line)
 			words := strings.Split(line, " ")
 			progress := words[1]
+			outchan <- fmt.Sprintf("PROGRESS %s", progress)
 			rate := words[2]
-			outchan <- fmt.Sprintf("\r%s: %s (%s)", ulfilename, progress, rate)
-			if progress == "100%" {
-				outchan <- green.Sprint(" OK\n")
-			}
+			outchan <- fmt.Sprintf("RATE %s", rate)
 		}
 	}
 	if err != nil {

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -252,6 +252,7 @@ func AnnexPull(content bool, pullchan chan<- RepoFileStatus) {
 // The status channel 'syncchan' is closed when this function returns.
 // (git annex sync [--content])
 func AnnexSync(content bool, syncchan chan<- RepoFileStatus) {
+	defer close(syncchan)
 	args := []string{"sync"}
 	if content {
 		args = append(args, "--content")
@@ -260,6 +261,30 @@ func AnnexSync(content bool, syncchan chan<- RepoFileStatus) {
 	var status RepoFileStatus
 	status.State = "Synchronising repository"
 	syncchan <- status
+	for {
+		line, rerr := cmd.OutPipe.ReadLine()
+		if rerr != nil {
+			break
+		}
+		line = util.CleanSpaces(line)
+		if strings.HasPrefix(line, "copy") || strings.HasPrefix(line, "get") {
+			words := strings.Split(line, " ")
+			status.FileName = strings.TrimSpace(words[1])
+			// new file - reset Progress and Rate
+			status.Progress = ""
+			status.Rate = ""
+			if !strings.HasSuffix(line, "ok") {
+				// if the copy line ends with ok, the file is already done (no upload needed)
+				// so we shouldn't send the status to the caller
+				syncchan <- status
+			}
+		} else if strings.Contains(line, "%") {
+			words := strings.Split(line, " ")
+			status.Progress = words[1]
+			status.Rate = words[2]
+			syncchan <- status
+		}
+	}
 	if err != nil || cmd.Wait() != nil {
 		util.LogWrite("Error during AnnexSync")
 		util.LogWrite("[Error]: %v", err)

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -864,6 +864,7 @@ func AnnexLock(filepaths []string, lockchan chan<- RepoFileStatus) {
 		status.FileName = annexAddRes.File
 		if annexAddRes.Success {
 			util.LogWrite("%s locked", annexAddRes.File)
+			status.Err = nil
 		} else {
 			util.LogWrite("Error locking %s", annexAddRes.File)
 			status.Err = fmt.Errorf("Failed")

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -403,7 +403,9 @@ func (gincl *Client) InitDir(repoPath string, initchan chan<- RepoFileStatus) {
 		}
 
 		// Sync if an initial commit was created
-		err = AnnexSync(false)
+		syncchan := make(chan RepoFileStatus)
+		go AnnexSync(false, syncchan)
+		<-syncchan // wait for channel to close
 		if err != nil {
 			initchan <- RepoFileStatus{Err: initerr}
 			return

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -224,31 +224,6 @@ func (gincl *Client) Upload(paths []string, uploadchan chan<- UploadStatus) {
 	return
 }
 
-// DownloadRepo downloads the files in an already checked out repository.
-// Setting the Workingdir package global affects the working directory in which the command is executed.
-func (gincl *Client) DownloadRepo(content bool) error {
-	util.LogWrite("DownloadRepo")
-
-	err := AnnexPull(content)
-	return err
-}
-
-// GetContent retrieves the contents of placeholder files in a checked out repository.
-func (gincl *Client) GetContent(filepaths []string) error {
-	util.LogWrite("GetContent")
-
-	err := AnnexGet(filepaths)
-	return err
-}
-
-// RmContent removes the contents of local files, turning them into placeholders, but ONLY IF the content is available on a remote
-func (gincl *Client) RmContent(filepaths []string) error {
-	util.LogWrite("RmContent")
-
-	err := AnnexDrop(filepaths)
-	return err
-}
-
 // CloneRepo clones a remote repository and initialises annex.
 // Returns the name of the directory in which the repository is cloned.
 func (gincl *Client) CloneRepo(repoPath string) (string, error) {

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -190,11 +190,11 @@ func (gincl *Client) Upload(paths []string, outchan chan<- string, errchan chan<
 		if stat.Err != nil {
 			errchan <- stat.Err
 		}
-		if stat.Filename != fname {
-			fname = stat.Filename
+		if stat.FileName != fname {
+			fname = stat.FileName
 			outchan <- "\n"
 		}
-		outchan <- fmt.Sprintf("\r%s: %s (%s)", stat.Filename, stat.Progress, stat.Rate)
+		outchan <- fmt.Sprintf("\r%s: %s (%s)", stat.FileName, stat.Progress, stat.Rate)
 		if stat.Progress == "100%" {
 			outchan <- green.Sprint(" - OK")
 		}

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -277,6 +277,7 @@ func (gincl *Client) InitDir(repoPath string) (string, error) {
 	if new {
 		// Push initial commit and set default remote
 		cmd, err := RunGitCommand("push", "--set-upstream", "origin", "master")
+		// TODO: Parse output or wait for command to finish
 		if err != nil {
 			util.LogWrite("Error during set upstream command")
 			cmd.LogStdOutErr()
@@ -474,6 +475,7 @@ func lfIndirect(paths ...string) (map[string]FileStatus, error) {
 	diffargs := []string{"diff", "--name-only", "--relative", "@{upstream}"}
 	diffargs = append(diffargs, cachedfiles...)
 	cmd, err := RunGitCommand(diffargs...)
+	// TODO: Parse output or wait for command to finish
 	if err != nil {
 		util.LogWrite("Error during diff command for status")
 		cmd.LogStdOutErr()

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -140,28 +140,18 @@ func (gincl *Client) Upload(paths []string, outchan chan<- string, errchan chan<
 	}
 
 	if len(paths) > 0 {
-		outchan <- "Preparing ...\n"
+		outchan <- "Preparing files for upload ...\n"
 		// Run git annex add using exclusion filters and then add the rest to git
-		annexfiles, ierr := AnnexAdd(paths)
+		_, ierr := AnnexAdd(paths, outchan)
 		if ierr != nil {
 			errchan <- ierr
 			return
-		}
-		if len(annexfiles) > 0 {
-			outchan <- "Added to large file store:\n"
-			outchan <- strings.Join(annexfiles, "\n")
-			outchan <- "\n"
 		}
 
-		gitfiles, ierr := GitAdd(paths)
+		_, ierr = GitAdd(paths, outchan)
 		if ierr != nil {
 			errchan <- ierr
 			return
-		}
-		if len(gitfiles) > 0 {
-			outchan <- "Added to small file store:\n"
-			outchan <- strings.Join(gitfiles, "\n")
-			outchan <- "\n"
 		}
 	}
 	changes, err := DescribeIndexShort()
@@ -186,7 +176,7 @@ func (gincl *Client) Upload(paths []string, outchan chan<- string, errchan chan<
 	}
 
 	outchan <- "Uploading files: "
-	err = AnnexPush(paths, changes)
+	err = AnnexPush(paths, changes, outchan)
 	if err != nil {
 		errchan <- err
 	}

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -214,7 +214,7 @@ func (gincl *Client) Upload(paths []string, uploadchan chan<- RepoFileStatus) {
 }
 
 // GetContent downloads the contents of placeholder files in a checked out repository.
-// The status channel 'downloadchan' is closed when this function returns.
+// The status channel 'getcontchan' is closed when this function returns.
 func (gincl *Client) GetContent(paths []string, getcontchan chan<- RepoFileStatus) {
 	defer close(getcontchan)
 	util.LogWrite("GetContent")
@@ -233,6 +233,25 @@ func (gincl *Client) GetContent(paths []string, getcontchan chan<- RepoFileStatu
 			break
 		}
 		getcontchan <- stat
+	}
+	return
+}
+
+// Download downloads changes and placeholder files in an already checked out repository.
+// Setting the Workingdir package global affects the working directory in which the command is executed.
+// The status channel 'downloadchan' is closed when this function returns.
+func (gincl *Client) Download(content bool, downloadchan chan<- RepoFileStatus) {
+	defer close(downloadchan)
+	util.LogWrite("Download")
+
+	downloadstatus := make(chan RepoFileStatus)
+	go AnnexPull(content, downloadstatus)
+	for {
+		stat, ok := <-downloadstatus
+		if !ok {
+			break
+		}
+		downloadchan <- stat
 	}
 	return
 }

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -205,12 +205,10 @@ func (gincl *Client) CloneRepo(repoPath string) (string, error) {
 		return "", err
 	}
 
-	fmt.Printf("Fetching repository '%s'... ", repoPath)
 	err = gincl.Clone(repoPath)
 	if err != nil {
 		return "", err
 	}
-	green.Println("OK")
 	_, repoName := splitRepoParts(repoPath)
 	Workingdir = repoName
 	return gincl.InitDir(repoPath)
@@ -218,7 +216,6 @@ func (gincl *Client) CloneRepo(repoPath string) (string, error) {
 
 // InitDir initialises the local directory with the default remote and annex configuration.
 func (gincl *Client) InitDir(repoPath string) (string, error) {
-	fmt.Printf("Initialising local storage... ")
 	_, repoName := splitRepoParts(repoPath)
 	initerr := fmt.Errorf("Error initialising local directory")
 	remotePath := fmt.Sprintf("ssh://%s@%s/%s", gincl.GitUser, gincl.GitHost, repoPath)
@@ -290,7 +287,6 @@ func (gincl *Client) InitDir(repoPath string) (string, error) {
 		}
 	}
 
-	green.Println("OK")
 	return repoName, nil
 }
 

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -277,8 +277,7 @@ func (gincl *Client) InitDir(repoPath string) (string, error) {
 	if new {
 		// Push initial commit and set default remote
 		cmd, err := RunGitCommand("push", "--set-upstream", "origin", "master")
-		// TODO: Parse output or wait for command to finish
-		if err != nil {
+		if err != nil || cmd.Wait() != nil {
 			util.LogWrite("Error during set upstream command")
 			cmd.LogStdOutErr()
 			return "", initerr
@@ -475,8 +474,7 @@ func lfIndirect(paths ...string) (map[string]FileStatus, error) {
 	diffargs := []string{"diff", "--name-only", "--relative", "@{upstream}"}
 	diffargs = append(diffargs, cachedfiles...)
 	cmd, err := RunGitCommand(diffargs...)
-	// TODO: Parse output or wait for command to finish
-	if err != nil {
+	if err != nil || cmd.Wait() != nil {
 		util.LogWrite("Error during diff command for status")
 		cmd.LogStdOutErr()
 		// ignoring error and continuing

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -33,7 +33,7 @@ func (gincl *Client) MakeSessionKey() error {
 		util.LogWrite("Could not retrieve hostname")
 		hostname = defaultHostname
 	}
-	description := fmt.Sprintf("%s@%s", gincl.Username, hostname)
+	description := fmt.Sprintf("GIN Client: %s@%s", gincl.Username, hostname)
 	pubkey := fmt.Sprintf("%s %s", strings.TrimSpace(keyPair.Public), description)
 	err = gincl.AddKey(pubkey, description, true)
 	if err != nil {

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -225,8 +225,8 @@ func (gincl *Client) InitDir(repoPath string) (string, error) {
 
 	if !IsRepo() {
 		cmd, err := RunGitCommand("init")
-		if err != nil {
-			util.LogWrite("Error during Init command")
+		if err != nil || cmd.Wait() != nil {
+			util.LogWrite("Error during Init command: %s", err.Error())
 			cmd.LogStdOutErr()
 			return "", initerr
 		}

--- a/help.go
+++ b/help.go
@@ -12,24 +12,60 @@ Options:
 	--version    Client version
 
 Commands:
-	login          [<username>]                | Login to the GIN services
-	logout                                     | Logout from the GIN services
-	create         [<name>] [<description>]    | Create a repository on the remote server and clone it
-	get            <repopath>                  | Retrieve (clone) a repository from the remote server
-	ls             [-s, --short] [<filenames>] | List the sync status of files in a local repository
-	unlock         [<filenames>]               | Unlock files for editing
-	lock           [<filenames>]               | Lock files
-	upload         [<filenames>]               | Upload local changes to a remote repository
-	download       [--content]                 | Download all new information from a remote repository
-	get-content    [<filenames>]               | Download the content of files from a remote repository
-	getc           [<filenames>]               | Synonym for get-content
-	remove-content [<filenames>]               | Remove the content of local files that have already been uploaded
-	rmc            [<filenames>]               | Synonym for remove-content
-	repos          [<username>]                | List available remote repositories
-	info           [<username>]                | Print user information
-	keys           [-v, --verbose]             | List the keys associated with the logged in user
-	keys           --add <filename>            | Add/upload a new public key to the GIN services
-	help           <command>                   | Get help for individual commands
+	login          [<username>]
+		 Login to the GIN services
+
+	logout
+		 Logout from the GIN services
+
+	create         [<name>] [<description>]
+		 Create a repository on the remote server and clone it
+
+	get            <repopath>
+		 Retrieve (clone) a repository from the remote server
+
+	ls             [-s, --short] [<filenames>]
+		 List the sync status of files in a local repository
+
+	unlock         [<filenames>]
+		 Unlock files for editing
+
+	lock           [<filenames>]
+		 Lock files
+
+	upload         [<filenames>]
+		 Upload local changes to a remote repository
+
+	download       [--content]
+		 Download all new information from a remote repository
+
+	get-content    [<filenames>]
+		 Download the content of files from a remote repository
+	
+	getc           [<filenames>]
+		 Synonym for get-content
+
+	remove-content [<filenames>]
+		 Remove the content of local files that have already been uploaded
+
+	rmc            [<filenames>]
+		 Synonym for remove-content
+
+	repos          [<username>]
+		 List available remote repositories
+
+	info           [<username>]
+		 Print user information
+
+	keys           [-v, --verbose]
+		 List the keys associated with the logged in user
+
+	keys           --add <filename>
+		 Add/upload a new public key to the GIN services
+
+	help           <command>
+		 Get help for individual commands
+
 
 Use 'help' followed by a command to see full description of the command.
 `

--- a/help.go
+++ b/help.go
@@ -22,6 +22,7 @@ Commands:
 	upload         [<filenames>]               | Upload local changes to a remote repository
 	download       [--content]                 | Download all new information from a remote repository
 	get-content    [<filenames>]               | Download the content of files from a remote repository
+	getc           [<filenames>]               | Synonym for get-content
 	remove-content [<filenames>]               | Remove the content of local files that have already been uploaded
 	rmc            [<filenames>]               | Synonym for remove-content
 	repos          [<username>]                | List available remote repositories
@@ -180,14 +181,14 @@ ARGUMENTS
 const lockHelp = `USAGE
 
 	gin lock [<filenames>]...
-	
+
 DESCRIPTION
 
 	Lock one or more files after editing. After unlocking files for editing,
 	using the 'unlock' command, it is recommended that they be locked again.
 	This records any changes made and prepares a file for upload to the GIN
 	server.
-	
+
 	Locked files are replaced by symbolic links in the working directory.
 
 	After performing an 'upload', 'download', or 'get', affected files are
@@ -211,7 +212,7 @@ DESCRIPTION
 	the GIN server. This command must be called from within the local
 	repository clone. Specific files or directories may be specified.
 	All changes made will be sent to the server, including addition of new
-	files, modifications and renaming of existing files, and file deletions. 
+	files, modifications and renaming of existing files, and file deletions.
 
 ARGUMENTS
 
@@ -258,7 +259,7 @@ ARGUMENTS
 `
 
 const rmcHelp = `USAGE
-	
+
 	gin remove-content [<filenames>]...
 	gin rmc [<filenames>]...
 
@@ -371,8 +372,9 @@ var cmdHelp = map[string]string{
 	"unlock":         unlockHelp,
 	"lock":           lockHelp,
 	"upload":         uploadHelp,
-	"get-content":    getContentHelp,
 	"download":       downloadHelp,
+	"get-content":    getContentHelp,
+	"getc":           getContentHelp,
 	"remove-content": rmcHelp,
 	"rmc":            rmcHelp,
 	"repos":          reposHelp,

--- a/main.go
+++ b/main.go
@@ -537,6 +537,7 @@ func gitrun(args []string) {
 	util.CheckError(err)
 
 	cmd, err := ginclient.RunGitCommand(args...)
+	util.CheckError(err)
 	for {
 		line, readerr := cmd.OutPipe.ReadLine()
 		if readerr != nil {
@@ -556,6 +557,7 @@ func annexrun(args []string) {
 	err := gincl.LoadToken()
 	util.CheckError(err)
 	cmd, err := ginclient.RunAnnexCommand(args...)
+	util.CheckError(err)
 	var line string
 	for {
 		line, err = cmd.OutPipe.ReadLine()

--- a/main.go
+++ b/main.go
@@ -523,12 +523,13 @@ func annexrun(args []string) {
 	gincl := ginclient.NewClient(util.Config.GinHost)
 	err := gincl.LoadToken()
 	util.CheckError(err)
-
-	stdout, stderr, err := ginclient.RunAnnexCommand(args...)
-	fmt.Print(stdout.String())
-	fmt.Fprint(os.Stderr, stderr.String())
-	if err != nil {
-		os.Exit(1)
+	cmd, err := ginclient.RunAnnexCommand(args...)
+	for {
+		line, err := cmd.Output.ReadLine()
+		if err != nil {
+			break
+		}
+		fmt.Print(line)
 	}
 }
 
@@ -598,7 +599,7 @@ func main() {
 	case "git":
 		gitrun(cmdArgs)
 	case "annex":
-		annexrun(cmdArgs)
+		annexrunp(cmdArgs)
 	default:
 		util.Die(usage)
 	}

--- a/main.go
+++ b/main.go
@@ -279,8 +279,18 @@ func upload(args []string) {
 
 	fmt.Print("Uploading... ")
 
-	err = gincl.Upload(args)
-	util.CheckError(err)
+	ulout := make(chan string)
+	ulerr := make(chan error)
+	go gincl.Upload(args, ulout, ulerr)
+	var out string
+	for ok := true; ok; {
+		select {
+		case out, ok = <-ulout:
+			fmt.Print(out)
+		case err, ok = <-ulerr:
+			util.CheckError(err)
+		}
+	}
 	_, _ = green.Println("OK")
 }
 

--- a/main.go
+++ b/main.go
@@ -248,16 +248,20 @@ func lock(args []string) {
 	if !ginclient.IsRepo() {
 		util.Die("This command must be run from inside a gin repository.")
 	}
-	err := ginclient.AnnexLock(args...)
-	util.CheckError(err)
+	gincl := ginclient.NewClient(util.Config.GinHost)
+	lockchan := make(chan ginclient.RepoFileStatus)
+	go gincl.LockContent(args, lockchan)
+	printProgress(lockchan)
 }
 
 func unlock(args []string) {
 	if !ginclient.IsRepo() {
 		util.Die("This command must be run from inside a gin repository.")
 	}
-	err := ginclient.AnnexUnlock(args...)
-	util.CheckError(err)
+	gincl := ginclient.NewClient(util.Config.GinHost)
+	unlockchan := make(chan ginclient.RepoFileStatus)
+	go gincl.UnlockContent(args, unlockchan)
+	printProgress(unlockchan)
 }
 
 func printProgress(statuschan chan ginclient.RepoFileStatus) {
@@ -311,8 +315,7 @@ func upload(args []string) {
 	if !ginclient.IsRepo() {
 		util.Die("This command must be run from inside a gin repository.")
 	}
-	err := ginclient.AnnexLock(args...)
-	util.CheckError(err)
+	lock(args)
 
 	gincl := ginclient.NewClient(util.Config.GinHost)
 	gincl.GitHost = util.Config.GitHost
@@ -332,8 +335,7 @@ func download(args []string) {
 	if !ginclient.IsRepo() {
 		util.Die("This command must be run from inside a gin repository.")
 	}
-	err := ginclient.AnnexLock()
-	util.CheckError(err)
+	lock(args)
 
 	var content bool
 	if len(args) > 0 {
@@ -374,9 +376,7 @@ func remove(args []string) {
 	if !ginclient.IsRepo() {
 		util.Die("This command must be run from inside a gin repository.")
 	}
-	err := ginclient.AnnexLock(args...)
-	util.CheckError(err)
-
+	lock(args)
 	gincl := ginclient.NewClient(util.Config.GinHost)
 	gincl.GitHost = util.Config.GitHost
 	gincl.GitUser = util.Config.GitUser

--- a/main.go
+++ b/main.go
@@ -113,7 +113,7 @@ func createRepo(args []string) {
 	gincl.GitHost = util.Config.GitHost
 	gincl.GitUser = util.Config.GitUser
 	repoPath := fmt.Sprintf("%s/%s", gincl.Username, repoName)
-	fmt.Printf("Creating repository '%s'... ", repoPath)
+	fmt.Printf("Creating repository '%s' ", repoPath)
 	err = gincl.CreateRepo(repoName, repoDesc)
 	// Parse error message and make error nicer
 	util.CheckError(err)
@@ -286,16 +286,25 @@ func printProgress(statuschan chan ginclient.RepoFileStatus) {
 			rate = fmt.Sprintf("(%s)", rate)
 		}
 		if stat.Err == nil {
-			if (stat.State != "Downloading" && stat.State != "Uploading") || progress == "100%" {
+			if progress == "100%" {
 				progress = green.Sprint("OK")
 			}
 		} else if stat.Err.Error() == "Failed" {
 			progress = red.Sprint("Failed")
 		} else {
-			progress = fmt.Sprintf("%s: %s", red.Sprint("Error"), stat.Err.Error())
+			errmsg := fmt.Sprintf("%s: %s", red.Sprint("Error"), stat.Err.Error())
+			fmt.Printf("%s %s %s\n", stat.State, stat.FileName, errmsg)
+			continue
 		}
 		fmt.Printf("\r%s", strings.Repeat(" ", prevlinelength)) // clear the previous line
-		prevlinelength, _ = fmt.Printf("\r%s %s: %s %s", stat.State, fname, progress, rate)
+		prevlinelength, _ = fmt.Printf("\r%s ", stat.State)
+		if len(stat.FileName) > 0 {
+			// skip filename print if empty
+			length, _ := fmt.Printf("%s ", stat.FileName)
+			prevlinelength += length
+		}
+		length, _ := fmt.Printf("%s %s", progress, rate)
+		prevlinelength += length
 	}
 	fmt.Println()
 }

--- a/main.go
+++ b/main.go
@@ -280,6 +280,7 @@ func upload(args []string) {
 	uploadchan := make(chan ginclient.UploadStatus)
 	go gincl.Upload(args, uploadchan)
 	var fname string
+	prevlinelength := 0 // used to clear lines before overwriting
 	for {
 		stat, ok := <-uploadchan
 		if !ok {
@@ -290,6 +291,7 @@ func upload(args []string) {
 		if stat.FileName != fname {
 			// New line if new file status
 			fmt.Println()
+			prevlinelength = 0
 			fname = stat.FileName
 		}
 		progress := stat.Progress
@@ -300,9 +302,10 @@ func upload(args []string) {
 		if progress == "100%" {
 			progress = green.Sprint("OK")
 		}
-		fmt.Printf("\r%s: %s %s     ", fname, progress, rate)
+		fmt.Printf("\r%s", strings.Repeat(" ", prevlinelength)) // clear the previous line
+		prevlinelength, _ = fmt.Printf("\r%s: %s %s", fname, progress, rate)
 	}
-	// _, _ = green.Println("OK")
+	fmt.Println()
 }
 
 func download(args []string) {

--- a/main.go
+++ b/main.go
@@ -121,8 +121,10 @@ func createRepo(args []string) {
 	if here {
 		// Init cwd
 		ginclient.Workingdir = "."
+		fmt.Printf("Initialising local storage... ")
 		_, err = gincl.InitDir(repoPath)
 		util.CheckError(err)
+		_, _ = green.Println("OK")
 	} else {
 		// Clone repository after creation
 		getRepo([]string{repoPath})
@@ -184,11 +186,13 @@ func getRepo(args []string) {
 		util.Die(fmt.Sprintf("Invalid repository path '%s'. Full repository name should be the owner's username followed by the repository name, separated by a '/'.\nType 'gin help get' for information and examples.", repostr))
 	}
 
+	fmt.Printf("Fetching repository '%s'... ", repostr)
 	gincl := ginclient.NewClient(util.Config.GinHost)
 	gincl.GitHost = util.Config.GitHost
 	gincl.GitUser = util.Config.GitUser
 	_, err := gincl.CloneRepo(repostr)
 	util.CheckError(err)
+	_, _ = green.Println("OK")
 }
 
 func lsRepo(args []string) {

--- a/main.go
+++ b/main.go
@@ -581,6 +581,8 @@ func main() {
 		download(cmdArgs)
 	case "get-content":
 		getContent(cmdArgs)
+	case "getc":
+		getContent(cmdArgs)
 	case "remove-content":
 		remove(cmdArgs)
 	case "rmc":

--- a/main.go
+++ b/main.go
@@ -290,8 +290,10 @@ func upload(args []string) {
 		util.CheckError(stat.Err)
 		if stat.FileName != fname {
 			// New line if new file status
-			fmt.Println()
-			prevlinelength = 0
+			if fname != "" {
+				fmt.Println()
+				prevlinelength = 0
+			}
 			fname = stat.FileName
 		}
 		progress := stat.Progress
@@ -299,11 +301,11 @@ func upload(args []string) {
 		if len(rate) > 0 {
 			rate = fmt.Sprintf("(%s)", rate)
 		}
-		if progress == "100%" {
+		if progress == "100%" || stat.State == "Added" {
 			progress = green.Sprint("OK")
 		}
 		fmt.Printf("\r%s", strings.Repeat(" ", prevlinelength)) // clear the previous line
-		prevlinelength, _ = fmt.Printf("\r%s: %s %s", fname, progress, rate)
+		prevlinelength, _ = fmt.Printf("\r%s %s: %s %s", stat.State, fname, progress, rate)
 	}
 	fmt.Println()
 }

--- a/main.go
+++ b/main.go
@@ -327,7 +327,7 @@ func download(args []string) {
 	gincl.GitHost = util.Config.GitHost
 	gincl.GitUser = util.Config.GitUser
 	fmt.Print("Downloading...")
-	err = gincl.DownloadRepo(content)
+	err = ginclient.AnnexPull(content)
 	_, _ = green.Println("OK")
 	util.CheckError(err)
 }
@@ -340,7 +340,7 @@ func getContent(args []string) {
 	gincl := ginclient.NewClient(util.Config.GinHost)
 	gincl.GitHost = util.Config.GitHost
 	gincl.GitUser = util.Config.GitUser
-	err := gincl.GetContent(args)
+	err := ginclient.AnnexGet(args)
 	util.CheckError(err)
 }
 
@@ -354,7 +354,7 @@ func remove(args []string) {
 	gincl := ginclient.NewClient(util.Config.GinHost)
 	gincl.GitHost = util.Config.GitHost
 	gincl.GitUser = util.Config.GitUser
-	err = gincl.RmContent(args)
+	err = ginclient.AnnexDrop(args)
 	util.CheckError(err)
 }
 

--- a/main.go
+++ b/main.go
@@ -277,8 +277,6 @@ func upload(args []string) {
 		fmt.Printf("To upload all files under the current directory, use:\n\n\tgin upload .\n\n")
 	}
 
-	fmt.Print("Uploading... ")
-
 	ulout := make(chan string)
 	ulerr := make(chan error)
 	go gincl.Upload(args, ulout, ulerr)
@@ -291,7 +289,7 @@ func upload(args []string) {
 			util.CheckError(err)
 		}
 	}
-	_, _ = green.Println("OK")
+	// _, _ = green.Println("OK")
 }
 
 func download(args []string) {

--- a/main.go
+++ b/main.go
@@ -116,7 +116,7 @@ func createRepo(args []string) {
 	err = gincl.CreateRepo(repoName, repoDesc)
 	// Parse error message and make error nicer
 	util.CheckError(err)
-	green.Println("OK")
+	_, _ = green.Println("OK")
 
 	if here {
 		// Init cwd
@@ -277,7 +277,7 @@ func upload(args []string) {
 
 	err = gincl.Upload(args)
 	util.CheckError(err)
-	green.Println("OK")
+	_, _ = green.Println("OK")
 }
 
 func download(args []string) {
@@ -300,7 +300,7 @@ func download(args []string) {
 	gincl.GitUser = util.Config.GitUser
 	fmt.Print("Downloading...")
 	err = gincl.DownloadRepo(content)
-	green.Println("OK")
+	_, _ = green.Println("OK")
 	util.CheckError(err)
 }
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,5 @@
 package main
 
-// TODO: Nicer error handling. Print useful, descriptive messages.
-
 import (
 	"bytes"
 	"fmt"
@@ -500,11 +498,11 @@ func checkAnnexVersion(verstring string) {
 	errmsg := fmt.Sprintf("The GIN Client requires git-annex %s or newer", minAnnexVersion)
 	systemver, err := version.NewVersion(verstring)
 	if err != nil {
-		util.Die(errmsg)
+		util.Die(fmt.Sprintln("git-annex not found") + errmsg)
 	}
 	minver, _ := version.NewVersion(minAnnexVersion)
 	if systemver.LessThan(minver) {
-		util.Die(errmsg)
+		util.Die(errmsg + fmt.Sprintf("Found version %s", systemver))
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -122,10 +122,9 @@ func createRepo(args []string) {
 	if here {
 		// Init cwd
 		ginclient.Workingdir = "."
-		fmt.Printf("Initialising local storage... ")
-		_, err = gincl.InitDir(repoPath)
-		util.CheckError(err)
-		_, _ = green.Println("OK")
+		initchan := make(chan ginclient.RepoFileStatus)
+		go gincl.InitDir(repoPath, initchan)
+		printProgress(initchan)
 	} else {
 		// Clone repository after creation
 		getRepo([]string{repoPath})
@@ -187,13 +186,12 @@ func getRepo(args []string) {
 		util.Die(fmt.Sprintf("Invalid repository path '%s'. Full repository name should be the owner's username followed by the repository name, separated by a '/'.\nType 'gin help get' for information and examples.", repostr))
 	}
 
-	fmt.Printf("Fetching repository '%s'... ", repostr)
 	gincl := ginclient.NewClient(util.Config.GinHost)
 	gincl.GitHost = util.Config.GitHost
 	gincl.GitUser = util.Config.GitUser
-	_, err := gincl.CloneRepo(repostr)
-	util.CheckError(err)
-	_, _ = green.Println("OK")
+	clonechan := make(chan ginclient.RepoFileStatus)
+	go gincl.CloneRepo(repostr, clonechan)
+	printProgress(clonechan)
 }
 
 func lsRepo(args []string) {

--- a/util/cmd.go
+++ b/util/cmd.go
@@ -47,6 +47,8 @@ func scanLinesCR(data []byte, atEOF bool) (advance int, token []byte, err error)
 	idx := -1
 	if cridx >= 0 {
 		idx = cridx
+	} else {
+		cridx = len(data) + 1
 	}
 	if nlidx >= 0 && nlidx < cridx {
 		idx = nlidx
@@ -72,7 +74,7 @@ func (reader *Reader) ReadLine() (str string, err error) {
 	}
 
 	reader.cache += str
-	return str, err
+	return
 }
 
 // ReadAll collects the buffer output until it reaches EOF and returns the entire output as a single string.

--- a/util/cmd.go
+++ b/util/cmd.go
@@ -55,3 +55,11 @@ func (cmd *GinCmd) LogStdOutErr() {
 	LogWrite("[stdout]\r\n%s", stdout)
 	LogWrite("[stderr]\r\n%s", stderr)
 }
+
+// Wait collects stdout and stderr from the command and then waits for the command to finish before returning.
+// Stdout and stderr are then available for reading through each pipe's respective cache.
+func (cmd *GinCmd) Wait() error {
+	_ = cmd.OutPipe.ReadAll()
+	_ = cmd.ErrPipe.ReadAll()
+	return cmd.Cmd.Wait()
+}

--- a/util/cmd.go
+++ b/util/cmd.go
@@ -1,0 +1,57 @@
+package util
+
+import (
+	"bufio"
+	"os/exec"
+)
+
+// Reader extends bufio.Reader with convenience functions for reading and caching piped output.
+type Reader struct {
+	*bufio.Reader
+	cache string
+}
+
+// GinCmd extends the exec.Cmd struct with convenience functions for reading piped output.
+type GinCmd struct {
+	*exec.Cmd
+	OutPipe *Reader
+	ErrPipe *Reader
+}
+
+// Command returns the GinCmd struct to execute the named program with the given arguments.
+func Command(name string, args ...string) GinCmd {
+	cmd := exec.Command(name, args...)
+	outpipe, _ := cmd.StdoutPipe()
+	errpipe, _ := cmd.StderrPipe()
+	outreader := bufio.NewReader(outpipe)
+	errreader := bufio.NewReader(errpipe)
+	var cout, cerr string
+	return GinCmd{cmd, &Reader{outreader, cout}, &Reader{errreader, cerr}}
+}
+
+// ReadLine returns the next line in the buffer, delimited by '\n'.
+func (reader *Reader) ReadLine() (string, error) {
+	str, err := reader.ReadString('\n')
+	reader.cache += str
+	return str, err
+}
+
+// ReadAll collects the buffer output until it reaches EOF and returns the entire output as a single string.
+// The outptut is cached so repeated calls to ReadAll return the output again.
+func (reader *Reader) ReadAll() (output string) {
+	for {
+		_, err := reader.ReadLine()
+		if err != nil {
+			break
+		}
+	}
+	return reader.cache
+}
+
+// LogStdOutErr writes the command stdout and stderr to the log file.
+func (cmd *GinCmd) LogStdOutErr() {
+	stdout := cmd.OutPipe.ReadAll()
+	stderr := cmd.ErrPipe.ReadAll()
+	LogWrite("[stdout]\r\n%s", stdout)
+	LogWrite("[stderr]\r\n%s", stderr)
+}

--- a/util/cmd.go
+++ b/util/cmd.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 	"io"
 	"os/exec"
+	"regexp"
+	"strings"
 )
 
 // Reader extends bufio.Reader with convenience functions for reading and caching piped output.
@@ -99,4 +101,10 @@ func (cmd *GinCmd) Wait() error {
 	_ = cmd.OutPipe.ReadAll()
 	_ = cmd.ErrPipe.ReadAll()
 	return cmd.Cmd.Wait()
+}
+
+// CleanSpaces replaces multiple occurences of the space character with one and trims leading and trailing spaces from a string.
+func CleanSpaces(str string) string {
+	re := regexp.MustCompile(`\s+`)
+	return re.ReplaceAllString(strings.TrimSpace(str), " ")
 }

--- a/util/die.go
+++ b/util/die.go
@@ -10,7 +10,7 @@ import (
 
 var red = color.New(color.FgRed)
 
-//Die prints a message to stderr and exits the program.
+//Die prints a message to stderr and exits the program with status 1.
 func Die(msg string) {
 	_, _ = red.Fprint(os.Stderr, "ERROR ")
 	fmt.Fprintln(os.Stderr, msg)

--- a/util/files.go
+++ b/util/files.go
@@ -34,18 +34,28 @@ func PathSplit(path string) (string, string) {
 
 // ExpandGlobs expands a list of globs into paths (files and directories).
 func ExpandGlobs(paths []string) (globexppaths []string, err error) {
+	if len(paths) == 0 {
+		// Nothing to do
+		globexppaths = paths
+		return
+	}
 	// expand potential globs
 	for _, p := range paths {
 		LogWrite("ExpandGlobs: Checking for glob expansion for %s", p)
-		exp, err := filepath.Glob(p)
-		if err != nil {
-			LogWrite(err.Error())
+		exp, globerr := filepath.Glob(p)
+		if globerr != nil {
+			LogWrite(globerr.Error())
 			LogWrite("Bad file pattern %s", p)
-			return nil, err
+			return nil, globerr
 		}
 		if exp != nil {
 			globexppaths = append(globexppaths, exp...)
 		}
+	}
+	if len(globexppaths) == 0 {
+		// Invalid paths
+		LogWrite("ExpandGlobs: No files matched")
+		err = fmt.Errorf("No files matched %v", paths)
 	}
 	return
 }

--- a/util/keygen.go
+++ b/util/keygen.go
@@ -22,7 +22,7 @@ type KeyPair struct {
 // KeyFile holds the absolute path and filename of the current logged in user's key file.
 type KeyFile struct {
 	Dir      string
-	Filename string
+	FileName string
 	Active   bool
 }
 


### PR DESCRIPTION
And here it is, the feature we've all been waiting for:
## Progress and status output for file operations
This PR restructures most of the internal functions, everything that deals with git and git-annex operations in the end. Most of these functions are now meant to be run as routines and communicate back to the caller through a channel. All new routines use the same struct to communicate called `RepoFileStatus` (not sure I like the name; I'm open to suggestions).

Closes #7.
Closes #24.

## New GinCmd struct embeds exec.Cmd
The new `GinCmd` type embeds `exec.Cmd` and provides a few convenience functions for reading buffered stdout and stderr, line by line. It defines a scanner that returns buffered output until it hits either a new line `\n` or carriage return `\r`. The latter is necessary to read _live_ output from file transfers. The stdout and stderr buffers are also cached in GinCmd so they can be reread if necessary.

### More to come
The following are scheduled as followup PRs to keep the current one from getting even bigger.
- The functions responsible for the `gin ls` command haven't been changed (see #122).
- I'd like to go back and provide synchronous versions of the new asynchronous routines. Basically, reimplement the old subpackage API as a wrapper over the new one. It's not much work, since the new functions will just call the routines, wait for them to finish, and return stdout and stderr.