### PR TITLE
Fix file adding in direct mode

### DIFF
--- a/ginclient/repos.go
+++ b/ginclient/repos.go
@@ -22,9 +22,6 @@ import (
 
 const unknownhostname = "(unknown)"
 
-// Workingdir sets the directory for shell commands
-var Workingdir = "."
-
 // Types
 
 // FileCheckoutStatus is used to report the status of a CheckoutFileCopies() operation.
@@ -351,7 +348,6 @@ func (gincl *Client) UnlockContent(paths []string, ulcchan chan<- git.RepoFileSt
 }
 
 // Download downloads changes and placeholder files in an already checked out repository.
-// Setting the Workingdir package global affects the working directory in which the command is executed.
 func (gincl *Client) Download() error {
 	log.Write("Download")
 	return git.AnnexPull()
@@ -374,10 +370,10 @@ func (gincl *Client) CloneRepo(repoPath string, clonechan chan<- git.RepoFileSta
 
 	repoPathParts := strings.SplitN(repoPath, "/", 2)
 	repoName := repoPathParts[1]
-	git.Workingdir = repoName
 
 	status := git.RepoFileStatus{State: "Initialising local storage"}
 	clonechan <- status
+	os.Chdir(repoName)
 	err := gincl.InitDir()
 	if err != nil {
 		status.Err = err
@@ -469,7 +465,6 @@ func (gincl *Client) InitDir() error {
 			initerr.UError = err.Error()
 			return initerr
 		}
-		Workingdir = "."
 	}
 
 	hostname, err := os.Hostname()
@@ -757,7 +752,6 @@ func lfIndirect(paths ...string) (map[string]FileStatus, error) {
 }
 
 // ListFiles lists the files and directories specified by paths and their sync status.
-// Setting the Workingdir package global affects the working directory in which the command is executed.
 func (gincl *Client) ListFiles(paths ...string) (map[string]FileStatus, error) {
 	paths, err := expandglobs(paths)
 	if err != nil {

--- a/gincmd/createcmd.go
+++ b/gincmd/createcmd.go
@@ -44,7 +44,6 @@ func createRepo(cmd *cobra.Command, args []string) {
 
 	if here {
 		// Init cwd
-		ginclient.Workingdir = "."
 		err = gincl.InitDir()
 		CheckError(err)
 		err = gincl.AddRemote("origin", repoPath)

--- a/gincmd/downloadcmd.go
+++ b/gincmd/downloadcmd.go
@@ -2,6 +2,7 @@ package gincmd
 
 import (
 	"fmt"
+	"os"
 
 	ginclient "github.com/G-Node/gin-cli/ginclient"
 	"github.com/G-Node/gin-cli/ginclient/config"
@@ -35,7 +36,7 @@ func download(cmd *cobra.Command, args []string) {
 	}
 	if content {
 		reporoot, _ := git.FindRepoRoot(".")
-		ginclient.Workingdir = reporoot
+		os.Chdir(reporoot)
 		getContent(cmd, nil)
 	}
 }

--- a/gincmd/lscmd.go
+++ b/gincmd/lscmd.go
@@ -32,6 +32,8 @@ func lsRepo(cmd *cobra.Command, args []string) {
 	filesStatus, err := gincl.ListFiles(args...)
 	CheckError(err)
 
+	// TODO: Print warning when in direct mode: git files that have not been uploaded will show up as synced.
+
 	if short {
 		for fname, status := range filesStatus {
 			fmt.Printf("%s %s\n", status.Abbrev(), fname)

--- a/git/annex.go
+++ b/git/annex.go
@@ -114,7 +114,6 @@ type AnnexInfoRes struct {
 }
 
 // AnnexInit initialises the repository for annex.
-// Setting the Workingdir package global affects the working directory in which the command is executed.
 // (git annex init)
 func AnnexInit(description string) error {
 	args := []string{"init", description}
@@ -137,7 +136,6 @@ func AnnexInit(description string) error {
 
 // AnnexSync synchronises the local repository with the remote.
 // Optionally synchronises content if content=True.
-// Setting the Workingdir package global affects the working directory in which the command is executed.
 // The status channel 'syncchan' is closed when this function returns.
 // (git annex sync [--content])
 func AnnexSync(content bool, syncchan chan<- RepoFileStatus) {
@@ -191,7 +189,6 @@ func AnnexSync(content bool, syncchan chan<- RepoFileStatus) {
 }
 
 // AnnexPull downloads all annexed files. Optionally also downloads all file content.
-// Setting the Workingdir package global affects the working directory in which the command is executed.
 // (git annex sync --no-push [--content])
 func AnnexPull() error {
 	args := []string{"sync", "--no-push", "--no-commit"}
@@ -217,7 +214,6 @@ func AnnexPull() error {
 }
 
 // AnnexPush uploads all changes and new content to the default remote.
-// Setting the Workingdir package global affects the working directory in which the command is executed.
 // The status channel 'pushchan' is closed when this function returns.
 // (git annex sync --no-pull; git annex copy --to=origin)
 func AnnexPush(paths []string, pushchan chan<- RepoFileStatus) {
@@ -335,7 +331,6 @@ func AnnexPush(paths []string, pushchan chan<- RepoFileStatus) {
 }
 
 // AnnexGet retrieves the content of specified files.
-// Setting the Workingdir package global affects the working directory in which the command is executed.
 // The status channel 'getchan' is closed when this function returns.
 // (git annex get)
 func AnnexGet(filepaths []string, getchan chan<- RepoFileStatus) {
@@ -410,7 +405,6 @@ func AnnexGet(filepaths []string, getchan chan<- RepoFileStatus) {
 }
 
 // AnnexDrop drops the content of specified files.
-// Setting the Workingdir package global affects the working directory in which the command is executed.
 // The status channel 'dropchan' is closed when this function returns.
 // (git annex drop)
 func AnnexDrop(filepaths []string, dropchan chan<- RepoFileStatus) {
@@ -494,7 +488,6 @@ func getAnnexMetadataName(key string) annexFilenameDate {
 
 // AnnexAdd adds paths to the annex.
 // Files specified for exclusion in the configuration are ignored automatically.
-// Setting the Workingdir package global affects the working directory in which the command is executed.
 // The status channel 'addchan' is closed when this function returns.
 // (git annex add)
 func AnnexAdd(filepaths []string, addchan chan<- RepoFileStatus) {
@@ -502,7 +495,6 @@ func AnnexAdd(filepaths []string, addchan chan<- RepoFileStatus) {
 }
 
 // AnnexWhereis returns information about annexed files in the repository
-// Setting the Workingdir package global affects the working directory in which the command is executed.
 // The output channel 'wichan' is closed when this function returns.
 // (git annex whereis)
 func AnnexWhereis(paths []string, wichan chan<- AnnexWhereisRes) {
@@ -534,7 +526,6 @@ func AnnexWhereis(paths []string, wichan chan<- AnnexWhereisRes) {
 }
 
 // AnnexStatus returns the status of a file or files in a directory
-// Setting the Workingdir package global affects the working directory in which the command is executed.
 // The output channel 'statuschan' is closed when this function returns.
 // (git annex status)
 func AnnexStatus(paths []string, statuschan chan<- AnnexStatusRes) {
@@ -567,7 +558,6 @@ func AnnexStatus(paths []string, statuschan chan<- AnnexStatusRes) {
 }
 
 // AnnexInfo returns the annex information for a given repository
-// Setting the Workingdir package global affects the working directory in which the command is executed.
 // (git annex info)
 func AnnexInfo() (AnnexInfoRes, error) {
 	cmd := AnnexCommand("info", "--json")
@@ -586,7 +576,6 @@ func AnnexInfo() (AnnexInfoRes, error) {
 // AnnexLock locks the specified files and directory contents if they are annexed.
 // Note that this function uses 'git annex add' to lock files, but only if they are marked as unlocked (T) by git annex.
 // Attempting to lock an untracked file, or a file in any state other than T will have no effect.
-// Setting the Workingdir package global affects the working directory in which the command is executed.
 // The status channel 'lockchan' is closed when this function returns.
 // (git annex add --update)
 func AnnexLock(filepaths []string, lockchan chan<- RepoFileStatus) {
@@ -594,7 +583,6 @@ func AnnexLock(filepaths []string, lockchan chan<- RepoFileStatus) {
 }
 
 // AnnexUnlock unlocks the specified files and directory contents if they are annexed
-// Setting the Workingdir package global affects the working directory in which the command is executed.
 // The status channel 'unlockchan' is closed when this function returns.
 // (git annex unlock)
 func AnnexUnlock(filepaths []string, unlockchan chan<- RepoFileStatus) {
@@ -680,7 +668,6 @@ func AnnexFind(paths []string) (map[string]AnnexFindRes, error) {
 // AnnexFromKey creates an Annex placeholder file at a given location with a specific key.
 // The creation is forced, so there is no guarantee that the key refers to valid repository content, nor that the content is still available in any of the remotes.
 // The location where the file is to be created must be available (no directories are created).
-// Setting the Workingdir package global affects the working directory in which the command is executed.
 // (git annex fromkey --force)
 func AnnexFromKey(key, filepath string) error {
 	cmd := AnnexCommand("fromkey", "--force", key, filepath)
@@ -829,17 +816,16 @@ func GetAnnexVersion() (string, error) {
 }
 
 // AnnexCommand sets up a git annex command with the provided arguments and returns a GinCmd struct.
-// Setting the Workingdir package global affects the working directory in which the command will be executed.
 func AnnexCommand(args ...string) shell.Cmd {
 	config := config.Read()
 	gitannexbin := config.Bin.GitAnnex
 	cmd := shell.Command(gitannexbin, args...)
-	cmd.Dir = Workingdir
 	token := web.UserToken{}
 	_ = token.LoadToken()
 	env := os.Environ()
 	cmd.Env = append(env, sshEnv(token.Username))
 	cmd.Env = append(cmd.Env, "GIT_ANNEX_USE_GIT_SSH=1")
-	log.Write("Running shell command (Dir: %s): %s", Workingdir, strings.Join(cmd.Args, " "))
+	workingdir, _ := filepath.Abs(".")
+	log.Write("Running shell command (Dir: %s): %s", workingdir, strings.Join(cmd.Args, " "))
 	return cmd
 }

--- a/git/util.go
+++ b/git/util.go
@@ -121,5 +121,6 @@ func filterpaths(paths, excludes []string) (filtered []string) {
 			log.Write("Error occured during path filtering: %s", err.Error())
 		}
 	}
+
 	return
 }


### PR DESCRIPTION
## Direct mode `git add`

Adding files in direct mode is a bit tricky. Here's a summary, copied from the first commit of this PR.

**Problem:** When in direct mode (e.g., on Windows), the repository stays "bare" and git-annex handles all git operations. When performing certain functions, to keep consistency between Direct and Indirect mode operations, the client temporarily disables "bare". This causes an issue during `git add`: annexed files, which annex adds to git as pointer files, appear as normal files to git and get added during the operation.

**Previous solution:** Scan the provided paths recursively and filter out annexed files. The problem with this solution was that if the changes being committed were just for removing files, the commit would have an empty argument list. Deleted files don't appear in the recursive directory listing, so their deletion is not added to the index.

**Updated solution:** Run `git ls-files` to get all files known to git (that match the paths in the argument) and filter out annexed files from that listing as well. This is in addition to running through the current directory listing.

## Other changes

The `Workingdir` package global has now been removed. It was a global variable of the `ginclient` package (pre-refactoring, see PR #200) that was rarely used and was a bit of a badly designed pattern. Now, if and when necessary, the client changes the working directory through the `os.Chdir` function instead. This is mostly used for initialising repository defaults after cloning, since the user starts the command from the repository's parent directory and config commands need to be run from within the newly cloned directory.

