### PR TITLE
Disable windows symlinks

### DIFF
--- a/gin-client/gin.go
+++ b/gin-client/gin.go
@@ -236,7 +236,8 @@ func (gincl *Client) Login(username, password, clientID string) error {
 // MakeHostsFile creates a known_hosts file in the config directory based on the server configuration for host key checking.
 func MakeHostsFile() {
 	hostkeyfile := util.HostKeyPath()
-	_ = ioutil.WriteFile(hostkeyfile, []byte(util.Config.GitHostKey), 0600)
+	ginhostkey := fmt.Sprintln(util.Config.GitHostKey)
+	_ = ioutil.WriteFile(hostkeyfile, []byte(ginhostkey), 0600)
 	return
 }
 

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -397,6 +398,7 @@ func (gincl *Client) InitDir(repoPath string, initchan chan<- RepoFileStatus) {
 		}
 		Workingdir = "."
 	}
+
 	stat.Progress = "10%"
 	initchan <- stat
 
@@ -423,6 +425,13 @@ func (gincl *Client) InitDir(repoPath string, initchan chan<- RepoFileStatus) {
 		}
 	}
 	stat.Progress = "20%"
+
+	if runtime.GOOS == "windows" {
+		// force disable symlinks even if user can create them
+		// see https://git-annex.branchable.com/bugs/Symlink_support_on_Windows_10_Creators_Update_with_Developer_Mode/
+		cmd, _ := RunGitCommand("config", "--local", "core.symlinks", "false")
+		cmd.Wait()
+	}
 
 	// If there are no commits, create the initial commit.
 	// While this isn't strictly necessary, it sets the active remote with commits that makes it easier to work with.

--- a/util/keygen.go
+++ b/util/keygen.go
@@ -78,15 +78,17 @@ func HostKeyPath() string {
 // GitSSHEnv returns the value that should be set for the GIT_SSH_COMMAND environment variable
 // in order to use the user's private key.
 func GitSSHEnv(user string) string {
-	sshbin := Config.Bin.SSH
 	// Windows git seems to require Unix paths for the SSH command -- this is dirty but works
 	ossep := string(os.PathSeparator)
-	sshbin = strings.Replace(sshbin, ossep, "/", -1)
-	sshbin = strings.Replace(sshbin, " ", "\\ ", -1)
-	keyfile := PrivKeyPath(user)
-	keyfile = strings.Replace(keyfile, ossep, "/", -1)
-	keyfile = strings.Replace(keyfile, " ", "\\ ", -1)
-	gitSSHCmd := fmt.Sprintf("GIT_SSH_COMMAND=%s -i %s -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=%s", sshbin, keyfile, HostKeyPath())
+	fixpathsep := func(p string) string {
+		p = strings.Replace(p, ossep, "/", -1)
+		p = strings.Replace(p, " ", "\\ ", -1)
+		return p
+	}
+	sshbin := fixpathsep(Config.Bin.SSH)
+	keyfile := fixpathsep(PrivKeyPath(user))
+	hostkeyfile := fixpathsep(HostKeyPath())
+	gitSSHCmd := fmt.Sprintf("GIT_SSH_COMMAND=%s -i %s -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=%s", sshbin, keyfile, hostkeyfile)
 	LogWrite("env %s", gitSSHCmd)
 	return gitSSHCmd
 }


### PR DESCRIPTION
This is a workaround for an issue with git-annex that appears on Windows when the user is allowed to create symbolic links.

The following page describes the issue: https://git-annex.branchable.com/bugs/Symlink_support_on_Windows_10_Creators_Update_with_Developer_Mode/?updated

In short, if a user can create symbolic links, git detects this and enables symlinks. Git annex does not expect this and doesn't work properly.

With this PR, if the client is running on Windows, it will perform a `git clone` with symlinks explicitly disables and then disable them for the repository locally after the clone is initialised.