### PR TITLE
Print output status only when text has changed

### DIFF
--- a/main.go
+++ b/main.go
@@ -328,7 +328,9 @@ func printProgress(statuschan <-chan ginclient.RepoFileStatus, jsonout bool) {
 		}
 		if stat.FileName != fname || stat.State != state {
 			// New line if new file or new state
-			fmt.Println()
+			if len(lastprint) > 0 {
+				fmt.Println()
+			}
 			lastprint = ""
 			fname = stat.FileName
 			state = stat.State

--- a/main.go
+++ b/main.go
@@ -317,7 +317,7 @@ func unlock(args []string) {
 
 func printProgress(statuschan <-chan ginclient.RepoFileStatus, jsonout bool) {
 	var fname, state string
-	prevlinelength := 0 // used to clear lines before overwriting
+	var lastprint string
 	filesuccess := make(map[string]bool)
 	for stat := range statuschan {
 		var msgparts []string
@@ -328,10 +328,8 @@ func printProgress(statuschan <-chan ginclient.RepoFileStatus, jsonout bool) {
 		}
 		if stat.FileName != fname || stat.State != state {
 			// New line if new file or new state
-			if fname != "" {
-				fmt.Println()
-				prevlinelength = 0
-			}
+			fmt.Println()
+			lastprint = ""
 			fname = stat.FileName
 			state = stat.State
 		}
@@ -347,10 +345,14 @@ func printProgress(statuschan <-chan ginclient.RepoFileStatus, jsonout bool) {
 			msgparts = append(msgparts, red(stat.Err.Error()))
 			filesuccess[stat.FileName] = false
 		}
-		fmt.Printf("\r%s", strings.Repeat(" ", prevlinelength)) // clear the previous line
-		prevlinelength, _ = fmt.Fprintf(color.Output, "\r%s", util.CleanSpaces(strings.Join(msgparts, " ")))
+		newprint := fmt.Sprintf("\r%s", util.CleanSpaces(strings.Join(msgparts, " ")))
+		if newprint != lastprint {
+			fmt.Printf("\r%s", strings.Repeat(" ", len(lastprint))) // clear the line
+			fmt.Fprint(color.Output, newprint)
+			lastprint = newprint
+		}
 	}
-	if prevlinelength > 0 {
+	if len(lastprint) > 0 {
 		fmt.Println()
 	}
 


### PR DESCRIPTION
On Windows, constantly updating the print progress causes the text to flicker. This is resolved by only printing when there is something new to print.