### PR TITLE
New command: repoinfo

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -41,7 +41,7 @@ func GetCmd() *cobra.Command {
 		"Get and initialise the repository named 'eegdata' owned by user 'peter'": "$ gin get peter/eegdata",
 	}
 	var getRepoCmd = &cobra.Command{
-		Use:     "get [--json] <repository>",
+		Use:     "get [--json] <repopath>",
 		Short:   "Retrieve (clone) a repository from the remote server",
 		Long:    formatdesc(description, args),
 		Example: formatexamples(examples),

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -14,7 +14,7 @@ func login(cmd *cobra.Command, args []string) {
 	var username string
 	var password string
 
-	if args != nil && len(args) == 0 {
+	if args == nil || len(args) == 0 {
 		// prompt for login
 		fmt.Print("Login: ")
 		fmt.Scanln(&username)

--- a/cmd/repoinfo.go
+++ b/cmd/repoinfo.go
@@ -1,0 +1,63 @@
+package gincmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	ginclient "github.com/G-Node/gin-cli/gin-client"
+	"github.com/G-Node/gin-cli/util"
+	gogs "github.com/gogits/go-gogs-client"
+	"github.com/spf13/cobra"
+)
+
+func printRepoInfo(repo gogs.Repository) {
+	fmt.Printf("* %s\n", repo.FullName)
+	fmt.Printf("\tLocation: %s\n", repo.HTMLURL)
+	desc := strings.Trim(repo.Description, "\n")
+	if desc != "" {
+		fmt.Printf("\tDescription: %s\n", desc)
+	}
+	if repo.Website != "" {
+		fmt.Printf("\tWebsite: %s\n", repo.Website)
+	}
+	if !repo.Private {
+		fmt.Println("\tThis repository is public")
+	}
+	fmt.Println()
+}
+
+func repoinfo(cmd *cobra.Command, args []string) {
+	flags := cmd.Flags()
+	jsonout, _ := flags.GetBool("json")
+	gincl := ginclient.NewClient(util.Config.GinHost)
+	requirelogin(cmd, gincl, true)
+	repoinfo, err := gincl.GetRepo(args[0])
+	util.CheckError(err)
+
+	if jsonout {
+		j, _ := json.Marshal(repoinfo)
+		fmt.Println(string(j))
+		return
+	}
+	printRepoInfo(repoinfo)
+}
+
+// RepoInfoCmd sets up the 'repoinfo' listing subcommand
+func RepoInfoCmd() *cobra.Command {
+	description := "Show the information for a specific repository on the server.\n\nThis can be used to check if the logged in user has access to a specific repository."
+
+	args := map[string]string{
+		"<repopath>": "The repository path must be specified on the command line. A repository path is the owner's username, followed by a \"/\" and the repository name.",
+	}
+	var reposCmd = &cobra.Command{
+		Use:   "repoinfo --json <repopath>",
+		Short: "Show the information for a specific repository",
+		Long:  formatdesc(description, args),
+		Args:  cobra.ExactArgs(1),
+		Run:   repoinfo,
+		DisableFlagsInUseLine: true,
+	}
+	reposCmd.Flags().Bool("json", false, "Print information in JSON format.")
+	return reposCmd
+}

--- a/cmd/repos.go
+++ b/cmd/repos.go
@@ -3,7 +3,6 @@ package gincmd
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	ginclient "github.com/G-Node/gin-cli/gin-client"
 	"github.com/G-Node/gin-cli/util"
@@ -13,19 +12,7 @@ import (
 
 func printRepoList(repolist []gogs.Repository) {
 	for _, repo := range repolist {
-		fmt.Printf("* %s\n", repo.FullName)
-		fmt.Printf("\tLocation: %s\n", repo.HTMLURL)
-		desc := strings.Trim(repo.Description, "\n")
-		if desc != "" {
-			fmt.Printf("\tDescription: %s\n", desc)
-		}
-		if repo.Website != "" {
-			fmt.Printf("\tWebsite: %s\n", repo.Website)
-		}
-		if !repo.Private {
-			fmt.Println("\tThis repository is public")
-		}
-		fmt.Println()
+		printRepoInfo(repo)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -130,6 +130,9 @@ func main() {
 	// List repos
 	rootCmd.AddCommand(gincmd.ReposCmd())
 
+	// Repo info
+	rootCmd.AddCommand(gincmd.RepoInfoCmd())
+
 	// Keys
 	rootCmd.AddCommand(gincmd.KeysCmd())
 


### PR DESCRIPTION
New command for getting the information for a specific repository. Useful for checking if a user has access to a specific repository (public, private, or shared) without retrieving the entire list. Especially useful for checking for public repo access and info, since there's no way to get public repositories in a listing, unless the user is a collaborator on it.