### PR TITLE
Fix for ls file status in direct mode

### DIFF
--- a/ginclient/repos.go
+++ b/ginclient/repos.go
@@ -709,9 +709,7 @@ func lfIndirect(paths ...string) (map[string]FileStatus, error) {
 			// Two notes:
 			//		1. There will definitely be overlap here with the same status in annex (not a problem)
 			//		2. The diff might be due to remote or local changes, but for now we're going to assume local
-			if strings.TrimSpace(fname) != "" {
-				statuses[fname] = LocalChanges
-			}
+			statuses[fname] = LocalChanges
 		}
 	}
 

--- a/git/git.go
+++ b/git/git.go
@@ -357,7 +357,9 @@ func Commit(commitmsg string) error {
 // (git diff --name-only --relative @{upstream})
 func DiffUpstream(paths []string, diffchan chan<- string) {
 	defer close(diffchan)
-	diffargs := []string{"diff", "-z", "--name-only", "--relative", "@{upstream}"}
+	// FIXME: Direct mode gets weird with the branches, so we explicitly state origin/master
+	// Should be fixed when we add configurable remotes
+	diffargs := []string{"diff", "-z", "--name-only", "--relative", "origin/master"} // "@{upstream}"}
 	diffargs = append(diffargs, paths...)
 	cmd := Command(diffargs...)
 	err := cmd.Start()
@@ -756,6 +758,10 @@ func IsVersion6() bool {
 	ver := strings.TrimSpace(string(stdout))
 	log.Write("Annex version is %s", ver)
 	return ver == "6"
+}
+
+func SetBare(state bool) {
+	setBare(state)
 }
 
 func setBare(state bool) error {

--- a/git/util.go
+++ b/git/util.go
@@ -90,6 +90,7 @@ func pathExists(path string) bool {
 }
 
 func stringInSlice(element string, strlist []string) bool {
+	// TODO: Replace this function with a map where possible
 	for _, str := range strlist {
 		if element == str {
 			return true


### PR DESCRIPTION
This PR fixes the status of files when working in direct mode. Previously, some conditions weren't being detected correctly, mostly due to direct mode working with bare repositories.

`gin ls` in direct mode now produces the exact same output as in indirect mode, with the exception of locking and unlocking of files having no effect.

Tests have been updated to reflect these changes.