### PR TITLE
Fix repository listing command

### DIFF
--- a/doc/weberrors.md
+++ b/doc/weberrors.md
@@ -43,12 +43,13 @@ Shouldn't happen. Failsafe for bad routing? Will ignore in client.
 - 404 Not Found: User or Repository (path) does not exist.
 
 
-## GET `/api/v1/user/repos`
+## GET `/api/v1/users/<user>/repos`
 
 **Description**: Retrieve a list of user repositories.
 
 ### Status codes
 - 200 OK: Success.
+- 404 Not Found: User does not exist.
 
 
 ## DELETE `/api/v1/repos/<user>/<repository>`

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -84,11 +84,13 @@ func (gincl *Client) ListRepos(user string) ([]gogs.Repository, error) {
 	var repoList []gogs.Repository
 	var res *http.Response
 	var err error
-	res, err = gincl.Get("/api/v1/user/repos")
+	res, err = gincl.Get(fmt.Sprintf("/api/v1/users/%s/repos", user))
 	if err != nil {
 		return nil, err // return error from Get() directly
 	}
 	switch code := res.StatusCode; {
+	case code == http.StatusNotFound:
+		return nil, ginerror{UError: res.Status, Origin: fn, Description: fmt.Sprintf("user '%s' does not exist", user)}
 	case code == http.StatusUnauthorized:
 		return nil, ginerror{UError: res.Status, Origin: fn, Description: "authorisation failed"}
 	case code == http.StatusInternalServerError:

--- a/help.go
+++ b/help.go
@@ -310,8 +310,8 @@ DESCRIPTION
 
 	Remove the content of local files. This command will not remove the content
 	of files that have not been already uploaded to a remote repository, even
-	if the user specifies such files exclusively.  Removed content can be
-	retrieved from the server by using the 'gin download' command.  With no
+	if the user specifies such files exclusively. Removed content can be
+	retrieved from the server by using the 'gin download' command. With no
 	arguments, removes the content of all files under the current working
 	directory, as long as they have been safely uploaded to a remote
 	repository.
@@ -329,26 +329,17 @@ ARGUMENTS
 const reposHelp = `USAGE
 
 	gin repos [<username>]
-	gin repos -s, --shared-with-me
-	gin repos -p, --public
 
 
 DESCRIPTION
 
 	List repositories on the server that provide read access. If no argument is
-	provided, it will list the repositories owned by the logged in user. If no
-	user is logged in, it will list all public repositories.
+	provided, it will list the repositories owned by the logged in user.
 
 ARGUMENTS
 
-	-s, --shared-with-me
-		List all repositories shared with the logged in user.
-
-	-p, --public
-		List all public repositories.
-
 	<username>
-		The name of the user whose repositories should be listed.  This
+		The name of the user whose repositories should be listed. This
 		consists of public repositories and repositories shared with the logged
 		in user.
 `

--- a/help.go
+++ b/help.go
@@ -24,7 +24,7 @@ Commands:
 	get            <repopath>
 		Retrieve (clone) a repository from the remote server
 
-	ls             [-s, --short, --json] [<filenames>]
+	ls             [-s | --short | --json] [<filenames>]
 		List the sync status of files in a local repository
 
 	unlock         [<filenames>]
@@ -51,13 +51,16 @@ Commands:
 	rmc            [<filenames>]
 		Synonym for remove-content
 
+	repos          [--shared | --all]
+		List remote repositories
+
 	repos          [<username>]
-		List available remote repositories
+		List available remote repositories for specific user
 
 	info           [<username>]
 		Print user information
 
-	keys           [-v, --verbose]
+	keys           [-v | --verbose]
 		List the keys associated with the logged in user
 
 	keys           --add <filename>
@@ -339,8 +342,8 @@ ARGUMENTS
 
 const reposHelp = `USAGE
 
+	gin repos [--shared | --all]
 	gin repos [<username>]
-
 
 DESCRIPTION
 
@@ -348,6 +351,13 @@ DESCRIPTION
 	provided, it will list the repositories owned by the logged in user.
 
 ARGUMENTS
+
+	--shared
+		List all repositories that the user is a member of (excluding own
+		repositories).
+
+	--all
+		List all repositories accessible by the logged in user.
 
 	<username>
 		The name of the user whose repositories should be listed. This

--- a/help.go
+++ b/help.go
@@ -18,7 +18,7 @@ Commands:
 	logout
 		Logout from the GIN services
 
-	create         [<name>] [<description>]
+	create         [--here] [<name>] [<description>]
 		Create a repository on the remote server and clone it
 
 	get            <repopath>
@@ -99,13 +99,20 @@ DESCRIPTION
 
 const createHelp = `USAGE
 
-	gin create [<name>] [<description>]
+	gin create [--here] [<name>] [<description>]
 
 DESCRIPTION
 
 	Create a new repository on the GIN server and clone it locally.
 
 ARGUMENTS
+
+	--here
+		Create the local repository clone in the current working directory.
+		By default, repositories are cloned to a directory that matches the
+		repository name inside the working directory. Specifying this option
+		will set up the current working directory as a local clone for the new
+		repository.
 
 	<name>
 		The name of the repository. If no <name> is provided, you will be
@@ -131,6 +138,10 @@ EXAMPLES
 	Create a repository named 'example' with no description
 
 		$ gin create example
+	
+	Create a repository named 'mydata' and initialise the current working
+	directory as the local clone
+		$ gin create --here mydata
 `
 
 const getHelp = `USAGE

--- a/main.go
+++ b/main.go
@@ -597,33 +597,19 @@ func repos(args []string) {
 	}
 	gincl := ginclient.NewClient(util.Config.GinHost)
 	requirelogin(gincl, true)
-	var arg string
-	if len(args) == 0 {
-		arg = gincl.Username
-	} else {
+	arg := gincl.Username
+	if len(args) == 1 {
 		arg = args[0]
-		if arg == "-p" {
-			arg = "--public"
-		} else if arg == "-s" {
-			arg = "--shared-with-me"
-		}
 	}
 	repolist, err := gincl.ListRepos(arg)
 	util.CheckError(err)
 
-	if arg == "" || arg == "--public" {
-		fmt.Print("Listing all public repositories:\n\n")
-	} else if arg == "--shared-with-me" {
-		fmt.Print("Listing all accessible shared repositories:\n\n")
+	if arg == gincl.Username {
+		fmt.Print("Listing your repositories:\n\n")
 	} else {
-		if gincl.Username == "" {
-			fmt.Printf("You are not logged in.\nListing only public repositories owned by '%s':\n\n", arg)
-		} else if arg == gincl.Username {
-			fmt.Print("Listing your repositories:\n\n")
-		} else {
-			fmt.Printf("Listing accessible repositories owned by '%s':\n\n", arg)
-		}
+		fmt.Printf("Listing accessible repositories owned by '%s':\n\n", arg)
 	}
+
 	for idx, repoInfo := range repolist {
 		fmt.Printf("%d: %s\n", idx+1, repoInfo.FullName)
 		fmt.Printf("Description: %s\n", strings.Trim(repoInfo.Description, "\n"))

--- a/web/web.go
+++ b/web/web.go
@@ -58,7 +58,6 @@ func (cl *Client) Get(address string) (*http.Response, error) {
 	util.LogWrite("Performing GET: %s", req.URL)
 	if cl.Token != "" {
 		req.Header.Set("Authorization", fmt.Sprintf("token %s", cl.Token))
-		util.LogWrite("Token: %s", cl.Token)
 	}
 	resp, err := cl.web.Do(req)
 	if err != nil {


### PR DESCRIPTION
This PR fixes the repository listing command and adds support for outputting the results in JSON.

## Repository listing commands

Public repositories that the current user is not a member of are never listed in the following results.

The new command now has four variants:
1. `gin repos` is the default invocation and only lists the user's own personal repositories.
2. `gin repos --shared` lists the repositories that the user is a member of excluding the user's own repositories.
3. `gin repos --all` lists all repositories the current logged in user has access to (own repositories + repositories the user is a member of).
4. `gin repos <username>` lists all the repositories owned by `<username>` that the current logged in user can access.

Variant 3 is the union of 1 and 2.

The repo listing function now uses the same API endpoint for own and other user repository
listings.

The help text has been updated accordingly.

## Information in listing

More information has been added to repository listings. Previously, the name and description were printed, and an information line about the repository being publicly visible when appropriate.
The repository's location (GIN URL) and website have now been added to the output.

## JSON repo listing

The repos command now also supports printing the results in JSON format.

## Arg parsing

Small changes in arg parsing for flags (e.g., `--json`, `--all`, and `--shared`). Arg parsing is getting a little messy and it will get a full rewrite at some point.