### PR TITLE
gin commit: Working without remotes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,9 @@ script:
   - make
   - make installtest
   - if [ ${TRAVIS_GO_VERSION} != "tip" ]; then
-        ./tests/start-server.sh;
+        ./tests/start-server;
         while ! curl localhost:3000 -so /dev/null; do sleep 1; done;
-        ./tests/run-cont-tests.sh;
+        ./tests/run-cont-tests;
     fi
 
 after_script:
@@ -57,6 +57,6 @@ after_script:
         echo $GISTTOKEN > ./tests/testuserhome/.gist;
         mv ./scripts/log/gin.log ./scripts/log/gin-${TRAVIS_BRANCH}.log;
         mv ./scripts/log/tests.log ./scripts/log/tests-${TRAVIS_BRANCH}.log;
-        ./tests/run-cont.sh gist -u 59e3b1c2fc3ff525127f9b3af81e7f4c ./scripts/log/*.log;
+        ./tests/run-cont gist -u 59e3b1c2fc3ff525127f9b3af81e7f4c ./scripts/log/*.log;
         rm ./tests/testuserhome/.gist;
     fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,6 @@ build_script:
   - go get github.com/docker/docker/pkg/term
   - go get github.com/alecthomas/template
   - go get github.com/dustin/go-humanize
-  - go get github.com/alecthomas/template
   - go vet ./...
   - gofmt -s -l .
   - golint github.com/G-Node/gin-cli...

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,6 +44,7 @@ build_script:
   - go get github.com/docker/docker/pkg/term
   - go get github.com/alecthomas/template
   - go get github.com/dustin/go-humanize
+  - go get github.com/alecthomas/template
   - go vet ./...
   - gofmt -s -l .
   - golint github.com/G-Node/gin-cli...

--- a/cmd/commitcmd.go
+++ b/cmd/commitcmd.go
@@ -11,19 +11,13 @@ import (
 
 func commit(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
-	gincl := ginclient.NewClient(util.Config.GinHost)
-	requirelogin(cmd, gincl, !jsonout)
 	if !ginclient.IsRepo() {
 		util.Die("This command must be run from inside a gin repository.")
 	}
 
-	gincl.GitHost = util.Config.GitHost
-	gincl.GitUser = util.Config.GitUser
-
 	paths := args
-
 	addchan := make(chan ginclient.RepoFileStatus)
-	go gincl.Add(paths, addchan)
+	go ginclient.Add(paths, addchan)
 	formatOutput(addchan, jsonout)
 
 	fmt.Print("Recording changes ")

--- a/cmd/commitcmd.go
+++ b/cmd/commitcmd.go
@@ -28,7 +28,7 @@ func commit(cmd *cobra.Command, args []string) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		util.LogWrite("Could not retrieve hostname")
-		hostname = "(unknown)"
+		hostname = unknownhostname
 	}
 	commitmsg := fmt.Sprintf("gin upload from %s\n\n%s", hostname, getchanges())
 	uploadchan := make(chan ginclient.RepoFileStatus)

--- a/cmd/commitcmd.go
+++ b/cmd/commitcmd.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func upload(cmd *cobra.Command, args []string) {
+func commit(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
 	gincl := ginclient.NewClient(util.Config.GinHost)
 	requirelogin(cmd, gincl, !jsonout)
@@ -32,20 +32,32 @@ func upload(cmd *cobra.Command, args []string) {
 	}
 	commitmsg := fmt.Sprintf("gin upload from %s\n\n%s", hostname, getchanges())
 	uploadchan := make(chan ginclient.RepoFileStatus)
-	go gincl.Upload(args, commitmsg, uploadchan)
+	go gincl.Commit(args, commitmsg, uploadchan)
 	formatOutput(uploadchan, jsonout)
 }
 
-// UploadCmd sets up the 'upload' subcommand
-func UploadCmd() *cobra.Command {
-	description := "Upload changes made in a local repository clone to the remote repository on the GIN server. This command must be called from within the local repository clone. Specific files or directories may be specified. All changes made will be sent to the server, including addition of new files, modifications and renaming of existing files, and file deletions.\n\nIf no arguments are specified, only changes to files already being tracked are uploaded."
+func getchanges() string {
+	// TODO FIXME: This function will often return "No changes" when changes are clearly made
+	changes, err := ginclient.DescribeIndexShort()
+	if err != nil {
+		util.LogWrite("Failed to determine file changes for commit message")
+	}
+	if changes == "" {
+		changes = "No changes recorded"
+	}
+	return changes
+}
+
+// CommitCmd sets up the 'commit' subcommand
+func CommitCmd() *cobra.Command {
+	description := "Record changes made in a local repository. This command must be called from within the local repository clone. Specific files or directories may be specified. All changes made to the files and directories that are specified will be recorded, including addition of new files, modifications and renaming of existing files, and file deletions.\n\nIf no arguments are specified, no changes are recorded."
 	args := map[string]string{"<filenames>": "One or more directories or files to upload and update."}
 	var uploadCmd = &cobra.Command{
-		Use:   "upload [--json] [<filenames>]...",
-		Short: "Upload local changes to a remote repository",
+		Use:   "commit [<filenames>]...",
+		Short: "Record changes in local repository",
 		Long:  formatdesc(description, args),
 		Args:  cobra.ArbitraryArgs,
-		Run:   upload,
+		Run:   commit,
 		DisableFlagsInUseLine: true,
 	}
 	uploadCmd.Flags().Bool("json", false, "Print output in JSON format.")

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -58,8 +58,10 @@ func printProgressOutput(statuschan <-chan ginclient.RepoFileStatus) (filesucces
 	var lastprint string
 	outline := new(bytes.Buffer)
 	outappend := func(part string) {
-		outline.WriteString(part)
-		outline.WriteString(" ")
+		if len(part) > 0 {
+			outline.WriteString(part)
+			outline.WriteString(" ")
+		}
 	}
 	for stat := range statuschan {
 		outline.Reset()

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -86,7 +86,7 @@ func printProgressOutput(statuschan <-chan ginclient.RepoFileStatus) (filesucces
 		}
 		newprint := outline.String()
 		if newprint != lastprint {
-			fmt.Printf("\r%s", strings.Repeat(" ", len(lastprint))) // clear the line
+			fmt.Printf("\r%s\r", strings.Repeat(" ", len(lastprint))) // clear the line
 			fmt.Fprint(color.Output, newprint)
 			lastprint = newprint
 		}

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -198,6 +198,9 @@ func SetUpCommands(verstr string) *cobra.Command {
 	// Lock content
 	rootCmd.AddCommand(LockCmd())
 
+	// Commit changes
+	rootCmd.AddCommand(CommitCmd())
+
 	// Upload
 	rootCmd.AddCommand(UploadCmd())
 

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -182,6 +182,9 @@ func SetUpCommands(verstr string) *cobra.Command {
 	// Logout
 	rootCmd.AddCommand(LogoutCmd())
 
+	// Init repo
+	rootCmd.AddCommand(InitCmd())
+
 	// Create repo
 	rootCmd.AddCommand(CreateCmd())
 

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -14,6 +14,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const unknownhostname = "(unknown)"
+
 var green = color.New(color.FgGreen).SprintFunc()
 var red = color.New(color.FgRed).SprintFunc()
 

--- a/cmd/createcmd.go
+++ b/cmd/createcmd.go
@@ -45,7 +45,7 @@ func createRepo(cmd *cobra.Command, args []string) {
 		ginclient.Workingdir = "."
 		initchan := make(chan ginclient.RepoFileStatus)
 		go gincl.InitDir(repoPath, initchan)
-		printProgress(initchan, false)
+		formatOutput(initchan, false)
 	} else if !noclone {
 		// Clone repository after creation
 		getRepo(cmd, []string{repoPath})

--- a/cmd/createcmd.go
+++ b/cmd/createcmd.go
@@ -43,9 +43,12 @@ func createRepo(cmd *cobra.Command, args []string) {
 	if here {
 		// Init cwd
 		ginclient.Workingdir = "."
-		initchan := make(chan ginclient.RepoFileStatus)
-		go gincl.InitDir(repoPath, initchan)
-		formatOutput(initchan, false)
+		err = gincl.InitDir()
+		util.CheckError(err)
+		err = gincl.AddRemote("origin", repoPath)
+		util.CheckError(err)
+		_, err := ginclient.CommitIfNew("origin")
+		util.CheckError(err)
 	} else if !noclone {
 		// Clone repository after creation
 		getRepo(cmd, []string{repoPath})

--- a/cmd/downloadcmd.go
+++ b/cmd/downloadcmd.go
@@ -22,7 +22,7 @@ func download(cmd *cobra.Command, args []string) {
 	gincl.GitUser = util.Config.GitUser
 	lockchan := make(chan ginclient.RepoFileStatus)
 	go gincl.LockContent([]string{}, lockchan)
-	printProgress(lockchan, jsonout)
+	formatOutput(lockchan, jsonout)
 	if !jsonout {
 		fmt.Print("Downloading changes ")
 	}

--- a/cmd/getcmd.go
+++ b/cmd/getcmd.go
@@ -28,6 +28,8 @@ func getRepo(cmd *cobra.Command, args []string) {
 	clonechan := make(chan ginclient.RepoFileStatus)
 	go gincl.CloneRepo(repostr, clonechan)
 	formatOutput(clonechan, jsonout)
+	_, err := ginclient.CommitIfNew("origin")
+	util.CheckError(err)
 }
 
 // GetCmd sets up the 'get' repository subcommand

--- a/cmd/getcmd.go
+++ b/cmd/getcmd.go
@@ -27,7 +27,7 @@ func getRepo(cmd *cobra.Command, args []string) {
 	gincl.GitUser = util.Config.GitUser
 	clonechan := make(chan ginclient.RepoFileStatus)
 	go gincl.CloneRepo(repostr, clonechan)
-	printProgress(clonechan, jsonout)
+	formatOutput(clonechan, jsonout)
 }
 
 // GetCmd sets up the 'get' repository subcommand

--- a/cmd/getcontentcmd.go
+++ b/cmd/getcontentcmd.go
@@ -18,7 +18,7 @@ func getContent(cmd *cobra.Command, args []string) {
 	gincl.GitUser = util.Config.GitUser
 	getcchan := make(chan ginclient.RepoFileStatus)
 	go gincl.GetContent(args, getcchan)
-	printProgress(getcchan, jsonout)
+	formatOutput(getcchan, jsonout)
 }
 
 // GetContentCmd sets up the 'get-content' subcommand

--- a/cmd/initcmd.go
+++ b/cmd/initcmd.go
@@ -1,0 +1,33 @@
+package gincmd
+
+import (
+	"fmt"
+
+	ginclient "github.com/G-Node/gin-cli/gin-client"
+	"github.com/G-Node/gin-cli/util"
+	"github.com/spf13/cobra"
+)
+
+func initRepo(cmd *cobra.Command, args []string) {
+	gincl := ginclient.NewClient(util.Config.GinHost)
+	fmt.Print("Initialising local storage ")
+	err := gincl.InitDir()
+	util.CheckError(err)
+	_, err = ginclient.CommitIfNew("")
+	util.CheckError(err)
+	fmt.Println(green("OK"))
+}
+
+// InitCmd sets up the 'init' repository subcommand
+func InitCmd() *cobra.Command {
+	description := "Initialise a local repository in the current directory with the default options."
+	var initRepoCmd = &cobra.Command{
+		Use:   "init",
+		Short: "Initialise the current directory as a gin repository",
+		Long:  formatdesc(description, nil),
+		Args:  cobra.NoArgs,
+		Run:   initRepo,
+		DisableFlagsInUseLine: true,
+	}
+	return initRepoCmd
+}

--- a/cmd/lockcmd.go
+++ b/cmd/lockcmd.go
@@ -14,7 +14,7 @@ func lock(cmd *cobra.Command, args []string) {
 	gincl := ginclient.NewClient(util.Config.GinHost)
 	lockchan := make(chan ginclient.RepoFileStatus)
 	go gincl.LockContent(args, lockchan)
-	printProgress(lockchan, jsonout)
+	formatOutput(lockchan, jsonout)
 }
 
 // LockCmd sets up the file 'lock' subcommand

--- a/cmd/removecontentcmd.go
+++ b/cmd/removecontentcmd.go
@@ -17,10 +17,10 @@ func remove(cmd *cobra.Command, args []string) {
 	gincl.GitUser = util.Config.GitUser
 	lockchan := make(chan ginclient.RepoFileStatus)
 	go gincl.LockContent(args, lockchan)
-	printProgress(lockchan, jsonout)
+	formatOutput(lockchan, jsonout)
 	rmchan := make(chan ginclient.RepoFileStatus)
 	go gincl.RemoveContent(args, rmchan)
-	printProgress(rmchan, jsonout)
+	formatOutput(rmchan, jsonout)
 }
 
 // RemoveContentCmd sets up the 'remove-content' subcommand

--- a/cmd/unlockcmd.go
+++ b/cmd/unlockcmd.go
@@ -14,7 +14,7 @@ func unlock(cmd *cobra.Command, args []string) {
 	gincl := ginclient.NewClient(util.Config.GinHost)
 	unlockchan := make(chan ginclient.RepoFileStatus)
 	go gincl.UnlockContent(args, unlockchan)
-	printProgress(unlockchan, jsonout)
+	formatOutput(unlockchan, jsonout)
 }
 
 // UnlockCmd sets up the file 'unlock' subcommand

--- a/cmd/uploadcmd.go
+++ b/cmd/uploadcmd.go
@@ -28,10 +28,8 @@ func upload(cmd *cobra.Command, args []string) {
 		formatOutput(addchan, jsonout)
 
 		fmt.Print("Recording changes ")
-		err := ginclient.GitCommit(makeCommitMessage("upload", paths))
-		if err != nil {
-			util.Die(err)
-		}
+		// ignore error for now :: call commit() instead
+		ginclient.GitCommit(makeCommitMessage("upload", paths))
 		fmt.Println(green("OK"))
 	}
 

--- a/cmd/uploadcmd.go
+++ b/cmd/uploadcmd.go
@@ -22,7 +22,7 @@ func upload(cmd *cobra.Command, args []string) {
 	paths := args
 
 	addchan := make(chan ginclient.RepoFileStatus)
-	go gincl.Add(paths, addchan)
+	go ginclient.Add(paths, addchan)
 	formatOutput(addchan, jsonout)
 
 	fmt.Print("Recording changes ")

--- a/cmd/uploadcmd.go
+++ b/cmd/uploadcmd.go
@@ -22,7 +22,7 @@ func upload(cmd *cobra.Command, args []string) {
 
 	lockchan := make(chan ginclient.RepoFileStatus)
 	go gincl.LockContent(args, lockchan)
-	printProgress(lockchan, jsonout)
+	formatOutput(lockchan, jsonout)
 
 	// add header commit line
 	hostname, err := os.Hostname()
@@ -33,7 +33,7 @@ func upload(cmd *cobra.Command, args []string) {
 	commitmsg := fmt.Sprintf("gin upload from %s\n\n%s", hostname, getchanges())
 	uploadchan := make(chan ginclient.RepoFileStatus)
 	go gincl.Upload(args, commitmsg, uploadchan)
-	printProgress(uploadchan, jsonout)
+	formatOutput(uploadchan, jsonout)
 }
 
 func getchanges() string {

--- a/cmd/uploadcmd.go
+++ b/cmd/uploadcmd.go
@@ -28,7 +28,7 @@ func upload(cmd *cobra.Command, args []string) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		util.LogWrite("Could not retrieve hostname")
-		hostname = "(unknown)"
+		hostname = unknownhostname
 	}
 	commitmsg := fmt.Sprintf("gin upload from %s\n\n%s", hostname, getchanges())
 	uploadchan := make(chan ginclient.RepoFileStatus)

--- a/cmd/uploadcmd.go
+++ b/cmd/uploadcmd.go
@@ -21,16 +21,19 @@ func upload(cmd *cobra.Command, args []string) {
 
 	paths := args
 
-	addchan := make(chan ginclient.RepoFileStatus)
-	go ginclient.Add(paths, addchan)
-	formatOutput(addchan, jsonout)
+	if len(paths) > 0 {
+		// Don't add + commit files if nothing was specified
+		addchan := make(chan ginclient.RepoFileStatus)
+		go ginclient.Add(paths, addchan)
+		formatOutput(addchan, jsonout)
 
-	fmt.Print("Recording changes ")
-	err := ginclient.GitCommit(makeCommitMessage("upload", paths))
-	if err != nil {
-		util.Die(err)
+		fmt.Print("Recording changes ")
+		err := ginclient.GitCommit(makeCommitMessage("upload", paths))
+		if err != nil {
+			util.Die(err)
+		}
+		fmt.Println(green("OK"))
 	}
-	fmt.Println(green("OK"))
 
 	uploadchan := make(chan ginclient.RepoFileStatus)
 	go gincl.Upload(paths, uploadchan)

--- a/cmd/versioncmd.go
+++ b/cmd/versioncmd.go
@@ -51,7 +51,7 @@ func repoversion(cmd *cobra.Command, args []string) {
 		hostname, herr := os.Hostname()
 		if herr != nil {
 			util.LogWrite("Could not retrieve hostname")
-			hostname = "(unknown)"
+			hostname = unknownhostname
 		}
 
 		commitsubject := fmt.Sprintf("Repository version changed by %s@%s", gincl.Username, hostname)

--- a/cmd/versioncmd.go
+++ b/cmd/versioncmd.go
@@ -3,7 +3,6 @@ package gincmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -48,18 +47,18 @@ func repoversion(cmd *cobra.Command, args []string) {
 		// e.g., File 'fname' restored to version <revision> (date)
 		err := ginclient.CheckoutVersion(commit.AbbreviatedHash, paths)
 		util.CheckError(err)
-		hostname, herr := os.Hostname()
-		if herr != nil {
-			util.LogWrite("Could not retrieve hostname")
-			hostname = unknownhostname
-		}
+		// hostname, herr := os.Hostname()
+		// if herr != nil {
+		// 	util.LogWrite("Could not retrieve hostname")
+		// 	hostname = unknownhostname
+		// }
 
-		commitsubject := fmt.Sprintf("Repository version changed by %s@%s", gincl.Username, hostname)
-		commitbody := fmt.Sprintf("Returning to version as of %s\nVersion ID: %s\n%s", commit.Date.Format("Mon Jan 2 15:04:05 2006 (-0700)"), commit.AbbreviatedHash, getchanges())
-		commitmsg := fmt.Sprintf("%s\n\n%s", commitsubject, commitbody)
+		// commitsubject := fmt.Sprintf("Repository version changed by %s@%s", gincl.Username, hostname)
+		// commitbody := fmt.Sprintf("Returning to version as of %s\nVersion ID: %s\n%s", commit.Date.Format("Mon Jan 2 15:04:05 2006 (-0700)"), commit.AbbreviatedHash, getchanges(paths))
+		// commitmsg := fmt.Sprintf("%s\n\n%s", commitsubject, commitbody)
 
 		uploadchan := make(chan ginclient.RepoFileStatus)
-		go gincl.Upload(paths, commitmsg, uploadchan)
+		go gincl.Upload(paths, uploadchan)
 		formatOutput(uploadchan, jsonout)
 	} else {
 		checkoutcopies(commit, paths, copyto)

--- a/cmd/versioncmd.go
+++ b/cmd/versioncmd.go
@@ -60,7 +60,7 @@ func repoversion(cmd *cobra.Command, args []string) {
 
 		uploadchan := make(chan ginclient.RepoFileStatus)
 		go gincl.Upload(paths, commitmsg, uploadchan)
-		printProgress(uploadchan, jsonout)
+		formatOutput(uploadchan, jsonout)
 	} else {
 		checkoutcopies(commit, paths, copyto)
 	}

--- a/gin-client/gin.go
+++ b/gin-client/gin.go
@@ -248,7 +248,7 @@ func (gincl *Client) Logout() {
 	hostname, err := os.Hostname()
 	if err != nil {
 		util.LogWrite("Could not retrieve hostname")
-		hostname = defaultHostname
+		hostname = unknownhostname
 	}
 
 	currentkeyname := fmt.Sprintf("GIN Client: %s@%s", gincl.Username, hostname)

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1275,6 +1276,18 @@ func AnnexFromKey(key, filepath string) error {
 		return fmt.Errorf(string(stderr))
 	}
 	return nil
+}
+
+// GitRevCount returns the number of commits between two revisions.
+// Setting the Workingdir package global affects the working directory in which the command is executed.
+func GitRevCount(a, b string) (int, error) {
+	cmd := GitCommand("rev-list", "--count", fmt.Sprintf("%s..%s", a, b))
+	stdout, stderr, err := cmd.OutputError()
+	if err != nil {
+		logstd(stdout, stderr)
+		return 0, fmt.Errorf(string(stderr))
+	}
+	return strconv.Atoi(string(stdout))
 }
 
 var annexmodecache = make(map[string]bool)

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -121,6 +121,7 @@ func (gincl *Client) Clone(repoPath string, clonechan chan<- RepoFileStatus) {
 	var stderr []byte
 	var status RepoFileStatus
 	status.State = "Downloading repository"
+	clonechan <- status
 	var rerr error
 	readbuffer := make([]byte, 1024)
 	var nread, errhead int
@@ -251,7 +252,7 @@ func AnnexPull() error {
 }
 
 // AnnexSync synchronises the local repository with the remote.
-// Optionally synchronises content if content=True
+// Optionally synchronises content if content=True.
 // Setting the Workingdir package global affects the working directory in which the command is executed.
 // The status channel 'syncchan' is closed when this function returns.
 // (git annex sync [--content])

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -64,7 +64,7 @@ func CommitIfNew() (bool, error) {
 		return false, fmt.Errorf("not a repository")
 	}
 	cmd := GitCommand("rev-parse", "HEAD")
-	err := cmd.Wait()
+	err := cmd.Run()
 	if err == nil {
 		// All good. No need to do anything
 		return false, nil

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -72,7 +72,7 @@ func CommitIfNew() (bool, error) {
 	// Create an empty initial commit and run annex sync to synchronise everything
 	hostname, err := os.Hostname()
 	if err != nil {
-		hostname = defaultHostname
+		hostname = unknownhostname
 	}
 	commitargs := []string{"commit", "--allow-empty", "-m", fmt.Sprintf("Initial commit: Repository initialised on %s", hostname)}
 	cmd = GitCommand(commitargs...)

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -412,6 +412,15 @@ func AnnexPush(paths []string, pushchan chan<- RepoFileStatus) {
 // Setting the Workingdir package global affects the working directory in which the command is executed.
 // (git commit)
 func GitCommit(commitmsg string) error {
+	if IsDirect() {
+		// Set bare false and revert at the end of the function
+		err := setBare(false)
+		if err != nil {
+			return fmt.Errorf("failed to toggle repository bare mode")
+		}
+		defer setBare(true)
+	}
+
 	cmd := GitCommand("commit", fmt.Sprintf("--message=%s", commitmsg))
 	stdout, stderr, err := cmd.OutputError()
 
@@ -421,7 +430,7 @@ func GitCommit(commitmsg string) error {
 			util.LogWrite("Nothing to commit")
 			return nil
 		}
-		util.LogWrite("Error during AnnexCommit")
+		util.LogWrite("Error during GitCommit")
 		logstd(stdout, stderr)
 		return fmt.Errorf(string(stderr))
 	}

--- a/gin-client/git.go
+++ b/gin-client/git.go
@@ -629,7 +629,7 @@ func GitAdd(filepaths []string, addchan chan<- RepoFileStatus) {
 			continue
 		}
 		if strings.HasPrefix(fname, "add") {
-			status.State = "Adding"
+			status.State = "Adding (git)  "
 			fname = strings.TrimPrefix(fname, "add '")
 		} else if strings.HasPrefix(fname, "remove") {
 			status.State = "Removing"
@@ -702,7 +702,7 @@ func annexAddCommon(filepaths []string, update bool, addchan chan<- RepoFileStat
 	var rerr error
 	var status RepoFileStatus
 	var addresult annexAction
-	status.State = "Adding"
+	status.State = "Adding (annex)"
 	if update {
 		status.State = "Locking"
 	}

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -220,6 +220,13 @@ func (gincl *Client) Commit(paths []string, commitmsg string, commitchan chan<- 
 			// Send UploadStatus
 			commitchan <- addstat
 		}
+
+		// Run sync with no push or pull
+		annexcommitchan := make(chan RepoFileStatus)
+		go AnnexCommit("COMMIT", annexcommitchan)
+		for comstat := range annexcommitchan {
+			commitchan <- comstat
+		}
 	}
 
 	return

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -19,7 +19,7 @@ import (
 	// but its only temporary...
 )
 
-var defaultHostname = "(unknown)"
+const unknownhostname = "(unknown)"
 
 // MakeSessionKey creates a private+public key pair.
 // The private key is saved in the user's configuration directory, to be used for git commands.
@@ -33,7 +33,7 @@ func (gincl *Client) MakeSessionKey() error {
 	hostname, err := os.Hostname()
 	if err != nil {
 		util.LogWrite("Could not retrieve hostname")
-		hostname = defaultHostname
+		hostname = unknownhostname
 	}
 	description := fmt.Sprintf("GIN Client: %s@%s", gincl.Username, hostname)
 	pubkey := fmt.Sprintf("%s %s", strings.TrimSpace(keyPair.Public), description)
@@ -482,7 +482,7 @@ func (gincl *Client) InitDir(repoPath string, initchan chan<- RepoFileStatus) {
 
 	hostname, err := os.Hostname()
 	if err != nil {
-		hostname = defaultHostname
+		hostname = unknownhostname
 	}
 	description := fmt.Sprintf("%s@%s", gincl.Username, hostname)
 

--- a/gin-client/repos.go
+++ b/gin-client/repos.go
@@ -195,7 +195,7 @@ func (s RepoFileStatus) MarshalJSON() ([]byte, error) {
 
 // Add updates the index with the changes in the files specified by 'paths'.
 // The status channel 'addchan' is closed when this function returns.
-func (gincl *Client) Add(paths []string, addchan chan<- RepoFileStatus) {
+func Add(paths []string, addchan chan<- RepoFileStatus) {
 	defer close(addchan)
 	paths, err := util.ExpandGlobs(paths)
 	if err != nil {

--- a/util/cmd.go
+++ b/util/cmd.go
@@ -33,3 +33,9 @@ func (cmd *GinCmd) OutputError() ([]byte, []byte, error) {
 	err := cmd.Run()
 	return bout.Bytes(), berr.Bytes(), err
 }
+
+// Output runs the command and returns its standard output.
+func (cmd *GinCmd) Output() ([]byte, error) {
+	cmd.Stdout = nil
+	return cmd.Cmd.Output()
+}

--- a/util/die.go
+++ b/util/die.go
@@ -16,8 +16,8 @@ func Die(msg interface{}) {
 	// Swap the line above for the line below when (if) https://github.com/fatih/color/pull/87 gets merged
 	msgstring := fmt.Sprintf("%s", msg)
 	if len(msgstring) > 0 {
-		LogWrite("Exiting with ERROR message: %s", msg)
-		fmt.Fprintln(os.Stderr, msg)
+		LogWrite("Exiting with ERROR message: %s", msgstring)
+		fmt.Fprintln(os.Stderr, msgstring)
 	} else {
 		LogWrite("Exiting with ERROR (no message)")
 	}

--- a/util/files.go
+++ b/util/files.go
@@ -102,7 +102,11 @@ func FilterPaths(paths, excludes []string) (filtered []string) {
 // A path to the repository root is returned, or an error if the root of the filesystem is reached first.
 // The returned path is absolute.
 func FindRepoRoot(path string) (string, error) {
-	path, _ = filepath.Abs(path)
+	var err error
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
 	gitdir := filepath.Join(path, ".git")
 	if PathExists(gitdir) {
 		return path, nil

--- a/util/log.go
+++ b/util/log.go
@@ -23,7 +23,7 @@ func LogInit(ver string) error {
 		return fmt.Errorf("Error creating file %s", logpath)
 	}
 
-	flags := log.Ldate | log.Ltime | log.LUTC | log.Llongfile
+	flags := log.Ldate | log.Ltime | log.LUTC
 	logger = log.New(logfile, "", flags)
 
 	LogWrite("=== LOGINIT ===")


### PR DESCRIPTION
## New commands

This PR introduces the offline workflow with the use of two new commands:
- `gin init`: Initialises a local directory as a gin repository. This performs a `git init`, followed by a `git annex init` and sets all the local defaults for git and git annex (as we do for all other repositories).
- `gin commit`: Takes filepaths as arguments and adds and commits them to git and git annex accordingly. The commit message, as with `gin upload` previously, is created automatically.

## Commit messages

The automatic commit messages are created as follows.

In the case of a commit command:

`gin commit from <HOSTNAME>`

or if a commit was created as a result of an upload command:

`gin upload from <HOSTNAME>`

The body of the commit is always the same:
```
Added files: <N>
Modified files: <N>
Deleted files: <N>
```

If `N` is 0 for any of the lines, the corresponding line is omitted.

An old bug in the way the counts were determined, resulting in commit messages incorrectly stating `No changes recorded` has been fixed (closes #167).

## Upload changes

Since a user can now perform multiple commits between uploads, the upload command needs to copy content to the server that could be unused (e.g., multiple versions of the same file). The upload command would previously upload only files specified on the command line, since those were the ones whose changes were being committed. Starting with this PR, the upload command instead performs a `git annex copy --all`, which copies (uploads) all content that it detects does not already exist on the server. 

This also required changes in the way the upload output is printed. Since old content is not associated with a filename (whether that original file name is still in the HEAD revision or not), we use the metadata feature of git-annex to attach filenames to content keys. The filename is then used during upload for progress output. The timedate when the key was committed to the index is also printed as version information.

## Future stuff

The ability to convert a local repository to a remote clone will be added in a subsequent pull request.