### PR TITLE
Error message and output improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
     - docker
 
 go:
-  - 1.9
+  - "1.10.x"
   - tip
 
 matrix:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# full pkg name
+PKG = github.com/G-Node/gin-cli
+
 # Binary
 GIN = gin
 
@@ -15,7 +18,7 @@ VERNUM = $(shell grep -o -E '[0-9.]+(dev|beta){0,1}' version)
 ncommits = $(shell git rev-list --count HEAD)
 BUILDNUM = $(shell printf '%06d' $(ncommits))
 COMMITHASH = $(shell git rev-parse HEAD)
-LDFLAGS = -ldflags "-X main.gincliversion=$(VERNUM) -X main.build=$(BUILDNUM) -X main.commit=$(COMMITHASH)"
+LDFLAGS = -ldflags=$(PKG)="-X main.gincliversion=$(VERNUM) -X main.build=$(BUILDNUM) -X main.commit=$(COMMITHASH)"
 
 SOURCES = $(shell find . -type f -iname "*.go")
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ BUILDLOC = build
 # Install location
 INSTLOC = $(GOPATH)/bin
 
+# tests submodule bin
+TESTBINLOC = tests/bin
+
 # Build flags
 VERNUM = $(shell grep -o -E '[0-9.]+(dev|beta){0,1}' version)
 ncommits = $(shell git rev-list --count HEAD)
@@ -24,6 +27,9 @@ allplatforms: linux windows macos
 
 install: gin
 	install $(BUILDLOC)/$(GIN) $(INSTLOC)/$(GIN)
+
+installtest: gin
+	install $(BUILDLOC)/$(GIN) $(TESTBINLOC)/$(GIN)
 
 linux: $(BUILDLOC)/linux/$(GIN)
 

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -226,6 +226,12 @@ func AnnexPull() error {
 		util.LogWrite("Error during AnnexPull.")
 		util.LogWrite("[Error]: %v", err)
 		cmd.LogStdOutErr()
+		stderr := cmd.ErrPipe.ReadAll()
+		if strings.Contains(stderr, "Permission denied") {
+			return fmt.Errorf("download failed: permission denied")
+		} else if strings.Contains(stderr, "Host key verification failed") {
+			return fmt.Errorf("download failed: bad host key - check server configuration")
+		}
 	}
 	return err
 }

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -247,6 +247,9 @@ func AnnexPull(content bool, pullchan chan<- RepoFileStatus) {
 			status.Progress = words[1]
 			status.Rate = words[2]
 			pullchan <- status
+		} else if strings.HasSuffix(line, "failed") {
+			status.Err = fmt.Errorf("failed")
+			pullchan <- status
 		}
 	}
 

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -172,6 +172,10 @@ func (gincl *Client) Clone(repoPath string, clonechan chan<- RepoFileStatus) {
 			gerr.Description = fmt.Sprintf("Repository download failed.\n"+
 				"'%s' already exists in the current directory and is not empty.", repoName)
 			clonechan <- RepoFileStatus{Err: gerr}
+
+		} else if strings.Contains(stderr, "Host key verification failed") {
+			gerr.Description = "Server key does not match known/configured host key."
+			clonechan <- RepoFileStatus{Err: gerr}
 		} else {
 			gerr.Description = "Repository download failed.\nAn unknown error occurred."
 			clonechan <- RepoFileStatus{Err: gerr}

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -331,17 +331,9 @@ func (gincl *Client) UnlockContent(paths []string, ulcchan chan<- RepoFileStatus
 
 // Download downloads changes and placeholder files in an already checked out repository.
 // Setting the Workingdir package global affects the working directory in which the command is executed.
-// The status channel 'downloadchan' is closed when this function returns.
-func (gincl *Client) Download(content bool, downloadchan chan<- RepoFileStatus) {
-	defer close(downloadchan)
+func (gincl *Client) Download() error {
 	util.LogWrite("Download")
-
-	downloadstatus := make(chan RepoFileStatus)
-	go AnnexPull(content, downloadstatus)
-	for stat := range downloadstatus {
-		downloadchan <- stat
-	}
-	return
+	return AnnexPull()
 }
 
 // CloneRepo clones a remote repository and initialises annex.

--- a/help.go
+++ b/help.go
@@ -420,6 +420,7 @@ const keysHelp = `USAGE
 
 	gin keys [-v | --verbose]
 	gin keys --add <filename>
+	gin keys --delete <number>
 
 DESCRIPTION
 
@@ -438,6 +439,10 @@ ARGUMENTS
 	--add <filename>
 		Specify a filename which contains a public key to be added to the GIN
 		server.
+
+	--delete <number>
+		Specify a number to delete the corresponding key from the server. Use
+		gin keys (with or without verbose) to get the numbered listing of keys.
 
 EXAMPLES
 

--- a/main.go
+++ b/main.go
@@ -402,14 +402,18 @@ func download(args []string) {
 	lockchan := make(chan ginclient.RepoFileStatus)
 	go gincl.LockContent([]string{}, lockchan)
 	printProgress(lockchan, jsonout)
-	dlchan := make(chan ginclient.RepoFileStatus)
-	if !content && !jsonout {
-		fmt.Print("Downloading...")
+	if !jsonout {
+		fmt.Print("Downloading changes ")
 	}
-	go gincl.Download(content, dlchan)
-	printProgress(dlchan, jsonout)
-	if !content && !jsonout {
+	err := gincl.Download()
+	util.CheckError(err)
+	if !jsonout {
 		fmt.Fprintln(color.Output, green("OK"))
+	}
+	if content {
+		reporoot, _ := util.FindRepoRoot(".")
+		ginclient.Workingdir = reporoot
+		getContent(nil)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -450,14 +450,13 @@ func keys(args []string) {
 		subcommand := args[0]
 		if subcommand == "--add" {
 			addKey(args)
+			return
 		} else if subcommand == "--delete" {
 			delKey(args)
-		} else {
-			usageDie("keys")
+			return
 		}
-	} else {
-		printKeys(args)
 	}
+	printKeys(args)
 }
 
 func printKeys(args []string) {


### PR DESCRIPTION
## New error conditions
- Bad host key: When a command fails due to a misconfigured host key, the client now prints an appropriate error message [**server key does not match known host key**].
- Unauthorised: When a command fails due to an unauthorised access attempt (e.g., the SSH key was removed from the user's profile), the client now prints an appropriate message [**permission denied**]. I considered more specific errors, but it's hard to know exactly what went wrong and it might be better to keep it a bit generic.
- Generic download/upload errors: `gin download` exits with error when the command fails. A bug made it return silently on failure when the cause was not known. Now it will simply print **failed**, which isn't helpful, but is better than silence. More error conditions need to be covered.

## Internal changes
- `gin download --content` internals have changed:
    - **Old**: The `--content` option was forwarded to the `git annex sync` command.
   - **New**: `git annex sync` is always run without `--content` and if the option is used, a `gin get-content` is performed following a successful download.
    - **Reasoning**: `git annex sync` does not support JSON output which I plan on using for all annex commands that support it. Further to this, `git annex sync` output is harder to parse even in its current state, especially for checking for failures and errors. The new implementation is also *cleaner*, since it reuses existing code for getting the content and minimises maintenance effort in the future.