### PR TITLE
Cross-platform filepaths for config and log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ install:
   - go get github.com/dustin/go-humanize
   - go get github.com/fatih/color
   - go get github.com/hashicorp/go-version
+  - go get github.com/shibukawa/configdir
   # import path symlink for forks
   - if [ ! -d ${GOPATH}/src/github.com/G-Node/gin-cli ]; then ln -vs $(pwd) ${GOPATH}/src/github.com/G-Node/gin-cli; fi
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,6 +40,7 @@ build_script:
   - go get github.com/dustin/go-humanize
   - go get github.com/fatih/color
   - go get github.com/hashicorp/go-version
+  - go get github.com/shibukawa/configdir
   - go vet ./...
   - gofmt -s -l .
   - golint github.com/G-Node/gin-cli...

--- a/util/config.go
+++ b/util/config.go
@@ -52,10 +52,10 @@ func LoadConfig() error {
 	// configpaths is a prioritised list of locations for finding configuration files (priority is lowest to highest)
 	var configpaths []string
 
-	// Global xdg config path
-	xdgconfpath, err := ConfigPath(false)
+	// Global (user) config path
+	userconfigpath, err := ConfigPath(false)
 	if err == nil {
-		configpaths = append(configpaths, xdgconfpath)
+		configpaths = append(configpaths, userconfigpath)
 	}
 	// Second prio config files in the directory of the executable
 	// this is useful for portable packaging

--- a/util/config.go
+++ b/util/config.go
@@ -6,8 +6,11 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/shibukawa/configdir"
 	"github.com/spf13/viper"
 )
