### PR TITLE
Strict host key checking for git/ssh commands

### DIFF
--- a/gin-client/gin.go
+++ b/gin-client/gin.go
@@ -228,7 +228,16 @@ func (gincl *Client) Login(username, password, clientID string) error {
 		return fmt.Errorf("Error while storing token: %s", err.Error())
 	}
 
+	MakeHostsFile()
+
 	return gincl.MakeSessionKey()
+}
+
+// MakeHostsFile creates a known_hosts file in the config directory based on the server configuration for host key checking.
+func MakeHostsFile() {
+	hostkeyfile := util.HostKeyPath()
+	_ = ioutil.WriteFile(hostkeyfile, []byte(util.Config.GitHostKey), 0600)
+	return
 }
 
 // Logout logs out the currently logged in user in 3 steps:

--- a/util/config.go
+++ b/util/config.go
@@ -14,10 +14,11 @@ import (
 var configDirs = configdir.New("g-node", "gin")
 
 type conf struct {
-	GinHost string
-	GitHost string
-	GitUser string
-	Bin     struct {
+	GinHost    string
+	GitHost    string
+	GitUser    string
+	GitHostKey string
+	Bin        struct {
 		Git      string
 		GitAnnex string
 		SSH      string
@@ -103,6 +104,7 @@ func LoadConfig() error {
 	viper.SetDefault("git.address", "gin.g-node.org")
 	viper.SetDefault("git.port", "22")
 	viper.SetDefault("git.user", "git")
+	viper.SetDefault("git.hostkey", "gin.g-node.org,141.84.41.216 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBE5IBgKP3nUryEFaACwY4N3jlqDx8Qw1xAxU2Xpt5V0p9RNefNnedVmnIBV6lA3n+9kT1OSbyqA/+SgsQ57nHo0=")
 
 	// annex filters
 	viper.SetDefault("annex.minsize", "10M")
@@ -127,8 +129,8 @@ func LoadConfig() error {
 	gitAddress := viper.GetString("git.address")
 	gitPort := viper.GetInt("git.port")
 	Config.GitHost = fmt.Sprintf("%s:%d", gitAddress, gitPort)
-
 	Config.GitUser = viper.GetString("git.user")
+	Config.GitHostKey = viper.GetString("git.hostkey")
 
 	// Config file in the repository root (annex excludes and size threshold only)
 	reporoot, err := FindRepoRoot(".")

--- a/util/keygen.go
+++ b/util/keygen.go
@@ -64,6 +64,17 @@ func PrivKeyPath(user string) string {
 	return filepath.Join(configpath, fmt.Sprintf("%s.key", user))
 }
 
+// HostKeyPath returns the full path for the location of the gin host key file.
+func HostKeyPath() string {
+	configpath, err := ConfigPath(false)
+	if err != nil {
+		LogWrite("Error getting user's config path. Can't create host key file.")
+		LogWrite(err.Error())
+		return ""
+	}
+	return filepath.Join(configpath, "ginhostkey")
+}
+
 // GitSSHEnv returns the value that should be set for the GIT_SSH_COMMAND environment variable
 // in order to use the user's private key.
 func GitSSHEnv(user string) string {

--- a/util/keygen.go
+++ b/util/keygen.go
@@ -86,7 +86,7 @@ func GitSSHEnv(user string) string {
 	keyfile := PrivKeyPath(user)
 	keyfile = strings.Replace(keyfile, ossep, "/", -1)
 	keyfile = strings.Replace(keyfile, " ", "\\ ", -1)
-	gitSSHCmd := fmt.Sprintf("GIT_SSH_COMMAND=%s -i %s -o IdentitiesOnly=yes -o StrictHostKeyChecking=no", sshbin, keyfile)
+	gitSSHCmd := fmt.Sprintf("GIT_SSH_COMMAND=%s -i %s -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=%s", sshbin, keyfile, HostKeyPath())
 	LogWrite("env %s", gitSSHCmd)
 	return gitSSHCmd
 }


### PR DESCRIPTION
This PR enables strict host key checking for git/ssh commands.

the `GIT_SSH_COMMAND` variable now specifies an alternate hosts key file that lives in the user's config directory. This file is created on login and the key can be specified in the configuration along with the server parameters (address and port). By default, the host key of the official GIN server is written.

Resolves #48.