### PR TITLE
Multiple bugfixes for Windows and file query routines

### DIFF
--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -671,7 +671,7 @@ type AnnexWhereisInfo struct {
 		Description string   `json:"description"`
 	}
 	Key string `json:"key"`
-	Err error
+	Err error  `json:"err"`
 }
 
 // AnnexWhereis returns information about annexed files in the repository
@@ -686,19 +686,19 @@ func AnnexWhereis(paths []string, wichan chan<- AnnexWhereisInfo) {
 	if err != nil {
 		util.LogWrite("Error during AnnexWhereis")
 		cmd.LogStdOutErr()
-		wichan <- AnnexWhereisInfo{Err: fmt.Errorf("Failed to run annex whereis: %s", err.Error())}
+		wichan <- AnnexWhereisInfo{Err: fmt.Errorf("Failed to run git-annex whereis: %s", err.Error())}
 		return
 	}
 
-	var res AnnexWhereisInfo
+	var info AnnexWhereisInfo
 	for {
 		line, rerr := cmd.OutPipe.ReadLine()
 		if rerr != nil {
 			break
 		}
-		jsonerr := json.Unmarshal([]byte(line), &res)
-		res.Err = jsonerr
-		wichan <- res
+		jsonerr := json.Unmarshal([]byte(line), &info)
+		info.Err = jsonerr
+		wichan <- info
 	}
 	return
 }

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -531,11 +531,7 @@ func GitAdd(filepaths []string, addchan chan<- RepoFileStatus) {
 		wichan := make(chan AnnexWhereisInfo)
 		go AnnexWhereis(filepaths, wichan)
 		var annexfiles []string
-		for {
-			wiInfo, ok := <-wichan
-			if !ok {
-				break
-			}
+		for wiInfo := range wichan {
 			if wiInfo.Err != nil {
 				continue
 			}
@@ -740,11 +736,7 @@ func DescribeIndexShort() (string, error) {
 	statuschan := make(chan AnnexStatusInfo)
 	go AnnexStatus([]string{""}, statuschan)
 	statusmap := make(map[string]int)
-	for {
-		item, ok := <-statuschan
-		if !ok {
-			break
-		}
+	for item := range statuschan {
 		if item.Err != nil {
 			return "", item.Err
 		}
@@ -772,11 +764,7 @@ func DescribeIndex() (string, error) {
 	statuschan := make(chan AnnexStatusInfo)
 	go AnnexStatus([]string{""}, statuschan)
 	statusmap := make(map[string][]string)
-	for {
-		item, ok := <-statuschan
-		if !ok {
-			break
-		}
+	for item := range statuschan {
 		if item.Err != nil {
 			return "", item.Err
 		}
@@ -822,11 +810,7 @@ func AnnexLock(filepaths []string, lockchan chan<- RepoFileStatus) {
 	statuschan := make(chan AnnexStatusInfo)
 	go AnnexStatus(filepaths, statuschan)
 	unlockedfiles := make([]string, 0, len(filepaths))
-	for {
-		item, ok := <-statuschan
-		if !ok {
-			break
-		}
+	for item := range statuschan {
 		if item.Err != nil {
 			lockchan <- RepoFileStatus{Err: item.Err}
 		}

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -223,6 +223,7 @@ func (gincl *Client) GetContent(paths []string, getcontchan chan<- RepoFileStatu
 	util.LogWrite("GetContent")
 
 	paths, err := util.ExpandGlobs(paths)
+
 	if err != nil {
 		getcontchan <- RepoFileStatus{Err: err}
 		return
@@ -539,7 +540,7 @@ func (fsSlice FileStatusSlice) Less(i, j int) bool {
 func lfDirect(paths ...string) (map[string]FileStatus, error) {
 	statuses := make(map[string]FileStatus)
 
-	wichan := make(chan AnnexWhereisInfo)
+	wichan := make(chan AnnexWhereisRes)
 	go AnnexWhereis(paths, wichan)
 	for wiInfo := range wichan {
 		if wiInfo.Err != nil {
@@ -566,7 +567,7 @@ func lfDirect(paths ...string) (map[string]FileStatus, error) {
 		asargs = []string{"."}
 	}
 
-	statuschan := make(chan AnnexStatusInfo)
+	statuschan := make(chan AnnexStatusRes)
 	go AnnexStatus(asargs, statuschan)
 	for item := range statuschan {
 		if item.Err != nil {
@@ -652,7 +653,7 @@ func lfIndirect(paths ...string) (map[string]FileStatus, error) {
 	}
 
 	// Run whereis on cached files
-	wichan := make(chan AnnexWhereisInfo)
+	wichan := make(chan AnnexWhereisRes)
 	go AnnexWhereis(cachedfiles, wichan)
 	for wiInfo := range wichan {
 		if wiInfo.Err != nil {
@@ -707,7 +708,7 @@ func lfIndirect(paths ...string) (map[string]FileStatus, error) {
 
 	// Check if modified files are actually annex unlocked instead
 	if len(modifiedfiles) > 0 {
-		statuschan := make(chan AnnexStatusInfo)
+		statuschan := make(chan AnnexStatusRes)
 		go AnnexStatus(modifiedfiles, statuschan)
 		for item := range statuschan {
 			if item.Err != nil {

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -736,6 +736,10 @@ func lfIndirect(paths ...string) (map[string]FileStatus, error) {
 // ListFiles lists the files and directories specified by paths and their sync status.
 // Setting the Workingdir package global affects the working directory in which the command is executed.
 func (gincl *Client) ListFiles(paths ...string) (map[string]FileStatus, error) {
+	paths, err := util.ExpandGlobs(paths)
+	if err != nil {
+		return nil, err
+	}
 	if IsDirect() {
 		return lfDirect(paths...)
 	}

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -11,13 +11,11 @@ import (
 
 	"github.com/G-Node/gin-cli/util"
 	"github.com/G-Node/gin-cli/web"
-	"github.com/fatih/color"
 	"github.com/gogits/go-gogs-client"
 	// its a bit unfortunate that we have that import now
 	// but its only temporary...
 )
 
-var green = color.New(color.FgGreen)
 var defaultHostname = "(unknown)"
 
 // MakeSessionKey creates a private+public key pair.

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -584,7 +584,7 @@ func (fsSlice FileStatusSlice) Less(i, j int) bool {
 func lfDirect(paths ...string) (map[string]FileStatus, error) {
 	statuses := make(map[string]FileStatus)
 
-	wichan := make(chan AnnexWhereisResult)
+	wichan := make(chan AnnexWhereisInfo)
 	go AnnexWhereis(paths, wichan)
 	for {
 		wiInfo, ok := <-wichan
@@ -657,7 +657,7 @@ func lfIndirect(paths ...string) (map[string]FileStatus, error) {
 	deletedfiles, _ := GitLsFiles(lsfilesargs)
 
 	// Run whereis on cached files
-	wichan := make(chan AnnexWhereisResult)
+	wichan := make(chan AnnexWhereisInfo)
 	go AnnexWhereis(cachedfiles, wichan)
 	for {
 		wiInfo, ok := <-wichan

--- a/help.go
+++ b/help.go
@@ -253,6 +253,9 @@ DESCRIPTION
 	All changes made will be sent to the server, including addition of new
 	files, modifications and renaming of existing files, and file deletions.
 
+	If no arguments are specified, only changes to files already being tracked
+	are uploaded.
+
 ARGUMENTS
 
 	<filenames>

--- a/main.go
+++ b/main.go
@@ -25,8 +25,8 @@ var commit string
 var verstr string
 var minAnnexVersion = "6.20160126" // Introduction of git-annex add --json
 
-var green = color.New(color.FgGreen)
-var red = color.New(color.FgRed)
+var green = color.New(color.FgGreen).SprintFunc()
+var red = color.New(color.FgRed).SprintFunc()
 
 // login requests credentials, performs login with auth server, and stores the token.
 func login(args []string) {
@@ -118,7 +118,7 @@ func createRepo(args []string) {
 	err = gincl.CreateRepo(repoName, repoDesc)
 	// Parse error message and make error nicer
 	util.CheckError(err)
-	_, _ = green.Println("OK")
+	fmt.Println(green("OK"))
 
 	if here {
 		// Init cwd
@@ -339,13 +339,13 @@ func printProgress(statuschan chan ginclient.RepoFileStatus, jsonout bool) {
 		}
 		if stat.Err == nil {
 			if progress == "100%" {
-				progress = green.Sprint("OK")
+				progress = green("OK")
 			}
 		} else if stat.Err.Error() == "Failed" {
-			progress = red.Sprint("Failed")
+			progress = red("Failed")
 			nerrors++
 		} else {
-			errmsg := fmt.Sprintf("%s: %s", red.Sprint("Error"), stat.Err.Error())
+			errmsg := fmt.Sprintf("%s: %s", red("Error"), stat.Err.Error())
 			fmt.Printf("%s %s %s\n", stat.State, stat.FileName, errmsg)
 			nerrors++
 			continue
@@ -437,7 +437,8 @@ func download(args []string) {
 	go gincl.Download(content, dlchan)
 	printProgress(dlchan, jsonout)
 	if !content && !jsonout {
-		_, _ = green.Println("OK")
+		fmt.Println(green("OK"))
+
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -702,6 +702,35 @@ func annexrun(args []string) {
 	}
 }
 
+func printversion(args []string) {
+	var jsonout bool
+	for idx, arg := range args {
+		if arg == "--json" {
+			args = append(args[:idx], args[idx+1:]...)
+			jsonout = true
+			break
+		}
+	}
+	if len(args) > 0 {
+		util.Die(usage)
+	}
+	if jsonout {
+		verjson := struct {
+			Version string `json:"version"`
+			Build   string `json:"build"`
+			Commit  string `json:"commit"`
+		}{
+			gincliversion,
+			build,
+			commit,
+		}
+		verjsonstr, _ := json.Marshal(verjson)
+		fmt.Println(string(verjsonstr))
+	} else {
+		fmt.Println(verstr)
+	}
+}
+
 func init() {
 	if gincliversion == "" {
 		verstr = "GIN command line client [dev build]"
@@ -766,6 +795,8 @@ func main() {
 		gitrun(cmdArgs)
 	case "annex":
 		annexrun(cmdArgs)
+	case "version":
+		printversion(cmdArgs)
 	default:
 		util.Die(usage)
 	}

--- a/main.go
+++ b/main.go
@@ -308,7 +308,7 @@ func unlock(args []string) {
 	printProgress(unlockchan, jsonout)
 }
 
-func printProgress(statuschan chan ginclient.RepoFileStatus, jsonout bool) {
+func printProgress(statuschan <-chan ginclient.RepoFileStatus, jsonout bool) {
 	var fname string
 	prevlinelength := 0 // used to clear lines before overwriting
 	nerrors := 0

--- a/main.go
+++ b/main.go
@@ -312,11 +312,7 @@ func printProgress(statuschan <-chan ginclient.RepoFileStatus, jsonout bool) {
 	var fname string
 	prevlinelength := 0 // used to clear lines before overwriting
 	nerrors := 0
-	for {
-		stat, ok := <-statuschan
-		if !ok {
-			break
-		}
+	for stat := range statuschan {
 		if jsonout {
 			j, _ := json.Marshal(stat)
 			fmt.Println(string(j))

--- a/main.go
+++ b/main.go
@@ -437,8 +437,7 @@ func download(args []string) {
 	go gincl.Download(content, dlchan)
 	printProgress(dlchan, jsonout)
 	if !content && !jsonout {
-		fmt.Println(green("OK"))
-
+		fmt.Fprintln(color.Output, green("OK"))
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -345,20 +345,14 @@ func printProgress(statuschan chan ginclient.RepoFileStatus, jsonout bool) {
 			progress = red("Failed")
 			nerrors++
 		} else {
-			errmsg := fmt.Sprintf("%s: %s", red("Error"), stat.Err.Error())
-			fmt.Printf("%s %s %s\n", stat.State, stat.FileName, errmsg)
+			msg := fmt.Sprintf("%s %s %s: %s", stat.State, stat.FileName, red("Error"), stat.Err.Error())
+			fmt.Fprintln(color.Output, util.CleanSpaces(msg))
 			nerrors++
 			continue
 		}
 		fmt.Printf("\r%s", strings.Repeat(" ", prevlinelength)) // clear the previous line
-		prevlinelength, _ = fmt.Printf("\r%s ", stat.State)
-		if len(stat.FileName) > 0 {
-			// skip filename print if empty
-			length, _ := fmt.Printf("%s ", stat.FileName)
-			prevlinelength += length
-		}
-		length, _ := fmt.Printf("%s %s", progress, rate)
-		prevlinelength += length
+		msg := fmt.Sprintf("%s %s %s %s", stat.State, stat.FileName, progress, rate)
+		prevlinelength, _ = fmt.Fprintf(color.Output, "\r%s", util.CleanSpaces(msg))
 	}
 	if prevlinelength > 0 {
 		fmt.Println()

--- a/main.go
+++ b/main.go
@@ -384,11 +384,6 @@ func upload(args []string) {
 	gincl.GitHost = util.Config.GitHost
 	gincl.GitUser = util.Config.GitUser
 
-	if len(args) == 0 {
-		fmt.Println("No files specified for upload. Synchronising metadata.")
-		fmt.Printf("To upload all files under the current directory, use:\n\n\tgin upload .\n\n")
-	}
-
 	lockchan := make(chan ginclient.RepoFileStatus)
 	go gincl.LockContent(args, lockchan)
 	printProgress(lockchan, jsonout)

--- a/util/cmd.go
+++ b/util/cmd.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"io"
 	"os/exec"
-	"regexp"
 	"strings"
 )
 

--- a/util/cmd.go
+++ b/util/cmd.go
@@ -106,6 +106,5 @@ func (cmd *GinCmd) Wait() error {
 
 // CleanSpaces replaces multiple occurences of the space character with one and trims leading and trailing spaces from a string.
 func CleanSpaces(str string) string {
-	re := regexp.MustCompile(`\s+`)
-	return re.ReplaceAllString(strings.TrimSpace(str), " ")
+	return strings.Join(strings.Fields(str), " ")
 }

--- a/util/die.go
+++ b/util/die.go
@@ -14,7 +14,7 @@ var red = color.New(color.FgRed).SprintFunc()
 func Die(msg string) {
 	// fmt.Fprintf(color.Error, "%s %s\n", red("ERROR"), msg)
 	// Swap the line above for the line below when (if) https://github.com/fatih/color/pull/87 gets merged
-	fmt.Fprintf(color.Output, "%s %s\n", red("ERROR"), msg)
+	fmt.Fprintf(os.Stderr, "%s %s\n", "ERROR", msg)
 	os.Exit(1)
 }
 

--- a/util/die.go
+++ b/util/die.go
@@ -12,7 +12,9 @@ var red = color.New(color.FgRed).SprintFunc()
 
 //Die prints a message to stderr and exits the program with status 1.
 func Die(msg string) {
-	fmt.Fprintf(color.Error, "%s %s\n", red("ERROR"), msg)
+	// fmt.Fprintf(color.Error, "%s %s\n", red("ERROR"), msg)
+	// Swap the line above for the line below when (if) https://github.com/fatih/color/pull/87 gets merged
+	fmt.Fprintf(color.Output, "%s %s\n", red("ERROR"), msg)
 	os.Exit(1)
 }
 

--- a/util/die.go
+++ b/util/die.go
@@ -8,12 +8,11 @@ import (
 	"github.com/fatih/color"
 )
 
-var red = color.New(color.FgRed)
+var red = color.New(color.FgRed).SprintFunc()
 
 //Die prints a message to stderr and exits the program with status 1.
 func Die(msg string) {
-	_, _ = red.Fprint(os.Stderr, "ERROR ")
-	fmt.Fprintln(os.Stderr, msg)
+	fmt.Fprintf(os.Stderr, "%s %s\n", red("ERROR"), msg)
 	os.Exit(1)
 }
 

--- a/util/die.go
+++ b/util/die.go
@@ -12,7 +12,7 @@ var red = color.New(color.FgRed).SprintFunc()
 
 //Die prints a message to stderr and exits the program with status 1.
 func Die(msg string) {
-	fmt.Fprintf(os.Stderr, "%s %s\n", red("ERROR"), msg)
+	fmt.Fprintf(color.Error, "%s %s\n", red("ERROR"), msg)
 	os.Exit(1)
 }
 

--- a/util/files.go
+++ b/util/files.go
@@ -48,9 +48,11 @@ func ExpandGlobs(paths []string) (globexppaths []string, err error) {
 			LogWrite("Bad file pattern %s", p)
 			return nil, globerr
 		}
-		if exp != nil {
-			globexppaths = append(globexppaths, exp...)
+		if exp == nil {
+			LogWrite("ExpandGlobs: No files matched")
+			return nil, fmt.Errorf("No files matched %v", p)
 		}
+		globexppaths = append(globexppaths, exp...)
 	}
 	if len(globexppaths) == 0 {
 		// Invalid paths


### PR DESCRIPTION
This PR contains multiple bug fixes that primarily show up on Windows but affect the program generally. One of the issues was related to the file querying commands used by `gin ls`. Since these commands were planned to be converted to routines (see #122), I decided to include their conversion in this bugfix PR.

Changelog:
- Windows compatible colour output.
    - Note the comment in `util/die.go` regarding printing colour to Stderr. This will be enabled once the PR to the library is merged or implemented using colorable if it is rejected.
- AnnexWhereis, AnnexStatus, and GitLsFiles are now routines that communicate to their caller via channels (closes #122).
- ExpandGlobs will now fail if any single argument fails to match a file or directory name.
- New command `gin version` which aliases `gin --version` but also supports `--json` formatted output (`gin version --json`, closes #129).
- `gin upload` without an argument no longer warns about the lack of file specification. Previously the warning was meant to inform the user that changes (metadata) are uploaded but no new files. The behaviour of the command (what is updated in the index and what is uploaded) is now clear due to the output progress and success or failure messages printed by the command and the warning message would probably lead to confusion. Note also that the behaviour of the command has changed slightly. New content will be uploaded for files that are already being tracked.
