### PR TITLE
Local config fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ install:
   - go get github.com/G-Node/gin-repo/wire
   - go get golang.org/x/crypto/ssh
   - go get github.com/gogits/go-gogs-client
-  - go get github.com/dustin/go-humanize
   - go get github.com/fatih/color
   - go get github.com/hashicorp/go-version
   - go get github.com/shibukawa/configdir

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,6 @@ build_script:
   - go get github.com/G-Node/gin-repo/wire
   - go get golang.org/x/crypto/ssh
   - go get github.com/gogits/go-gogs-client
-  - go get github.com/dustin/go-humanize
   - go get github.com/fatih/color
   - go get github.com/hashicorp/go-version
   - go get github.com/shibukawa/configdir

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -600,6 +600,9 @@ func AnnexAdd(filepaths []string, addchan chan<- RepoFileStatus) {
 		exclargs = append(exclargs, arg)
 	}
 
+	// explicitly exclude config file
+	exclargs = append(exclargs, "--exclude=config.yml")
+
 	if len(exclargs) > 0 {
 		cmdargs = append(cmdargs, exclargs...)
 	}

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -4,14 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"math"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/G-Node/gin-cli/util"
 	"github.com/G-Node/gin-cli/web"
-	"github.com/dustin/go-humanize"
 )
 
 // Workingdir sets the directory for shell commands
@@ -1073,49 +1070,6 @@ func RunAnnexCommand(args ...string) (util.GinCmd, error) {
 	util.LogWrite("Running shell command (Dir: %s): %s", Workingdir, strings.Join(cmd.Args, " "))
 	err := cmd.Start()
 	return cmd, err
-}
-
-// selectGitOrAnnex splits a list of paths into two: the first to be added to git proper and the second to be added to git annex.
-// The selection is made based on the file type (extension) and size, both of which are configurable.
-func selectGitOrAnnex(paths []string) (gitpaths []string, annexpaths []string) {
-	minsize, err := humanize.ParseBytes(util.Config.Annex.MinSize)
-	if err != nil {
-		util.LogWrite("Invalid minsize string found in config. Defaulting to 10 MiB")
-		minsize, _ = humanize.ParseBytes("10 MiB")
-	}
-	excludes := util.Config.Annex.Exclude
-
-	util.LogWrite("Using minsize %v", minsize)
-	util.LogWrite("Using exclude list %v", excludes)
-
-	var fsize uint64
-	for _, p := range paths {
-		fstat, err := os.Stat(p)
-		if err != nil {
-			util.LogWrite("Cannot stat file [%s]: %s", p, err.Error())
-			fsize = math.MaxUint64
-		} else {
-			fsize = uint64(fstat.Size())
-		}
-		if fsize < minsize {
-			for _, pattern := range excludes {
-				match, err := filepath.Match(pattern, p)
-				if match {
-					if err != nil {
-						util.LogWrite("Bad pattern found in annex exclusion list %s", excludes)
-						continue
-					}
-					gitpaths = append(gitpaths, p)
-					util.LogWrite("Adding %v to git paths", p)
-					continue
-				}
-			}
-		}
-		util.LogWrite("Adding %v to annex paths", p)
-		annexpaths = append(annexpaths, p)
-	}
-
-	return
 }
 
 // GetAnnexVersion returns the version string of the system's git-annex.

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -91,7 +91,7 @@ func (gincl *Client) ListRepos(user string) ([]gogs.Repository, error) {
 // CreateRepo creates a repository on the server.
 func (gincl *Client) CreateRepo(name, description string) error {
 	util.LogWrite("Creating repository")
-	newrepo := gogs.Repository{Name: name, Description: description, Private: true}
+	newrepo := gogs.CreateRepoOption{Name: name, Description: description, Private: true}
 	util.LogWrite("Name: %s :: Description: %s", name, description)
 	res, err := gincl.Post("/api/v1/user/repos", newrepo)
 	if err != nil {

--- a/util/config.go
+++ b/util/config.go
@@ -120,11 +120,6 @@ func LoadConfig() error {
 		execpath, _ := path.Split(execloc)
 		configpaths = append(configpaths, execpath)
 	}
-	// Highest priority config file is in the repository root
-	reporoot, err := FindRepoRoot(".")
-	if err == nil {
-		configpaths = append(configpaths, reporoot)
-	}
 
 	configFileName := "config.yml"
 	for _, path := range configpaths {
@@ -137,8 +132,6 @@ func LoadConfig() error {
 	Config.Bin.Git = viper.GetString("bin.git")
 	Config.Bin.GitAnnex = viper.GetString("bin.gitannex")
 	Config.Bin.SSH = viper.GetString("bin.ssh")
-	Config.Annex.Exclude = viper.GetStringSlice("annex.exclude")
-	Config.Annex.MinSize = viper.GetString("annex.minsize")
 
 	ginAddress := viper.GetString("gin.address")
 	ginPort := viper.GetInt("gin.port")
@@ -149,6 +142,17 @@ func LoadConfig() error {
 	Config.GitHost = fmt.Sprintf("%s:%d", gitAddress, gitPort)
 
 	Config.GitUser = viper.GetString("git.user")
+
+	// Highest priority config file is in the repository root for excludes
+	reporoot, err := FindRepoRoot(".")
+	if err == nil {
+		confPath := filepath.Join(reporoot, configFileName)
+		viper.SetConfigFile(confPath)
+		_ = viper.MergeInConfig()
+	}
+
+	Config.Annex.Exclude = viper.GetStringSlice("annex.exclude")
+	Config.Annex.MinSize = viper.GetString("annex.minsize")
 
 	LogWrite("Configuration values")
 	LogWrite("%+v", Config)


### PR DESCRIPTION
- Does not allow local (in-repo) config file to specify binaries or servers. Local config file can only be used to specify annex excludes. Any other option is ignored and falls back to the global user configuration, or the defaults.
- The in-repo config file is never checked into annex, regardless of the minsize settings (see #136).
- Minor fixes and cleanup.