### PR TITLE
Remove file status output

### DIFF
--- a/version
+++ b/version
@@ -1,1 +1,1 @@
-version=0.13
+version=0.14dev


### PR DESCRIPTION
Print 'Removing' when deleting files.
Previously, it would print "Adding remove 'filename'", which was weird and wrong.

Fixes #155.