### PR TITLE
Allow running git and annex proxies without token

### DIFF
--- a/main.go
+++ b/main.go
@@ -702,8 +702,7 @@ func checkAnnexVersion() {
 
 func gitrun(args []string) {
 	gincl := ginclient.NewClient(util.Config.GinHost)
-	err := gincl.LoadToken()
-	util.CheckError(err)
+	_ = gincl.LoadToken() // OK to run without token
 
 	cmd, err := ginclient.RunGitCommand(args...)
 	util.CheckError(err)
@@ -723,8 +722,7 @@ func gitrun(args []string) {
 
 func annexrun(args []string) {
 	gincl := ginclient.NewClient(util.Config.GinHost)
-	err := gincl.LoadToken()
-	util.CheckError(err)
+	_ = gincl.LoadToken() // OK to run without token
 	cmd, err := ginclient.RunAnnexCommand(args...)
 	util.CheckError(err)
 	var line string


### PR DESCRIPTION
For many git and annex commands, the user doesn't need to be logged in and especially does not need a web token. This PR allows running `gin git ...` and `gin annex ...` proxy commands without being logged in.