### PR TITLE
Json output for gin ls command

### DIFF
--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -133,16 +133,32 @@ func (gincl *Client) DelRepo(name string) error {
 // RepoFileStatus describes the status of files when being added to the repo or transfered to/from remotes.
 type RepoFileStatus struct {
 	// The name of the file.
-	FileName string
+	FileName string `json:"filename"`
 	// The state of the operation (Added, Uploading, or Downloading).
 	// TODO: Use enum
-	State string
+	State string `json:"state"`
 	// Progress of the operation, if available. This is empty when the State is "Added"
-	Progress string
+	Progress string `json:"progress"`
 	// The data rate. This is empty when the State is "Added"
-	Rate string
+	Rate string `json:"rate"`
 	// Errors
-	Err error
+	Err error `json:"err"`
+}
+
+// MarshalJSON overrides the default marshalling of RepoFileStatus to return the error string for the Err field.
+func (s RepoFileStatus) MarshalJSON() ([]byte, error) {
+	type Alias RepoFileStatus
+	errmsg := ""
+	if s.Err != nil {
+		errmsg = s.Err.Error()
+	}
+	return json.Marshal(struct {
+		Alias
+		Err string `json:"err"`
+	}{
+		Alias: Alias(s),
+		Err:   errmsg,
+	})
 }
 
 // Upload adds files to a repository and uploads them.

--- a/help.go
+++ b/help.go
@@ -24,7 +24,7 @@ Commands:
 	get            <repopath>
 		 Retrieve (clone) a repository from the remote server
 
-	ls             [-s, --short] [<filenames>]
+	ls             [-s, --short, --json] [<filenames>]
 		 List the sync status of files in a local repository
 
 	unlock         [<filenames>]
@@ -163,7 +163,7 @@ EXAMPLES
 
 const lsHelp = `USAGE
 
-	gin ls [--short, -s] [<filenames>]...
+	gin ls [--short, -s, --json] [<filenames>]...
 
 DESCRIPTION
 
@@ -186,6 +186,9 @@ ARGUMENTS
 
 	--short, -s
 		Print listing in short form.
+
+	--json
+		Print listing in json format (uses short form abbrevations).
 
 	<filenames>
 		One or more directories or files to list.

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -200,10 +201,16 @@ func lsRepo(args []string) {
 	}
 
 	var short bool
+	var jsonout bool
 	for idx, arg := range args {
 		if arg == "-s" || arg == "--short" {
 			args = append(args[:idx], args[idx+1:]...)
 			short = true
+			break
+		}
+		if arg == "--json" {
+			args = append(args[:idx], args[idx+1:]...)
+			jsonout = true
 			break
 		}
 	}
@@ -219,6 +226,18 @@ func lsRepo(args []string) {
 		for fname, status := range filesStatus {
 			fmt.Printf("%s %s\n", status.Abbrev(), fname)
 		}
+	} else if jsonout {
+		type fstat struct {
+			FileName string `json:"filename"`
+			Status   string `json:"status"`
+		}
+		var statuses []fstat
+		for fname, status := range filesStatus {
+			statuses = append(statuses, fstat{FileName: fname, Status: status.Abbrev()})
+		}
+		jsonbytes, err := json.Marshal(statuses)
+		util.CheckError(err)
+		fmt.Println(string(jsonbytes))
 	} else {
 		// Files are printed separated by status and sorted by name
 		statFiles := make(map[ginclient.FileStatus][]string)


### PR DESCRIPTION
`gin ls --json` now outputs the status of files in JSON format as a single JSON array.
This is contrary to git-annex JSON output, which outputs one JSON object per line.

Partial solution for issue #118.

Uses the same status abbreviations as `gin ls --short`.
Sample output
```
▶ gin ls --json gin-cli-0.12dev.deb gin-cli-0.12dev-macos-amd64.tar.gz
[{"filename":"gin-cli-0.12dev-macos-amd64.tar.gz","status":"NC"},{"filename":"gin-cli-0.12dev.deb","status":"OK"}]
```