### PR TITLE
JSON parsing bug fixes and login requirements

### DIFF
--- a/gin-client/gin.go
+++ b/gin-client/gin.go
@@ -39,11 +39,6 @@ func NewClient(host string) *Client {
 // GetUserKeys fetches the public keys that the user has added to the auth server.
 func (gincl *Client) GetUserKeys() ([]gogs.PublicKey, error) {
 	var keys []gogs.PublicKey
-	err := gincl.LoadToken()
-	if err != nil {
-		return keys, fmt.Errorf("This command requires login")
-	}
-
 	res, err := gincl.Get("/api/v1/user/keys")
 	if err != nil {
 		return keys, fmt.Errorf("Request for keys returned error")
@@ -109,10 +104,6 @@ func (gincl *Client) SearchAccount(query string) ([]gin.Account, error) {
 // AddKey adds the given key to the current user's authorised keys.
 // If force is enabled, any key which matches the new key's description will be overwritten.
 func (gincl *Client) AddKey(key, description string, force bool) error {
-	err := gincl.LoadToken()
-	if err != nil {
-		return err
-	}
 	newkey := gogs.PublicKey{Key: key, Title: description}
 
 	if force {
@@ -133,11 +124,6 @@ func (gincl *Client) AddKey(key, description string, force bool) error {
 
 // DeletePubKey removes the key that matches the given description (title) from the current user's authorised keys.
 func (gincl *Client) DeletePubKey(description string) error {
-	err := gincl.LoadToken()
-	if err != nil {
-		return err
-	}
-
 	keys, err := gincl.GetUserKeys()
 	if err != nil {
 		util.LogWrite("Error when getting user keys: %v", err)

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -437,6 +437,11 @@ func AnnexDrop(filepaths []string, dropchan chan<- RepoFileStatus) {
 		if rerr != nil {
 			break
 		}
+		line = strings.TrimSpace(line)
+		if len(line) == 0 {
+			// Empty line output. Ignore
+			continue
+		}
 		// Send file name
 		err = json.Unmarshal([]byte(line), &annexDropRes)
 		if err != nil {
@@ -621,6 +626,11 @@ func AnnexAdd(filepaths []string, addchan chan<- RepoFileStatus) {
 		if rerr != nil {
 			break
 		}
+		line = strings.TrimSpace(line)
+		if len(line) == 0 {
+			// Empty line output. Ignore
+			continue
+		}
 		// Send file name
 		err = json.Unmarshal([]byte(line), &annexAddRes)
 		if err != nil {
@@ -684,6 +694,11 @@ func AnnexWhereis(paths []string, wichan chan<- AnnexWhereisRes) {
 		if rerr != nil {
 			break
 		}
+		line = strings.TrimSpace(line)
+		if len(line) == 0 {
+			// Empty line output. Ignore
+			continue
+		}
 		jsonerr := json.Unmarshal([]byte(line), &info)
 		info.Err = jsonerr
 		wichan <- info
@@ -720,6 +735,11 @@ func AnnexStatus(paths []string, statuschan chan<- AnnexStatusRes) {
 		line, rerr := cmd.OutPipe.ReadLine()
 		if rerr != nil {
 			break
+		}
+		line = strings.TrimSpace(line)
+		if len(line) == 0 {
+			// Empty line output. Ignore
+			continue
 		}
 		jsonerr := json.Unmarshal([]byte(line), &status)
 		status.Err = jsonerr
@@ -842,6 +862,11 @@ func AnnexLock(filepaths []string, lockchan chan<- RepoFileStatus) {
 		if rerr != nil {
 			break
 		}
+		line = strings.TrimSpace(line)
+		if len(line) == 0 {
+			// Empty line output. Ignore
+			continue
+		}
 		// Send file name
 		err = json.Unmarshal([]byte(line), &annexAddRes)
 		if err != nil {
@@ -894,6 +919,11 @@ func AnnexUnlock(filepaths []string, unlockchan chan<- RepoFileStatus) {
 		line, rerr := cmd.OutPipe.ReadLine()
 		if rerr != nil {
 			break
+		}
+		line = strings.TrimSpace(line)
+		if len(line) == 0 {
+			// Empty line output. Ignore
+			continue
 		}
 		// Send file name
 		err = json.Unmarshal([]byte(line), &annexUnlockRes)
@@ -958,9 +988,13 @@ func AnnexInfo() (AnnexInfoRes, error) {
 		return AnnexInfoRes{}, fmt.Errorf("Error retrieving annex info")
 	}
 
-	// TODO: Buffered reading
 	stdout := cmd.OutPipe.ReadAll()
+	stdout = strings.TrimSpace(stdout)
 	var info AnnexInfoRes
+	if len(stdout) == 0 {
+		// empty output - error?
+		return info, nil
+	}
 	err = json.Unmarshal([]byte(stdout), &info)
 	return info, err
 }

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -91,11 +91,6 @@ func (gincl *Client) ListRepos(user string) ([]gogs.Repository, error) {
 // CreateRepo creates a repository on the server.
 func (gincl *Client) CreateRepo(name, description string) error {
 	util.LogWrite("Creating repository")
-	err := gincl.LoadToken()
-	if err != nil {
-		return fmt.Errorf("[Create repository] This action requires login")
-	}
-
 	newrepo := gogs.Repository{Name: name, Description: description, Private: true}
 	util.LogWrite("Name: %s :: Description: %s", name, description)
 	res, err := gincl.Post("/api/v1/user/repos", newrepo)
@@ -112,11 +107,6 @@ func (gincl *Client) CreateRepo(name, description string) error {
 // DelRepo deletes a repository from the server.
 func (gincl *Client) DelRepo(name string) error {
 	util.LogWrite("Deleting repository")
-	err := gincl.LoadToken()
-	if err != nil {
-		return fmt.Errorf("[Delete repository] This action requires login")
-	}
-
 	res, err := gincl.Delete(fmt.Sprintf("/api/v1/repos/%s", name))
 	if err != nil {
 		return err
@@ -317,12 +307,6 @@ func (gincl *Client) Download(content bool, downloadchan chan<- RepoFileStatus) 
 func (gincl *Client) CloneRepo(repoPath string, clonechan chan<- RepoFileStatus) {
 	defer close(clonechan)
 	util.LogWrite("CloneRepo")
-	err := gincl.LoadToken()
-	if err != nil {
-		clonechan <- RepoFileStatus{Err: err}
-		return
-	}
-
 	clonestatus := make(chan RepoFileStatus)
 	go gincl.Clone(repoPath, clonestatus)
 	for stat := range clonestatus {

--- a/main.go
+++ b/main.go
@@ -31,12 +31,14 @@ var red = color.New(color.FgRed).SprintFunc()
 // requirelogin prompts for login if the user is not already logged in.
 // It only checks if a local token exists and does not confirm its validity with the server.
 // The function should be called at the start of any command that requires being logged in to run.
-func requirelogin(gincl *ginclient.Client) {
+func requirelogin(gincl *ginclient.Client, prompt bool) {
 	err := gincl.LoadToken()
-	if err != nil {
-		login([]string{})
+	if prompt {
+		if err != nil {
+			login([]string{})
+		}
+		err = gincl.LoadToken()
 	}
-	err = gincl.LoadToken()
 	util.CheckError(err)
 }
 
@@ -100,7 +102,7 @@ func logout(args []string) {
 
 func createRepo(args []string) {
 	gincl := ginclient.NewClient(util.Config.GinHost)
-	requirelogin(gincl)
+	requirelogin(gincl, true)
 
 	var repoName, repoDesc string
 	var here bool
@@ -145,7 +147,7 @@ func createRepo(args []string) {
 
 func deleteRepo(args []string) {
 	gincl := ginclient.NewClient(util.Config.GinHost)
-	requirelogin(gincl)
+	requirelogin(gincl, true)
 	var repostr, confirmation string
 
 	if len(args) == 0 {
@@ -185,9 +187,6 @@ func isValidRepoPath(path string) bool {
 }
 
 func getRepo(args []string) {
-	gincl := ginclient.NewClient(util.Config.GinHost)
-	requirelogin(gincl)
-
 	var jsonout bool
 	for idx, arg := range args {
 		if arg == "--json" {
@@ -196,6 +195,8 @@ func getRepo(args []string) {
 			break
 		}
 	}
+	gincl := ginclient.NewClient(util.Config.GinHost)
+	requirelogin(gincl, !jsonout)
 
 	var repostr string
 	if len(args) != 1 {
@@ -375,8 +376,6 @@ func printProgress(statuschan <-chan ginclient.RepoFileStatus, jsonout bool) {
 }
 
 func upload(args []string) {
-	gincl := ginclient.NewClient(util.Config.GinHost)
-	requirelogin(gincl)
 	var jsonout bool
 	for idx, arg := range args {
 		if arg == "--json" {
@@ -385,6 +384,8 @@ func upload(args []string) {
 			break
 		}
 	}
+	gincl := ginclient.NewClient(util.Config.GinHost)
+	requirelogin(gincl, !jsonout)
 	if !ginclient.IsRepo() {
 		util.Die("This command must be run from inside a gin repository.")
 	}
@@ -401,8 +402,6 @@ func upload(args []string) {
 }
 
 func download(args []string) {
-	gincl := ginclient.NewClient(util.Config.GinHost)
-	requirelogin(gincl)
 	var jsonout bool
 	for idx, arg := range args {
 		if arg == "--json" {
@@ -411,6 +410,8 @@ func download(args []string) {
 			break
 		}
 	}
+	gincl := ginclient.NewClient(util.Config.GinHost)
+	requirelogin(gincl, !jsonout)
 	if !ginclient.IsRepo() {
 		util.Die("This command must be run from inside a gin repository.")
 	}
@@ -440,8 +441,6 @@ func download(args []string) {
 }
 
 func getContent(args []string) {
-	gincl := ginclient.NewClient(util.Config.GinHost)
-	requirelogin(gincl)
 	var jsonout bool
 	for idx, arg := range args {
 		if arg == "--json" {
@@ -450,6 +449,8 @@ func getContent(args []string) {
 			break
 		}
 	}
+	gincl := ginclient.NewClient(util.Config.GinHost)
+	requirelogin(gincl, !jsonout)
 	if !ginclient.IsRepo() {
 		util.Die("This command must be run from inside a gin repository.")
 	}
@@ -462,8 +463,6 @@ func getContent(args []string) {
 }
 
 func remove(args []string) {
-	gincl := ginclient.NewClient(util.Config.GinHost)
-	requirelogin(gincl)
 	var jsonout bool
 	for idx, arg := range args {
 		if arg == "--json" {
@@ -472,6 +471,8 @@ func remove(args []string) {
 			break
 		}
 	}
+	gincl := ginclient.NewClient(util.Config.GinHost)
+	requirelogin(gincl, !jsonout)
 	if !ginclient.IsRepo() {
 		util.Die("This command must be run from inside a gin repository.")
 	}
@@ -495,7 +496,7 @@ func keys(args []string) {
 
 func printKeys(args []string) {
 	gincl := ginclient.NewClient(util.Config.GinHost)
-	requirelogin(gincl)
+	requirelogin(gincl, true)
 	printFull := false
 	if len(args) > 1 {
 		util.Die(usage)
@@ -535,7 +536,7 @@ func printKeys(args []string) {
 
 func addKey(args []string) {
 	gincl := ginclient.NewClient(util.Config.GinHost)
-	requirelogin(gincl)
+	requirelogin(gincl, true)
 	if len(args) != 2 {
 		util.Die(usage)
 	}
@@ -599,7 +600,7 @@ func repos(args []string) {
 		util.Die(usage)
 	}
 	gincl := ginclient.NewClient(util.Config.GinHost)
-	requirelogin(gincl)
+	requirelogin(gincl, true)
 	var arg string
 	if len(args) == 0 {
 		arg = gincl.Username

--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func createRepo(args []string) {
 	err = gincl.CreateRepo(repoName, repoDesc)
 	// Parse error message and make error nicer
 	util.CheckError(err)
-	fmt.Println(green("OK"))
+	fmt.Fprintln(color.Output, green("OK"))
 
 	if here {
 		// Init cwd

--- a/main.go
+++ b/main.go
@@ -36,6 +36,8 @@ func requirelogin(gincl *ginclient.Client) {
 	if err != nil {
 		login([]string{})
 	}
+	err = gincl.LoadToken()
+	util.CheckError(err)
 }
 
 // login requests credentials, performs login with auth server, and stores the token.

--- a/version
+++ b/version
@@ -1,1 +1,1 @@
-version=0.12
+version=0.12dev


### PR DESCRIPTION
- Fix missed coloured output that wasn't writing to the colour writer and was therefore not printing properly on Windows.
- Skip empty lines in annex json output: Some annex commands print an extra empty line at the end of the output (possibly also at the start?) when json output is requested. We now check every line's length (after trimming) to make sure it's not an extra blank line before attempting to unmarshal.
- Prompts for login when the user attempts to run a command that requires authorisation and is not already logged in. Fixes #117
    - The above does not occur when json output is requested.