### PR TITLE
No commit on gin download

### DIFF
--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -214,7 +214,7 @@ func AnnexInit(description string) error {
 // (git annex sync --no-push [--content])
 func AnnexPull(content bool, pullchan chan<- RepoFileStatus) {
 	defer close(pullchan)
-	args := []string{"sync", "--no-push"}
+	args := []string{"sync", "--no-push", "--no-commit"}
 	if content {
 		args = append(args, "--content")
 	}

--- a/scripts/gin-shell.bat
+++ b/scripts/gin-shell.bat
@@ -7,10 +7,10 @@
 ::
 :: The following actions are taken:
 ::
-:: - The location of gin.exe is appended to the PATH variable so it can be
+:: - The location of gin.exe is prepended to the PATH variable so it can be
 :: used from the shell.
 :: - The locations of the git, annex, and utility binaries (SSH, rsync, etc)
-:: are appended to the PATH variable.
+:: are prepended to the PATH variable.
 :: - A shell is started in the user's home directory.
 
 echo off


### PR DESCRIPTION
AnnexPull is performed by doing an `annex sync --no-push`, but if `--no-commit` is not specified, local changes are added to a new commit.