### PR TITLE
Version check fix

### DIFF
--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -1099,15 +1099,16 @@ func selectGitOrAnnex(paths []string) (gitpaths []string, annexpaths []string) {
 func GetAnnexVersion() (string, error) {
 	cmd, err := RunAnnexCommand("version", "--raw")
 	if err != nil {
-		util.LogWrite("Error while checking git-annex version")
+		util.LogWrite("Error while preparing git-annex version command")
+		if strings.Contains(err.Error(), "executable file not found") ||
+			strings.Contains(err.Error(), "no such file or directory") {
+			return "", fmt.Errorf("git-annex executable '%s' not found", util.Config.Bin.GitAnnex)
+		}
 		return "", err
 	}
 	if err = cmd.Wait(); err != nil {
 		util.LogWrite("Error while checking git-annex version")
 		cmd.LogStdOutErr()
-		if strings.Contains(cmd.ErrPipe.ReadAll(), "command not found") {
-			return "", fmt.Errorf("Error: git-annex command not found")
-		}
 		return "", err
 	}
 

--- a/main.go
+++ b/main.go
@@ -52,7 +52,8 @@ func login(args []string) {
 			util.Die("Cancelled.")
 		}
 		if err == gopass.ErrMaxLengthExceeded {
-			util.Die("[Error] Input too long.")
+			errmsg := fmt.Sprintf("%s Input too long.", red.Sprintf("ERROR"))
+			util.Die(errmsg)
 		}
 		util.Die(err.Error())
 	}

--- a/main.go
+++ b/main.go
@@ -575,10 +575,10 @@ func checkAnnexVersion() {
 		// Cutting off the suffix and checking again
 		verstring = strings.Split(verstring, "~")[0]
 		systemver, err = version.NewVersion(verstring)
-	}
-	if err != nil {
-		// Can't figure out the version. Giving up.
-		util.Die(fmt.Sprintf("%s\ngit-annex version %s not understood", errmsg, verstring))
+		if err != nil {
+			// Can't figure out the version. Giving up.
+			util.Die(fmt.Sprintf("%s\ngit-annex version %s not understood", errmsg, verstring))
+		}
 	}
 	minver, _ := version.NewVersion(minAnnexVersion)
 	if systemver.LessThan(minver) {

--- a/main.go
+++ b/main.go
@@ -52,8 +52,7 @@ func login(args []string) {
 			util.Die("Cancelled.")
 		}
 		if err == gopass.ErrMaxLengthExceeded {
-			errmsg := fmt.Sprintf("%s Input too long.", red.Sprintf("ERROR"))
-			util.Die(errmsg)
+			util.Die("Input too long")
 		}
 		util.Die(err.Error())
 	}
@@ -565,15 +564,17 @@ func help(args []string) {
 	fmt.Println(helptext)
 }
 
-func checkAnnexVersion(verstring string) {
+func checkAnnexVersion() {
 	errmsg := fmt.Sprintf("The GIN Client requires git-annex %s or newer", minAnnexVersion)
+	verstring, err := ginclient.GetAnnexVersion()
+	util.CheckError(err)
 	systemver, err := version.NewVersion(verstring)
 	if err != nil {
-		util.Die(fmt.Sprintln("git-annex not found") + errmsg)
+		util.Die(fmt.Sprintf("%s\nVersion %s not understood", errmsg, verstring))
 	}
 	minver, _ := version.NewVersion(minAnnexVersion)
 	if systemver.LessThan(minver) {
-		util.Die(errmsg + fmt.Sprintf("Found version %s", systemver))
+		util.Die(fmt.Sprintf("%s\nFound version %s", errmsg, verstring))
 	}
 }
 
@@ -640,10 +641,7 @@ func main() {
 
 	err = util.LoadConfig()
 	util.CheckError(err)
-
-	annexver, err := ginclient.GetAnnexVersion()
-	util.CheckError(err)
-	checkAnnexVersion(annexver)
+	checkAnnexVersion()
 
 	switch command {
 	case "login":

--- a/main.go
+++ b/main.go
@@ -570,7 +570,15 @@ func checkAnnexVersion() {
 	util.CheckError(err)
 	systemver, err := version.NewVersion(verstring)
 	if err != nil {
-		util.Die(fmt.Sprintf("%s\nVersion %s not understood", errmsg, verstring))
+		// Special case for neurodebian git-annex version
+		// The versionn string contains a tilde as a separator for the arch suffix
+		// Cutting off the suffix and checking again
+		verstring = strings.Split(verstring, "~")[0]
+		systemver, err = version.NewVersion(verstring)
+	}
+	if err != nil {
+		// Can't figure out the version. Giving up.
+		util.Die(fmt.Sprintf("%s\ngit-annex version %s not understood", errmsg, verstring))
 	}
 	minver, _ := version.NewVersion(minAnnexVersion)
 	if systemver.LessThan(minver) {


### PR DESCRIPTION
## Handle ~ for version suffix

When handling version strings that include ~ to separate the suffix, the version checker now splits the string and ignores that suffix.
See issue #121: git-annex in neurodebian uses '~ndall' suffix, presumably to specify architecture or distribution version.

This also changes the error output to be more informative. If the git-annex binary is not found, the configured value will be printed with an appropriate message. The user is also informed in cases where the version string cannot be parsed.