### PR TITLE
Progress bars for file operations

### DIFF
--- a/gincmd/commitcmd.go
+++ b/gincmd/commitcmd.go
@@ -21,12 +21,16 @@ func commit(cmd *cobra.Command, args []string) {
 	go ginclient.Add(paths, addchan)
 	formatOutput(addchan, 0, jsonout)
 
-	fmt.Print("Recording changes ")
+	if !jsonout {
+		fmt.Print(":: Recording changes ")
+	}
 	err := git.Commit(makeCommitMessage("commit", paths))
 	if err != nil {
 		Die(err)
 	}
-	fmt.Println(green("OK"))
+	if !jsonout {
+		fmt.Println(green("OK"))
+	}
 }
 
 func makeCommitMessage(action string, paths []string) (commitmsg string) {

--- a/gincmd/commitcmd.go
+++ b/gincmd/commitcmd.go
@@ -1,14 +1,26 @@
 package gincmd
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 
 	ginclient "github.com/G-Node/gin-cli/ginclient"
 	"github.com/G-Node/gin-cli/ginclient/log"
 	"github.com/G-Node/gin-cli/git"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
+
+func countItemsAdd(paths []string) int {
+	args := append([]string{"add", "--dry-run"}, paths...)
+	cmd := git.Command(args...)
+	output, err := cmd.Output()
+	if err != nil {
+		return 0
+	}
+	return len(bytes.Split(bytes.TrimSpace(output), []byte("\n")))
+}
 
 func commit(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
@@ -18,8 +30,9 @@ func commit(cmd *cobra.Command, args []string) {
 
 	paths := args
 	addchan := make(chan git.RepoFileStatus)
+	nitems := countItemsAdd(paths)
 	go ginclient.Add(paths, addchan)
-	formatOutput(addchan, 0, jsonout)
+	formatOutput(addchan, nitems, jsonout)
 
 	if !jsonout {
 		fmt.Print(":: Recording changes ")

--- a/gincmd/commitcmd.go
+++ b/gincmd/commitcmd.go
@@ -38,11 +38,18 @@ func commit(cmd *cobra.Command, args []string) {
 		fmt.Print(":: Recording changes ")
 	}
 	err := git.Commit(makeCommitMessage("commit", paths))
+	var stat string
 	if err != nil {
-		Die(err)
+		if err.Error() == "Nothing to commit" {
+			stat = "N/A\n:: No changes recorded"
+		} else {
+			Die(err)
+		}
+	} else {
+		stat = green("OK")
 	}
 	if !jsonout {
-		fmt.Println(green("OK"))
+		fmt.Fprintln(color.Output, stat)
 	}
 }
 

--- a/gincmd/commitcmd.go
+++ b/gincmd/commitcmd.go
@@ -19,7 +19,7 @@ func commit(cmd *cobra.Command, args []string) {
 	paths := args
 	addchan := make(chan git.RepoFileStatus)
 	go ginclient.Add(paths, addchan)
-	formatOutput(addchan, jsonout)
+	formatOutput(addchan, 0, jsonout)
 
 	fmt.Print("Recording changes ")
 	err := git.Commit(makeCommitMessage("commit", paths))

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -26,7 +26,7 @@ var red = color.New(color.FgRed).SprintFunc()
 func Die(msg interface{}) {
 	// fmt.Fprintf(color.Error, "%s %s\n", red("ERROR"), msg)
 	// Swap the line above for the line below when (if) https://github.com/fatih/color/pull/87 gets merged
-	msgstring := fmt.Sprintf("%s", msg)
+	msgstring := fmt.Sprintf("E: %s", msg)
 	if len(msgstring) > 0 {
 		log.Write("Exiting with ERROR message: %s", msgstring)
 		fmt.Fprintln(os.Stderr, msgstring)

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -139,6 +139,7 @@ func printProgressWithBar(statuschan <-chan git.RepoFileStatus, nitems int) (fil
 		dprg := fmt.Sprintf(dfmt, ncomplt, nitems)
 		fmt.Printf("\n [%s%s] %s\r", blocks, blanks, dprg)
 	}
+	fmt.Println()
 	return
 }
 

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -139,7 +139,9 @@ func printProgressWithBar(statuschan <-chan git.RepoFileStatus, nitems int) (fil
 		dprg := fmt.Sprintf(dfmt, ncomplt, nitems)
 		fmt.Printf("\n [%s%s] %s\r", blocks, blanks, dprg)
 	}
-	fmt.Println()
+	if outline.Len() > 0 {
+		fmt.Println()
+	}
 	return
 }
 

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -118,6 +118,7 @@ func printProgressWithBar(statuschan <-chan git.RepoFileStatus, nitems int) (fil
 	for stat := range statuschan {
 		ncomplt++
 		outline.Reset()
+		outline.WriteString(" ")
 		outappend(stat.State)
 		outappend(stat.FileName)
 		if stat.Err == nil {
@@ -154,6 +155,7 @@ func printProgressOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[
 	}
 	for stat := range statuschan {
 		outline.Reset()
+		outline.WriteString(" ")
 		if stat.FileName != fname || stat.State != state {
 			// New line if new file or new state
 			if len(lastprint) > 0 {
@@ -181,6 +183,7 @@ func printProgressOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[
 		if newprint != lastprint {
 			fmt.Printf("\r%s\r", strings.Repeat(" ", len(lastprint))) // clear the line
 			fmt.Fprint(color.Output, newprint)
+			fmt.Print("\r")
 			lastprint = newprint
 		}
 	}

--- a/gincmd/createcmd.go
+++ b/gincmd/createcmd.go
@@ -37,7 +37,7 @@ func createRepo(cmd *cobra.Command, args []string) {
 	gincl.GitHost = conf.GitHost
 	gincl.GitUser = conf.GitUser
 	repoPath := fmt.Sprintf("%s/%s", gincl.Username, repoName)
-	fmt.Printf("Creating repository '%s' ", repoPath)
+	fmt.Printf(":: Creating repository '%s' ", repoPath)
 	err := gincl.CreateRepo(repoName, repoDesc)
 	CheckError(err)
 	fmt.Fprintln(color.Output, green("OK"))

--- a/gincmd/downloadcmd.go
+++ b/gincmd/downloadcmd.go
@@ -25,7 +25,7 @@ func download(cmd *cobra.Command, args []string) {
 	gincl.GitUser = conf.GitUser
 	lockchan := make(chan git.RepoFileStatus)
 	go gincl.LockContent([]string{}, lockchan)
-	formatOutput(lockchan, jsonout)
+	formatOutput(lockchan, 0, jsonout)
 	if !jsonout {
 		fmt.Print("Downloading changes ")
 	}

--- a/gincmd/getcmd.go
+++ b/gincmd/getcmd.go
@@ -29,7 +29,7 @@ func getRepo(cmd *cobra.Command, args []string) {
 	gincl.GitUser = conf.GitUser
 	clonechan := make(chan git.RepoFileStatus)
 	go gincl.CloneRepo(repostr, clonechan)
-	formatOutput(clonechan, jsonout)
+	formatOutput(clonechan, 0, jsonout)
 	_, err := git.CommitIfNew("origin")
 	CheckError(err)
 }

--- a/gincmd/getcontentcmd.go
+++ b/gincmd/getcontentcmd.go
@@ -20,7 +20,7 @@ func getContent(cmd *cobra.Command, args []string) {
 	gincl.GitUser = conf.GitUser
 	getcchan := make(chan git.RepoFileStatus)
 	go gincl.GetContent(args, getcchan)
-	formatOutput(getcchan, jsonout)
+	formatOutput(getcchan, 0, jsonout)
 }
 
 // GetContentCmd sets up the 'get-content' subcommand

--- a/gincmd/initcmd.go
+++ b/gincmd/initcmd.go
@@ -12,7 +12,7 @@ import (
 func initRepo(cmd *cobra.Command, args []string) {
 	conf := config.Read()
 	gincl := ginclient.New(conf.GinHost)
-	fmt.Print("Initialising local storage ")
+	fmt.Print(":: Initialising local storage ")
 	err := gincl.InitDir()
 	CheckError(err)
 	_, err = git.CommitIfNew("")

--- a/gincmd/lockcmd.go
+++ b/gincmd/lockcmd.go
@@ -23,9 +23,9 @@ func lock(cmd *cobra.Command, args []string) {
 	}
 	conf := config.Read()
 	gincl := ginclient.New(conf.GinHost)
+	nitems := countItemsLock(args)
 	lockchan := make(chan git.RepoFileStatus)
 	go gincl.LockContent(args, lockchan)
-	nitems := countItemsLock(args)
 	formatOutput(lockchan, nitems, jsonout)
 }
 

--- a/gincmd/lockcmd.go
+++ b/gincmd/lockcmd.go
@@ -21,6 +21,10 @@ func lock(cmd *cobra.Command, args []string) {
 	if !git.IsRepo() {
 		Die("This command must be run from inside a gin repository.")
 	}
+	// lock should do nothing in direct mode
+	if git.IsDirect() {
+		return
+	}
 	conf := config.Read()
 	gincl := ginclient.New(conf.GinHost)
 	nitems := countItemsLock(args)

--- a/gincmd/lockcmd.go
+++ b/gincmd/lockcmd.go
@@ -7,6 +7,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func countItemsLock(paths []string) (count int) {
+	statchan := make(chan git.AnnexStatusRes)
+	go git.AnnexStatus(paths, statchan)
+	for _ = range statchan {
+		count++
+	}
+	return
+}
+
 func lock(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
 	if !git.IsRepo() {
@@ -16,7 +25,8 @@ func lock(cmd *cobra.Command, args []string) {
 	gincl := ginclient.New(conf.GinHost)
 	lockchan := make(chan git.RepoFileStatus)
 	go gincl.LockContent(args, lockchan)
-	formatOutput(lockchan, jsonout)
+	nitems := countItemsLock(args)
+	formatOutput(lockchan, nitems, jsonout)
 }
 
 // LockCmd sets up the file 'lock' subcommand

--- a/gincmd/logincmd.go
+++ b/gincmd/logincmd.go
@@ -51,7 +51,7 @@ func login(cmd *cobra.Command, args []string) {
 	CheckError(err)
 	info, err := gincl.RequestAccount(username)
 	CheckError(err)
-	fmt.Printf("Hello %s. You are now logged in.\n", info.UserName)
+	fmt.Printf(":: Hello %s. You are now logged in.\n", info.UserName)
 }
 
 // LoginCmd sets up the 'login' subcommand

--- a/gincmd/logoutcmd.go
+++ b/gincmd/logoutcmd.go
@@ -20,7 +20,7 @@ func logout(cmd *cobra.Command, args []string) {
 	}
 
 	gincl.Logout()
-	fmt.Println("You have been logged out.")
+	fmt.Println(":: You have been logged out.")
 }
 
 // LogoutCmd sets up the 'logout' subcommand

--- a/gincmd/removecontentcmd.go
+++ b/gincmd/removecontentcmd.go
@@ -19,10 +19,10 @@ func remove(cmd *cobra.Command, args []string) {
 	gincl.GitUser = conf.GitUser
 	lockchan := make(chan git.RepoFileStatus)
 	go gincl.LockContent(args, lockchan)
-	formatOutput(lockchan, jsonout)
+	formatOutput(lockchan, 0, jsonout)
 	rmchan := make(chan git.RepoFileStatus)
 	go gincl.RemoveContent(args, rmchan)
-	formatOutput(rmchan, jsonout)
+	formatOutput(rmchan, 0, jsonout)
 }
 
 // RemoveContentCmd sets up the 'remove-content' subcommand

--- a/gincmd/removecontentcmd.go
+++ b/gincmd/removecontentcmd.go
@@ -7,6 +7,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func countItemsRemove(paths []string) int {
+	avail, err := git.AnnexFind(paths)
+	if err != nil {
+		return 0
+	}
+	return len(avail)
+}
+
 func remove(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
 	conf := config.Read()
@@ -17,12 +25,11 @@ func remove(cmd *cobra.Command, args []string) {
 	}
 	gincl.GitHost = conf.GitHost
 	gincl.GitUser = conf.GitUser
-	lockchan := make(chan git.RepoFileStatus)
-	go gincl.LockContent(args, lockchan)
-	formatOutput(lockchan, 0, jsonout)
+	lock(cmd, args)
+	nitems := countItemsRemove(args)
 	rmchan := make(chan git.RepoFileStatus)
 	go gincl.RemoveContent(args, rmchan)
-	formatOutput(rmchan, 0, jsonout)
+	formatOutput(rmchan, nitems, jsonout)
 }
 
 // RemoveContentCmd sets up the 'remove-content' subcommand

--- a/gincmd/unlockcmd.go
+++ b/gincmd/unlockcmd.go
@@ -7,6 +7,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func countItemsUnlock(paths []string) (count int) {
+	wichan := make(chan git.AnnexWhereisRes)
+	go git.AnnexWhereis(paths, wichan)
+	for _ = range wichan {
+		count++
+	}
+	return
+}
+
 func unlock(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
 	if !git.IsRepo() {
@@ -16,7 +25,8 @@ func unlock(cmd *cobra.Command, args []string) {
 	gincl := ginclient.New(conf.GinHost)
 	unlockchan := make(chan git.RepoFileStatus)
 	go gincl.UnlockContent(args, unlockchan)
-	formatOutput(unlockchan, jsonout)
+	nitems := countItemsUnlock(args)
+	formatOutput(unlockchan, nitems, jsonout)
 }
 
 // UnlockCmd sets up the file 'unlock' subcommand

--- a/gincmd/unlockcmd.go
+++ b/gincmd/unlockcmd.go
@@ -21,6 +21,10 @@ func unlock(cmd *cobra.Command, args []string) {
 	if !git.IsRepo() {
 		Die("This command must be run from inside a gin repository.")
 	}
+	// unlock should do nothing in direct mode
+	if git.IsDirect() {
+		return
+	}
 	conf := config.Read()
 	gincl := ginclient.New(conf.GinHost)
 	nitems := countItemsUnlock(args)

--- a/gincmd/unlockcmd.go
+++ b/gincmd/unlockcmd.go
@@ -23,9 +23,9 @@ func unlock(cmd *cobra.Command, args []string) {
 	}
 	conf := config.Read()
 	gincl := ginclient.New(conf.GinHost)
+	nitems := countItemsUnlock(args)
 	unlockchan := make(chan git.RepoFileStatus)
 	go gincl.UnlockContent(args, unlockchan)
-	nitems := countItemsUnlock(args)
 	formatOutput(unlockchan, nitems, jsonout)
 }
 

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -27,7 +27,7 @@ func upload(cmd *cobra.Command, args []string) {
 		// Don't add + commit files if nothing was specified
 		addchan := make(chan git.RepoFileStatus)
 		go ginclient.Add(paths, addchan)
-		formatOutput(addchan, jsonout)
+		formatOutput(addchan, 0, jsonout)
 
 		fmt.Print("Recording changes ")
 		// ignore error for now :: call commit() instead
@@ -37,7 +37,7 @@ func upload(cmd *cobra.Command, args []string) {
 
 	uploadchan := make(chan git.RepoFileStatus)
 	go gincl.Upload(paths, uploadchan)
-	formatOutput(uploadchan, jsonout)
+	formatOutput(uploadchan, 0, jsonout)
 }
 
 // UploadCmd sets up the 'upload' subcommand

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -1,8 +1,6 @@
 package gincmd
 
 import (
-	"fmt"
-
 	ginclient "github.com/G-Node/gin-cli/ginclient"
 	"github.com/G-Node/gin-cli/ginclient/config"
 	"github.com/G-Node/gin-cli/git"
@@ -24,15 +22,7 @@ func upload(cmd *cobra.Command, args []string) {
 	paths := args
 
 	if len(paths) > 0 {
-		// Don't add + commit files if nothing was specified
-		addchan := make(chan git.RepoFileStatus)
-		go ginclient.Add(paths, addchan)
-		formatOutput(addchan, 0, jsonout)
-
-		fmt.Print("Recording changes ")
-		// ignore error for now :: call commit() instead
-		git.Commit(makeCommitMessage("upload", paths))
-		fmt.Println(green("OK"))
+		commit(cmd, paths)
 	}
 
 	uploadchan := make(chan git.RepoFileStatus)

--- a/gincmd/versioncmd.go
+++ b/gincmd/versioncmd.go
@@ -48,7 +48,7 @@ func repoversion(cmd *cobra.Command, args []string) {
 
 		addchan := make(chan git.RepoFileStatus)
 		go ginclient.Add(paths, addchan)
-		formatOutput(addchan, jsonout)
+		formatOutput(addchan, 0, jsonout)
 
 		fmt.Print("Recording changes ")
 		err = git.Commit(makeCommitMessage("commit", paths))

--- a/git/annex.go
+++ b/git/annex.go
@@ -658,6 +658,11 @@ func AnnexFind(paths []string) (map[string]AnnexFindRes, error) {
 	outlines := bytes.Split(stdout, []byte("\n"))
 	items := make(map[string]AnnexFindRes, len(outlines))
 	for _, line := range outlines {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			// Empty line output. Ignore
+			continue
+		}
 		var afr AnnexFindRes
 		json.Unmarshal(line, &afr)
 		items[afr.Key] = afr

--- a/git/annex.go
+++ b/git/annex.go
@@ -622,7 +622,7 @@ func AnnexUnlock(filepaths []string, unlockchan chan<- RepoFileStatus) {
 			status.Err = nil
 		} else {
 			log.Write("Error unlocking %s", unlockres.File)
-			status.Err = fmt.Errorf("Content not available locally\nUse 'gin get-content' to download")
+			status.Err = fmt.Errorf("Content not available locally. Use 'gin get-content' to download")
 		}
 		status.Progress = progcomplete
 		unlockchan <- status

--- a/git/git.go
+++ b/git/git.go
@@ -341,9 +341,9 @@ func Commit(commitmsg string) error {
 
 	if err != nil {
 		if strings.Contains(string(stdout), "nothing to commit") {
-			// eat the error
+			// Return special error
 			log.Write("Nothing to commit")
-			return nil
+			return fmt.Errorf("Nothing to commit")
 		}
 		log.Write("Error during GitCommit")
 		logstd(stdout, stderr)


### PR DESCRIPTION
This PR is prints a progress bar for operations where a per-file rate and progress is not possible.

Affected operations
- Commit: Adding files during a commit involves computing hashes. There's no straightforward way to get the progress of a hashing operation for a single file.
- Lock: Same as commit (lock is an 'add' operation).
- Unlock: Involves copying a file in place of its symlink. The annex unlock command does not expose any kind of progress information.
- Remove content: Involves checking if content is available on the server and then removing the local data.

When any of these operations is being performed, a progress bar is printed which displays the progress of the overall operation and the filecount. See attached image for a demonstration.

[![asciicast](https://asciinema.org/a/lmvK00K2ilJvSCEiCzdGEvy1q.png)](https://asciinema.org/a/lmvK00K2ilJvSCEiCzdGEvy1q)

Internally, in order to create the progress, before each operation, some precalculation is performed to figure out the number of files that will be affected. This overhead is small and I think is acceptable in order to have a progress indicator.

Closes #173.