+
+var configDirs = configdir.New("g-node", "gin")
 
 type conf struct {
 	GinHost string
@@ -95,4 +98,30 @@ func LoadConfig() error {
 	LogWrite("%+v", Config)
 
 	return nil
+}
+
+// ConfigPath returns the configuration path where configuration files should be stored.
+func ConfigPath(create bool) (string, error) {
+	path := configDirs.QueryFolders(configdir.Global)[0].Path
+	var err error
+	if create {
+		err = os.MkdirAll(path, 0777)
+		if err != nil {
+			return "", fmt.Errorf("Error creating directory %s", path)
+		}
+	}
+	return path, err
+}
+
+// CachePath returns the path where gin cache files (logs) should be stored.
+func CachePath(create bool) (string, error) {
+	path := configDirs.QueryCacheFolder().Path
+	var err error
+	if create {
+		err = os.MkdirAll(path, 0777)
+		if err != nil {
+			return "", fmt.Errorf("Error creating directory %s", path)
+		}
+	}
+	return path, err
 }

--- a/util/config.go
+++ b/util/config.go
@@ -41,13 +41,14 @@ func moveOldFiles(newpath string) {
 		for _, file := range files {
 			oldfilename := file.Name()
 			oldfilepath := path.Join(oldpath, oldfilename)
-			fmt.Printf("Found %s\n", oldfilename)
 			newfilepath := path.Join(newpath, oldfilename)
 			for counter := 0; ; counter++ {
 				if _, operr := os.Stat(newfilepath); os.IsNotExist(operr) {
 					ConfigPath(true)
 					os.Rename(oldfilepath, newfilepath)
-					movemessages = append(movemessages, fmt.Sprintf("%s -> %s", oldfilepath, newfilepath))
+					msg := fmt.Sprintf("%s -> %s", oldfilepath, newfilepath)
+					movemessages = append(movemessages, msg)
+					LogWrite("Moving old config file: %s", msg)
 					break
 				} else {
 					// File already exists - rename to old and place alongside

--- a/util/config.go
+++ b/util/config.go
@@ -60,18 +60,18 @@ func moveOldFiles(newpath string) {
 	}
 
 	if len(movemessages) > 0 {
-		fmt.Println("NOTICE: Configuration directory changed.")
-		fmt.Println("The location of the configuration directory has changed.")
-		fmt.Print("Any existing config file, token, and key have been moved to the new location.\n\n")
+		fmt.Fprintln(os.Stderr, "NOTICE: Configuration directory changed.")
+		fmt.Fprintln(os.Stderr, "The location of the configuration directory has changed.")
+		fmt.Fprint(os.Stderr, "Any existing config file, token, and key have been moved to the new location.\n\n")
 		for _, msg := range movemessages {
-			fmt.Println("\t", msg)
+			fmt.Fprintln(os.Stderr, "\t", msg)
 		}
 		if moveconflicts {
-			fmt.Print("\nSome files were renamed to avoid overwriting new ones.\nYou may want to review the contents of the new configuration directory:\n\n")
-			fmt.Println("\t", newpath)
+			fmt.Fprint(os.Stderr, "\nSome files were renamed to avoid overwriting new ones.\nYou may want to review the contents of the new configuration directory:\n\n")
+			fmt.Fprintln(os.Stderr, "\t", newpath)
 		}
-		fmt.Println("\nThis message should not appear again.")
-		fmt.Println("END OF NOTICE")
+		fmt.Fprintln(os.Stderr, "\nThis message should not appear again.")
+		fmt.Fprintln(os.Stderr, "END OF NOTICE")
 
 		// Make sure old config directory is empty and remove
 		files, _ := ioutil.ReadDir(oldpath)

--- a/util/config.go
+++ b/util/config.go
@@ -78,6 +78,9 @@ func moveOldFiles(newpath string) {
 		if len(files) == 0 {
 			os.Remove(oldpath)
 		}
+		// Pause for the user to notice
+		fmt.Print("Press the Enter key to continue")
+		fmt.Scanln()
 	}
 }
 

--- a/util/log.go
+++ b/util/log.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"time"
 )
 
 var logfile *os.File
@@ -12,10 +13,18 @@ var logger *log.Logger
 
 // LogInit initialises the log file and logger.
 func LogInit() error {
+	// move old log and clear old log path
+	oldpath, _ := OldDataPath(false)
 
 	cachepath, err := CachePath(true)
 	if err != nil {
 		return err
+	}
+
+	if _, operr := os.Stat(oldpath); !os.IsNotExist(operr) {
+		isodate := time.Now().Format("2006-01-02")
+		movedest := path.Join(cachepath, fmt.Sprintf("old-logs-%s", isodate))
+		os.Rename(oldpath, movedest)
 	}
 
 	// TODO: Log rotation

--- a/util/log.go
+++ b/util/log.go
@@ -12,13 +12,14 @@ var logger *log.Logger
 
 // LogInit initialises the log file and logger.
 func LogInit() error {
-	dataPath, err := DataPath(true)
+
+	cachepath, err := CachePath(true)
 	if err != nil {
 		return err
 	}
 
 	// TODO: Log rotation
-	fullPath := path.Join(dataPath, "gin.log")
+	fullPath := path.Join(cachepath, "gin.log")
 	logfile, err = os.OpenFile(fullPath, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0666)
 	if err != nil {
 		return fmt.Errorf("Error creating file %s", fullPath)

--- a/util/xdg.go
+++ b/util/xdg.go
@@ -11,9 +11,8 @@ import (
 
 var suffix = "gin"
 
-// ConfigPath returns the configuration path where configuration files should be stored.
-func ConfigPath(create bool) (string, error) {
-	// TODO: Handle Windows paths
+// OldConfigPath is the old deprecated config path function. It's used to move the old configuration file to the new location.
+func OldConfigPath(create bool) (string, error) {
 	var path string
 	var err error
 
@@ -38,9 +37,8 @@ func ConfigPath(create bool) (string, error) {
 	return path, err
 }
 
-// DataPath returns the data path where gin data files (such as transaction logs) should be stored.
-func DataPath(create bool) (string, error) {
-	// TODO: Handle Windows paths
+// OldDataPath is the old deprecated data path function. It's used to move the old log file to the new location.
+func OldDataPath(create bool) (string, error) {
 	var path string
 	var err error
 


### PR DESCRIPTION
Using platform specific filepaths for config and log directories.
 
If files are found in the old locations, they are moved to the new ones. The user is notified of any changes. This will be removed in a future version.

For the config directory, all files are moved to the new location. If filename conflicts occur (e.g., a config or key file already exists in the new config directory), a suffix (.old.#) is appended and incremented accordingly and a message is included in the notice for the user.

For logs, the old directory (`$HOME/.local/share/gin/`) is moved into the new one as a subdirectory and renamed to `old-logs-YYYY-MM-DD`.

Closes #42 