### PR TITLE
New command: add-remote

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,8 @@ after_script:
   # push logs to gist
   - if [ ${TRAVIS_GO_VERSION} != "tip" ]; then
         echo $GISTTOKEN > ./tests/testuserhome/.gist;
-        mv ./scripts/log/gin.log ./scripts/log/gin-${TRAVIS_BRANCH}.log;
-        mv ./scripts/log/tests.log ./scripts/log/tests-${TRAVIS_BRANCH}.log;
+        mv ./tests/scripts/log/gin.log ./tests/scripts/log/gin-${TRAVIS_BRANCH}.log;
+        mv ./tests/scripts/log/tests.log ./tests/scripts/log/tests-${TRAVIS_BRANCH}.log;
         ./tests/run-cont gist -u 59e3b1c2fc3ff525127f9b3af81e7f4c ./scripts/log/*.log;
         rm ./tests/testuserhome/.gist;
     fi

--- a/doc/config.md
+++ b/doc/config.md
@@ -11,19 +11,22 @@ In addition to this global configuration, the [git-annex filtering criteria](fil
 The following shows the default values for every configurable option
 ```yaml
 bin:
-    git: git
-    gitannex: git-annex
-    ssh: ssh
+  git: git
+  gitannex: git-annex
+  ssh: ssh
 
-gin:
-    address: https://web.gin.g-node.org
-    port: 443
+servers:
+  gin:
+    web:
+      protocol: https
+      host: web.gin.g-node.org
+      port: 443
 
-git:
-    address: gin.g-node.org
-    port: 22
-    user: git
-    hostkey: "gin.g-node.org,141.84.41.216 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBE5IBgKP3nUryEFaACwY4N3jlqDx8Qw1xAxU2Xpt5V0p9RNefNnedVmnIBV6lA3n+9kT1OSbyqA/+SgsQ57nHo0="
+    git:
+      host: gin.g-node.org
+      port: 22
+      user: git
+      hostkey: "gin.g-node.org,141.84.41.216 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBE5IBgKP3nUryEFaACwY4N3jlqDx8Qw1xAxU2Xpt5V0p9RNefNnedVmnIBV6lA3n+9kT1OSbyqA/+SgsQ57nHo0="
 
 annex:
     minsize: 10M
@@ -35,14 +38,16 @@ annex:
     - git: The path to the git executable.
     - gitannex: The path to the git-annex executable.
     - ssh: The path to the ssh executable.
-- gin: The gin section is used to specify the address and port of the GIN web server. By default it points to the official G-Node GIN server. This can be changed to work with locally deployed servers.
-    - address: The web address of the server. This should include the scheme (e.g., `http://`, `https://`).
-    - port: The port used by the server, typically `80` for `HTTP` or `443` for `HTTPS`.
-- git: The git section is used to specify the git address, port, username, and host key that the GIN web server is configured to use.
-    - address: The git/ssh server address. This is often the same as the web (gin) address, but may be different, or have a different subdomain.
-    - port: The ssh server port (typically `22`).
-    - user: For most git servers this is simply the user `git`. This is the name of the server-side user that handles all remote git operations.
-    - hostkey: The SSH key of the git server. The GIN client uses strict host key checking, so if this is not specified, or is specified incorrectly, git operations will not work. This key is different for each server installation.
+- servers: The servers section is used to define GIN servers that the client can interact with. By default, there is only one server configured called 'gin'.
+  - gin: The default GIN server. By default it points to the official G-Node GIN server. This can be changed to work with locally deployed servers. Additional servers can be added with different names (called aliases).
+      - protocol: The protocol (scheme) used by the server, typically `http` or `https`.
+      - host: The web address of the server.
+      - port: The port used by the server, typically `80` for `HTTP` or `443` for `HTTPS`.
+  - git: The git section is used to specify the git address, port, username, and host key that the GIN web server is configured to use.
+      - address: The git/ssh server address. This is often the same as the web (gin) address, but may be different, or have a different subdomain.
+      - port: The ssh server port (typically `22`).
+      - user: For most git servers this is simply the user `git`. This is the name of the server-side user that handles all remote git operations.
+      - hostkey: The SSH key of the git server. The GIN client uses strict host key checking, so if this is not specified, or is specified incorrectly, git operations will not work. This key is different for each server installation.
 - annex: The annex section is used to specify the [git-annex filtering criteria](filtering.md). This is the only configuration section that is read for **local** (per repository) configurations.
     - minsize: The minimum size of a file that should be added to the annex. All files smaller than this size are added to git instead.
     - exclude: Patterns or filenames that should be excluded from the annex. For example, the pattern `*.py` will exclude all Python source code files from the annex, adding them to git instead. Files which match a pattern are always excluded from the annex, even if they are above the minsize. Patterns should be specified as a list of strings, e.g., `["*.py", "*.md", "*.m"]`.

--- a/ginclient/config/config.go
+++ b/ginclient/config/config.go
@@ -13,28 +13,28 @@ import (
 
 var configDirs = configdir.New("g-node", "gin")
 
-// WebConfiguration is the configuration for the web server.
-type WebConfiguration struct {
+// WebCfg is the configuration for the web server.
+type WebCfg struct {
 	Protocol string
 	Host     string
 	Port     string
 }
 
-// GitConfiguration is the configuration for the git server.
-type GitConfiguration struct {
+// GitCfg is the configuration for the git server.
+type GitCfg struct {
 	User string
 	Host string
 	Port string
 }
 
-// ServerConfiguration holds the information required for GIN servers (web and git).
-type ServerConfiguration struct {
-	Web WebConfiguration
-	Git GitConfiguration
+// ServerCfg holds the information required for GIN servers (web and git).
+type ServerCfg struct {
+	Web WebCfg
+	Git GitCfg
 }
 
-// GinConfiguration holds the client configuration values.
-type GinConfiguration struct {
+// GinCliCfg holds the client configuration values.
+type GinCliCfg struct {
 	GinHost    string
 	GitHost    string
 	GitUser    string
@@ -78,12 +78,12 @@ func findreporoot(path string) (string, error) {
 }
 
 // local configuration cache
-var configuration GinConfiguration
+var configuration GinCliCfg
 var set = false
 
 // Read loads in the configuration from the config file(s) and returns a populated GinConfiguration struct.
 // The configuration is cached. Subsequent reads reuse the already loaded configuration.
-func Read() GinConfiguration {
+func Read() GinCliCfg {
 	if set {
 		return configuration
 	}
@@ -152,7 +152,8 @@ func Read() GinConfiguration {
 	return configuration
 }
 
-func WriteServerConf(alias string, conf ServerConfiguration) error {
+func WriteServerConf(alias string, conf ServerCfg) error {
+	fmt.Printf("Saving to %s: %+v", alias, conf)
 	return nil
 }
 

--- a/ginclient/config/config.go
+++ b/ginclient/config/config.go
@@ -163,17 +163,26 @@ func removeInvalidServerConfs() {
 	}
 }
 
+// WriteServerConf writes a new server configuration into the user config file.
 func WriteServerConf(alias string, newcfg ServerCfg) error {
-	configuration := Read()
-	configuration.Servers[alias] = newcfg
+	// Read in the file configuration ONLY
+	confpath, _ := Path(true) // create config path if necessary
+	confpath = filepath.Join(confpath, defaultFileName)
+	v := viper.New()
+	v.SetConfigFile(confpath)
 
-	confpath, _ := Path(false)
-	configFileName := "config.yml"
-	confpath = filepath.Join(confpath, configFileName)
-	viper.SetConfigFile(confpath)
+	v.ReadInConfig()
 
-	// viper.
-	// 	viper.WriteConfigAs
+	v.Set(fmt.Sprintf("servers.%s.web.protocol", alias), newcfg.Web.Protocol)
+	v.Set(fmt.Sprintf("servers.%s.web.host", alias), newcfg.Web.Host)
+	v.Set(fmt.Sprintf("servers.%s.web.port", alias), newcfg.Web.Port)
+
+	v.Set(fmt.Sprintf("servers.%s.git.user", alias), newcfg.Git.User)
+	v.Set(fmt.Sprintf("servers.%s.git.host", alias), newcfg.Git.Host)
+	v.Set(fmt.Sprintf("servers.%s.git.port", alias), newcfg.Git.Port)
+
+	v.WriteConfig()
+
 	return nil
 }
 

--- a/ginclient/config/config.go
+++ b/ginclient/config/config.go
@@ -180,6 +180,7 @@ func WriteServerConf(alias string, newcfg ServerCfg) error {
 	v.Set(fmt.Sprintf("servers.%s.git.user", alias), newcfg.Git.User)
 	v.Set(fmt.Sprintf("servers.%s.git.host", alias), newcfg.Git.Host)
 	v.Set(fmt.Sprintf("servers.%s.git.port", alias), newcfg.Git.Port)
+	v.Set(fmt.Sprintf("servers.%s.git.hostkey", alias), newcfg.Git.HostKey)
 
 	v.WriteConfig()
 

--- a/ginclient/config/config.go
+++ b/ginclient/config/config.go
@@ -144,7 +144,7 @@ func Read() GinCliCfg {
 func removeInvalidServerConfs() {
 	// Check server configurations for invalid names and port numbers
 	for alias := range viper.GetStringMap("servers") {
-		if alias == "dir" || alias == "all" {
+		if alias == "dir" {
 			fmt.Fprintf(color.Error, "%s server alias '%s' is not allowed (reserved word): server configuration ignored\n", yellow("[warning]"), alias)
 			delete(configuration.Servers, alias)
 			continue

--- a/ginclient/config/config.go
+++ b/ginclient/config/config.go
@@ -124,7 +124,7 @@ func Read() GinConfiguration {
 	configuration.Annex.Exclude = viper.GetStringSlice("annex.exclude")
 	configuration.Annex.MinSize = viper.GetString("annex.minsize")
 
-	log.Write("configurationuration values")
+	log.Write("values")
 	log.Write("%+v", configuration)
 
 	// TODO: Validate URLs on config read

--- a/ginclient/config/config.go
+++ b/ginclient/config/config.go
@@ -2,29 +2,47 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/G-Node/gin-cli/ginclient/log"
+	"github.com/fatih/color"
 	"github.com/shibukawa/configdir"
 	"github.com/spf13/viper"
 )
 
-var configDirs = configdir.New("g-node", "gin")
+var (
+	configDirs = configdir.New("g-node", "gin")
+	yellow     = color.New(color.FgYellow).SprintFunc()
+)
 
 // WebCfg is the configuration for the web server.
 type WebCfg struct {
 	Protocol string
 	Host     string
-	Port     string
+	Port     uint16
+}
+
+// AddressStr constructs a full address string from the configuration.
+// The string has the format Scheme://Host:Port (e.g., https://web.gin.g-node.org:443)
+func (c WebCfg) AddressStr() string {
+	return fmt.Sprintf("%s://%s:%d", c.Protocol, c.Host, c.Port)
 }
 
 // GitCfg is the configuration for the git server.
 type GitCfg struct {
-	User string
-	Host string
-	Port string
+	User    string
+	Host    string
+	Port    uint16
+	HostKey string
+}
+
+// AddressStr constructs a full address string from the configuration.
+// The string has the format ssh://User@Host:Port (e.g., ssh://git@gin.g-node.org:22)
+func (c GitCfg) AddressStr() string {
+	return fmt.Sprintf("ssh://%s@%s:%d", c.User, c.Host, c.Port)
 }
 
 // ServerCfg holds the information required for GIN servers (web and git).
@@ -35,11 +53,8 @@ type ServerCfg struct {
 
 // GinCliCfg holds the client configuration values.
 type GinCliCfg struct {
-	GinHost    string
-	GitHost    string
-	GitUser    string
-	GitHostKey string
-	Bin        struct {
+	Servers map[string]ServerCfg
+	Bin     struct {
 		Git      string
 		GitAnnex string
 		SSH      string
@@ -94,15 +109,6 @@ func Read() GinCliCfg {
 	viper.SetDefault("bin.gitannex", "git-annex")
 	viper.SetDefault("bin.ssh", "ssh")
 
-	// Hosts
-	viper.SetDefault("gin.address", "https://web.gin.g-node.org")
-	viper.SetDefault("gin.port", "443")
-
-	viper.SetDefault("git.address", "gin.g-node.org")
-	viper.SetDefault("git.port", "22")
-	viper.SetDefault("git.user", "git")
-	viper.SetDefault("git.hostkey", "gin.g-node.org,141.84.41.216 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBE5IBgKP3nUryEFaACwY4N3jlqDx8Qw1xAxU2Xpt5V0p9RNefNnedVmnIBV6lA3n+9kT1OSbyqA/+SgsQ57nHo0=")
-
 	// annex filters
 	viper.SetDefault("annex.minsize", "10M")
 
@@ -117,19 +123,43 @@ func Read() GinCliCfg {
 		log.Write("Found config file %s", confpath)
 	}
 
+	// Servers
+	servers := make(map[string]ServerCfg)
+
+	// append default gin configuration
+	servers["gin"] = ServerCfg{
+		WebCfg{
+			Protocol: "https",
+			Host:     "web.gin.g-node.org",
+			Port:     443,
+		},
+		GitCfg{
+			Host:    "gin.g-node.org",
+			Port:    22,
+			User:    "git",
+			HostKey: "gin.g-node.org,141.84.41.216 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBE5IBgKP3nUryEFaACwY4N3jlqDx8Qw1xAxU2Xpt5V0p9RNefNnedVmnIBV6lA3n+9kT1OSbyqA/+SgsQ57nHo0=",
+		},
+	}
+
+	// Read the config, overwriting the "gin" configuration if it exists
+	srvcfgMap := viper.GetStringMap("servers")
+	for alias, cfg := range srvcfgMap {
+		// Marshal map then unmarshal into ServerCfg struct
+		marshaled, _ := json.Marshal(cfg)
+		s := ServerCfg{}
+		err := json.Unmarshal(marshaled, &s)
+		if err != nil {
+			fmt.Fprintf(color.Output, "%s invalid value found in configuration for '%s': server configuration ignored\n", yellow("[warning]"), alias)
+			continue
+		}
+		servers[alias] = s
+	}
+	configuration.Servers = servers
+
+	// Binaries
 	configuration.Bin.Git = viper.GetString("bin.git")
 	configuration.Bin.GitAnnex = viper.GetString("bin.gitannex")
 	configuration.Bin.SSH = viper.GetString("bin.ssh")
-
-	ginAddress := viper.GetString("gin.address")
-	ginPort := viper.GetInt("gin.port")
-	configuration.GinHost = fmt.Sprintf("%s:%d", ginAddress, ginPort)
-
-	gitAddress := viper.GetString("git.address")
-	gitPort := viper.GetInt("git.port")
-	configuration.GitHost = fmt.Sprintf("%s:%d", gitAddress, gitPort)
-	configuration.GitUser = viper.GetString("git.user")
-	configuration.GitHostKey = viper.GetString("git.hostkey")
 
 	// configuration file in the repository root (annex excludes and size threshold only)
 	reporoot, err := findreporoot(".")

--- a/ginclient/config/config.go
+++ b/ginclient/config/config.go
@@ -13,7 +13,27 @@ import (
 
 var configDirs = configdir.New("g-node", "gin")
 
-// GinConfiguration holds the client configuration values
+// WebConfiguration is the configuration for the web server.
+type WebConfiguration struct {
+	Protocol string
+	Host     string
+	Port     string
+}
+
+// GitConfiguration is the configuration for the git server.
+type GitConfiguration struct {
+	User string
+	Host string
+	Port string
+}
+
+// ServerConfiguration holds the information required for GIN servers (web and git).
+type ServerConfiguration struct {
+	Web WebConfiguration
+	Git GitConfiguration
+}
+
+// GinConfiguration holds the client configuration values.
 type GinConfiguration struct {
 	GinHost    string
 	GitHost    string
@@ -130,6 +150,10 @@ func Read() GinConfiguration {
 	// TODO: Validate URLs on config read
 	set = true
 	return configuration
+}
+
+func WriteServerConf(alias string, conf ServerConfiguration) error {
+	return nil
 }
 
 // Path returns the configuration path where configuration files should be stored.

--- a/ginclient/gin.go
+++ b/ginclient/gin.go
@@ -33,7 +33,7 @@ type GINUser struct {
 
 // New returns a new client for the GIN server.
 func New(host string) *Client {
-	return &Client{Client: web.NewClient(host)}
+	return &Client{Client: web.New(host)}
 }
 
 // AccessToken represents a API access token.
@@ -45,8 +45,7 @@ type AccessToken struct {
 // Client is a client interface to the GIN server. Embeds web.Client.
 type Client struct {
 	*web.Client
-	GitHost string
-	GitUser string
+	GitAddress string
 }
 
 // GetUserKeys fetches the public keys that the user has added to the auth server.
@@ -280,7 +279,7 @@ func (gincl *Client) Logout() {
 func MakeHostsFile() {
 	conf := config.Read()
 	hostkeyfile := git.HostKeyPath()
-	ginhostkey := fmt.Sprintln(conf.GitHostKey)
+	ginhostkey := fmt.Sprintln(conf.Servers["gin"].Git.HostKey)
 	_ = ioutil.WriteFile(hostkeyfile, []byte(ginhostkey), 0600)
 	return
 }

--- a/ginclient/repos.go
+++ b/ginclient/repos.go
@@ -249,6 +249,7 @@ func Add(paths []string, addchan chan<- git.RepoFileStatus) {
 // Upload transfers locally recorded changes to a remote.
 // The status channel 'uploadchan' is closed when this function returns.
 func (gincl *Client) Upload(paths []string, remotes []string, uploadchan chan<- git.RepoFileStatus) {
+	// TODO: Does this need to be a Client method?
 	defer close(uploadchan)
 	log.Write("Upload")
 
@@ -375,12 +376,12 @@ func (gincl *Client) Download() error {
 
 // CloneRepo clones a remote repository and initialises annex.
 // The status channel 'clonechan' is closed when this function returns.
-func (gincl *Client) CloneRepo(repoPath string, clonechan chan<- git.RepoFileStatus) {
+func (gincl *Client) CloneRepo(repopath string, clonechan chan<- git.RepoFileStatus) {
 	defer close(clonechan)
 	log.Write("CloneRepo")
 	clonestatus := make(chan git.RepoFileStatus)
-	remotepath := fmt.Sprintf("ssh://%s@%s/%s", gincl.GitUser, gincl.GitHost, repoPath)
-	go git.Clone(remotepath, repoPath, clonestatus)
+	remotepath := fmt.Sprintf("%s/%s", gincl.GitAddress, repopath)
+	go git.Clone(remotepath, repopath, clonestatus)
 	for stat := range clonestatus {
 		clonechan <- stat
 		if stat.Err != nil {
@@ -388,7 +389,7 @@ func (gincl *Client) CloneRepo(repoPath string, clonechan chan<- git.RepoFileSta
 		}
 	}
 
-	repoPathParts := strings.SplitN(repoPath, "/", 2)
+	repoPathParts := strings.SplitN(repopath, "/", 2)
 	repoName := repoPathParts[1]
 
 	status := git.RepoFileStatus{State: "Initialising local storage"}

--- a/ginclient/repos.go
+++ b/ginclient/repos.go
@@ -444,11 +444,18 @@ func DefaultRemote() (string, error) {
 
 // SetDefaultRemote sets the name of the default gin remote.
 func SetDefaultRemote(remote string) error {
-	err := git.ConfigSet("gin.remote", remote)
+	remotes, err := git.RemoteShow()
 	if err != nil {
-		err = fmt.Errorf("Failed to set default remote: %s", err)
+		return fmt.Errorf("failed to determine configured remotes")
 	}
-	return err
+	if _, ok := remotes[remote]; !ok {
+		return fmt.Errorf("no such remote: %s", remote)
+	}
+	err = git.ConfigSet("gin.remote", remote)
+	if err != nil {
+		return fmt.Errorf("failed to set default remote: %s", err)
+	}
+	return nil
 }
 
 // CheckoutVersion checks out all files specified by paths from the revision with the specified commithash.

--- a/ginclient/repos.go
+++ b/ginclient/repos.go
@@ -466,6 +466,19 @@ func SetDefaultRemote(remote string) error {
 	return nil
 }
 
+// RemoveRemote removes a remote from the repository configuration.
+func RemoveRemote(remote string) error {
+	remotes, err := git.RemoteShow()
+	if err != nil {
+		return fmt.Errorf("failed to determine configured remotes")
+	}
+	if _, ok := remotes[remote]; !ok {
+		return fmt.Errorf("no such remote: %s", remote)
+	}
+	err = git.RemoteRemove(remote)
+	return err
+}
+
 // CheckoutVersion checks out all files specified by paths from the revision with the specified commithash.
 func CheckoutVersion(commithash string, paths []string) error {
 	return git.Checkout(commithash, paths)

--- a/ginclient/repos.go
+++ b/ginclient/repos.go
@@ -386,7 +386,7 @@ func (gincl *Client) CloneRepo(repoPath string, clonechan chan<- git.RepoFileSta
 	status := git.RepoFileStatus{State: "Initialising local storage"}
 	clonechan <- status
 	os.Chdir(repoName)
-	err := gincl.InitDir()
+	err := gincl.InitDir(false)
 	if err != nil {
 		status.Err = err
 		clonechan <- status
@@ -477,11 +477,12 @@ func CheckoutFileCopies(commithash string, paths []string, outpath string, suffi
 }
 
 // InitDir initialises the local directory with the default remote and annex configuration.
+// Optionally initialised as a bare repository (for annex directory remotes).
 // The status channel 'initchan' is closed when this function returns.
-func (gincl *Client) InitDir() error {
+func (gincl *Client) InitDir(bare bool) error {
 	initerr := ginerror{Origin: "InitDir", Description: "Error initialising local directory"}
 	if !git.IsRepo() {
-		err := git.Init(false)
+		err := git.Init(bare)
 		if err != nil {
 			initerr.UError = err.Error()
 			return initerr

--- a/ginclient/repos.go
+++ b/ginclient/repos.go
@@ -475,11 +475,8 @@ func CheckoutFileCopies(commithash string, paths []string, outpath string, suffi
 func (gincl *Client) InitDir() error {
 	initerr := ginerror{Origin: "InitDir", Description: "Error initialising local directory"}
 	if !git.IsRepo() {
-		cmd := git.Command("init")
-		stdout, stderr, err := cmd.OutputError()
+		err := git.Init(false)
 		if err != nil {
-			log.Write("Error during Init command: %s", string(stderr))
-			log.Write("[stdout]\n%s\n[stderr]\n%s", string(stdout), string(stderr))
 			initerr.UError = err.Error()
 			return initerr
 		}

--- a/ginclient/repos.go
+++ b/ginclient/repos.go
@@ -268,7 +268,6 @@ func (gincl *Client) Upload(paths []string, remotes []string, uploadchan chan<- 
 	}
 
 	for _, remote := range remotes {
-		// TODO: Add remote destination to RepoFileStatus
 		annexpushchan := make(chan git.RepoFileStatus)
 		go git.AnnexPush(paths, remote, annexpushchan)
 		for stat := range annexpushchan {

--- a/gincmd/addremote.go
+++ b/gincmd/addremote.go
@@ -148,18 +148,26 @@ func addRemote(cmd *cobra.Command, args []string) {
 
 // AddRemoteCmd sets up the 'add-remote' repository subcommand
 func AddRemoteCmd() *cobra.Command {
-	description := "Adds a server or location for data storage."
+	description := `Add a remote to the current repository for uploading and downloading. The name of the remote can be any word except the reserved keyword 'all'.
+
+The location must be of the form alias:path or server:path. Currently supported aliases are 'gin' for the default configured gin server, and 'dir' for directories. If neither is specified, it is assumed to be the address of a git server. For gin remotes, the path is the location of the repository on the server, in the form user/repositoryname. For directories, it is the path to the storage directory.
+
+When a remote is added, if it does not exist on the server or in the specified directory, the client will offer to create it. This is only possible for 'gin' and 'dir' remotes.
+
+A new remote is set as the default for uploading if no other remotes are configured. To set any new remote as the default, use the --default option. Use the 'set-remote' command to change the default remote at any time.`
+
+	// When a remote is added, if it does not exist, the client will offer to create it. This is only possible for 'gin' and 'dir' remotes and any other GIN servers the user has configured.`
 	args := map[string]string{
 		"<name>":     "The name of the new remote",
-		"<location>": "The server address or location for the data store.",
+		"<location>": "The location of the data store, in the form alias:path or server:path",
 	}
 	examples := map[string]string{
-		"Add a GIN server repository as a remote": "$ …",
-		"Add a storage drive":                     "$ …",
+		"Add a GIN server repository as a remote named 'primary'":          "$ gin add-remote primary gin:alice/example",
+		"Add a directory on a storage drive as a remote named 'datastore'": "$ gin add-remote datastore dir:/mnt/gindatastore",
 	}
 	var addRemoteCmd = &cobra.Command{
 		Use:     "add-remote <name> <location>",
-		Short:   description,
+		Short:   "Add a remote to the current repository for uploading and downloading.",
 		Long:    formatdesc(description, args),
 		Example: formatexamples(examples),
 		Args:    cobra.ExactArgs(2),
@@ -167,5 +175,6 @@ func AddRemoteCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	addRemoteCmd.Flags().Bool("create", false, "Create the remote on the server if it does not already exist.")
+	addRemoteCmd.Flags().Bool("default", false, "Sets the new remote as the default (if the command succeeds).")
 	return addRemoteCmd
 }

--- a/gincmd/addremote.go
+++ b/gincmd/addremote.go
@@ -133,6 +133,7 @@ func addRemote(cmd *cobra.Command, args []string) {
 	if name == allremotes {
 		Die("cannot set a remote with name 'all': see 'gin help add-remote' and 'gin help upload'")
 	}
+	// TODO: Check if remote with same name already exists; fail early
 	rt, url := parseRemote(remote)
 	err := checkRemote(cmd, url)
 	// TODO: Check if it's a gin URL before offering to create

--- a/gincmd/addremote.go
+++ b/gincmd/addremote.go
@@ -21,6 +21,8 @@ const (
 	unknownrt
 )
 
+const allremotes = "all"
+
 func splitAliasRemote(remote string) (string, string) {
 	// split on first colon and check if it's a known alias
 	parts := strings.SplitN(remote, ":", 2)
@@ -128,6 +130,9 @@ func addRemote(cmd *cobra.Command, args []string) {
 	create, _ := flags.GetBool("create")
 	setdefault, _ := flags.GetBool("default")
 	name, remote := args[0], args[1]
+	if name == allremotes {
+		Die("cannot set a remote with name 'all': see 'gin help add-remote' and 'gin help upload'")
+	}
 	rt, url := parseRemote(remote)
 	err := checkRemote(cmd, url)
 	// TODO: Check if it's a gin URL before offering to create
@@ -153,7 +158,7 @@ func addRemote(cmd *cobra.Command, args []string) {
 
 // AddRemoteCmd sets up the 'add-remote' repository subcommand
 func AddRemoteCmd() *cobra.Command {
-	description := `Add a remote to the current repository for uploading and downloading. The name of the remote can be any word except the reserved keyword 'all'.
+	description := `Add a remote to the current repository for uploading and downloading. The name of the remote can be any word except the reserved keyword 'all' (reserved for performing uploads to all configured remotes).
 
 The location must be of the form alias:path or server:path. Currently supported aliases are 'gin' for the default configured gin server, and 'dir' for directories. If neither is specified, it is assumed to be the address of a git server. For gin remotes, the path is the location of the repository on the server, in the form user/repositoryname. For directories, it is the path to the storage directory.
 

--- a/gincmd/addremote.go
+++ b/gincmd/addremote.go
@@ -113,7 +113,7 @@ func promptCreate(cmd *cobra.Command, rt rtype, remote string) {
 	}
 }
 
-func defaultIfUnset(name string) {
+func defaultRemoteIfUnset(name string) {
 	_, err := ginclient.DefaultRemote()
 	if err != nil {
 		ginclient.SetDefaultRemote(name)

--- a/gincmd/addremote.go
+++ b/gincmd/addremote.go
@@ -163,7 +163,7 @@ func AddRemoteCmd() *cobra.Command {
 
 The location must be of the form alias:path or server:path. Currently supported aliases are 'gin' for the default configured gin server, and 'dir' for directories. If neither is specified, it is assumed to be the address of a git server. For gin remotes, the path is the location of the repository on the server, in the form user/repositoryname. For directories, it is the path to the storage directory.
 
-When a remote is added, if it does not exist on the server or in the specified directory, the client will offer to create it. This is only possible for 'gin' and 'dir' remotes.
+When a remote is added, if it does not exist, the client will offer to create it. This is only possible for 'gin' and 'dir' type remotes and any other GIN servers the user has configured.
 
 A new remote is set as the default for uploading if no other remotes are configured. To set any new remote as the default, use the --default option. Use the 'use-remote' command to change the default remote at any time.`
 

--- a/gincmd/addremote.go
+++ b/gincmd/addremote.go
@@ -159,7 +159,7 @@ The location must be of the form alias:path or server:path. Currently supported 
 
 When a remote is added, if it does not exist on the server or in the specified directory, the client will offer to create it. This is only possible for 'gin' and 'dir' remotes.
 
-A new remote is set as the default for uploading if no other remotes are configured. To set any new remote as the default, use the --default option. Use the 'set-remote' command to change the default remote at any time.`
+A new remote is set as the default for uploading if no other remotes are configured. To set any new remote as the default, use the --default option. Use the 'use-remote' command to change the default remote at any time.`
 
 	// When a remote is added, if it does not exist, the client will offer to create it. This is only possible for 'gin' and 'dir' remotes and any other GIN servers the user has configured.`
 	args := map[string]string{
@@ -172,7 +172,7 @@ A new remote is set as the default for uploading if no other remotes are configu
 	}
 	var addRemoteCmd = &cobra.Command{
 		Use:     "add-remote <name> <location>",
-		Short:   "Add a remote to the current repository for uploading and downloading.",
+		Short:   "Add a remote to the current repository for uploading and downloading",
 		Long:    formatdesc(description, args),
 		Example: formatexamples(examples),
 		Args:    cobra.ExactArgs(2),

--- a/gincmd/addremote.go
+++ b/gincmd/addremote.go
@@ -78,9 +78,8 @@ func createDirRemote(remote string) {
 	os.MkdirAll(repopath, 0755)
 	os.Chdir(repopath)
 	gincl := ginclient.New("")
-	err = gincl.InitDir()
+	err = gincl.InitDir(true)
 	CheckError(err)
-	git.SetBare(true)
 	git.AnnexDescribe("here", "GIN Storage")
 }
 

--- a/gincmd/addremote.go
+++ b/gincmd/addremote.go
@@ -126,6 +126,7 @@ func addRemote(cmd *cobra.Command, args []string) {
 	}
 	flags := cmd.Flags()
 	create, _ := flags.GetBool("create")
+	setdefault, _ := flags.GetBool("default")
 	name, remote := args[0], args[1]
 	rt, url := parseRemote(remote)
 	err := checkRemote(cmd, url)
@@ -140,7 +141,11 @@ func addRemote(cmd *cobra.Command, args []string) {
 	err = git.RemoteAdd(name, url)
 	CheckError(err)
 	fmt.Printf(":: Added new remote: %s [%s]\n", name, url)
-	defaultIfUnset(name)
+	if setdefault {
+		ginclient.SetDefaultRemote(name)
+	} else {
+		defaultRemoteIfUnset(name)
+	}
 	defremote, err := ginclient.DefaultRemote()
 	CheckError(err)
 	fmt.Printf(":: Default remote: %s\n", defremote)

--- a/gincmd/addremote.go
+++ b/gincmd/addremote.go
@@ -76,15 +76,10 @@ func promptCreate(cmd *cobra.Command, remote string) {
 	}
 }
 
-func defaultIfOne(name string) {
-	remotes, err := git.RemoteShow()
-	CheckError(err)
-	if len(remotes) == 1 {
-		// Set default upstream
-		for k := range remotes {
-			git.BranchSetUpstream(k)
-			break
-		}
+func defaultIfUnset(name string) {
+	_, err := ginclient.DefaultRemote()
+	if err != nil {
+		ginclient.SetDefaultRemote(name)
 	}
 }
 
@@ -108,8 +103,8 @@ func addRemote(cmd *cobra.Command, args []string) {
 	err = git.RemoteAdd(name, url)
 	CheckError(err)
 	fmt.Printf(":: Added new remote: %s [%s]\n", name, url)
-	defaultIfOne(name)
-	defremote, err := git.DefaultRemote()
+	defaultIfUnset(name)
+	defremote, err := ginclient.DefaultRemote()
 	CheckError(err)
 	fmt.Printf(":: Default remote: %s\n", defremote)
 }

--- a/gincmd/addremote.go
+++ b/gincmd/addremote.go
@@ -109,8 +109,8 @@ func addRemote(cmd *cobra.Command, args []string) {
 	CheckError(err)
 	fmt.Printf(":: Added new remote: %s [%s]\n", name, url)
 	defaultIfOne(name)
-	defremote, err := git.ConfigGet("branch.master.remote")
-	CheckErrorMsg(err, "could not determine default remote")
+	defremote, err := git.DefaultRemote()
+	CheckError(err)
 	fmt.Printf(":: Default remote: %s\n", defremote)
 }
 

--- a/gincmd/addremote.go
+++ b/gincmd/addremote.go
@@ -76,6 +76,18 @@ func promptCreate(cmd *cobra.Command, remote string) {
 	}
 }
 
+func defaultIfOne(name string) {
+	remotes, err := git.RemoteShow()
+	CheckError(err)
+	if len(remotes) == 1 {
+		// Set default upstream
+		for k := range remotes {
+			git.BranchSetUpstream(k)
+			break
+		}
+	}
+}
+
 func addRemote(cmd *cobra.Command, args []string) {
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
@@ -96,6 +108,10 @@ func addRemote(cmd *cobra.Command, args []string) {
 	err = git.AddRemote(name, url)
 	CheckError(err)
 	fmt.Printf(":: Added new remote: %s [%s]\n", name, url)
+	defaultIfOne(name)
+	defremote, err := git.ConfigGet("branch.master.remote")
+	CheckErrorMsg(err, "could not determine default remote")
+	fmt.Printf(":: Default remote: %s\n", defremote)
 }
 
 // AddRemoteCmd sets up the 'add-remote' repository subcommand

--- a/gincmd/addremote.go
+++ b/gincmd/addremote.go
@@ -105,7 +105,7 @@ func addRemote(cmd *cobra.Command, args []string) {
 			promptCreate(cmd, remote)
 		}
 	}
-	err = git.AddRemote(name, url)
+	err = git.RemoteAdd(name, url)
 	CheckError(err)
 	fmt.Printf(":: Added new remote: %s [%s]\n", name, url)
 	defaultIfOne(name)

--- a/gincmd/addserver.go
+++ b/gincmd/addserver.go
@@ -95,7 +95,7 @@ func fetchHostKey(gitconf *config.GitCfg) {
 		HostKeyCallback: keycb,
 	}
 	_, err := ssh.Dial("tcp", fmt.Sprintf("%s:%d", gitconf.Host, gitconf.Port), &sshcon)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "unable to authenticate") {
 		Die(fmt.Sprintf("connection test failed: %s", err))
 	}
 	fmt.Printf(":: Host key fingerprint: %s\n", fingerprint)

--- a/gincmd/addserver.go
+++ b/gincmd/addserver.go
@@ -81,7 +81,7 @@ func parseGitstring(gitstring string) (gitconf config.GitCfg) {
 	return
 }
 
-func newRemote(cmd *cobra.Command, args []string) {
+func addServer(cmd *cobra.Command, args []string) {
 	alias := args[0]
 	webstring, _ := cmd.Flags().GetString("web")
 	gitstring, _ := cmd.Flags().GetString("git")
@@ -104,9 +104,9 @@ func newRemote(cmd *cobra.Command, args []string) {
 	config.WriteServerConf(alias, serverConf)
 }
 
-// NewRemoteCmd sets up the 'use-remote' repository subcommand
-func NewRemoteCmd() *cobra.Command {
-	description := `Configure a new GIN server that can be added as a remote to repositories.
+// AddServerCmd sets up the 'add-server' command for adding new server configurations
+func AddServerCmd() *cobra.Command {
+	description := `Configure a new GIN server that can be used to add remotes to repositories.
 
 The command requires only one argument, the alias for the server. All other information can be provided on the command line using the flags described below. You will be prompted for any required information that is not provided.
 
@@ -132,18 +132,18 @@ See the Examples section for a full example.
 		"<alias>": "The alias (name) for the server.",
 	}
 	examples := map[string]string{
-		"This is what configuring the built-in GIN remote would look like (note: this is already configured)": "$ gin new-remote --web https://web.gin.g-node.org:443 --git git@git.g-node.org:22 gin",
+		"This is what configuring the built-in G-Node GIN server would look like (note: this is already configured)": "$ gin add-server --web https://web.gin.g-node.org:443 --git git@git.g-node.org:22 gin",
 	}
-	var newRemoteCmd = &cobra.Command{
-		Use:     "new-remote [--web http[s]://<hostname>[:<port>]] [--git [<gituser>@]<hostname>[:<port>]] <alias>",
-		Short:   "Set the repository's default upload remote",
+	var addServerCmd = &cobra.Command{
+		Use:     "add-server [--web http[s]://<hostname>[:<port>]] [--git [<gituser>@]<hostname>[:<port>]] <alias>",
+		Short:   "Add a new GIN server configuration",
 		Long:    formatdesc(description, args),
 		Args:    cobra.ExactArgs(1),
 		Example: formatexamples(examples),
-		Run:     newRemote,
+		Run:     addServer,
 		DisableFlagsInUseLine: true,
 	}
-	newRemoteCmd.Flags().String("web", "", "Set the address and port for the web server.")
-	newRemoteCmd.Flags().String("git", "", "Set the user, address and port for the git server.")
-	return newRemoteCmd
+	addServerCmd.Flags().String("web", "", "Set the address and port for the web server.")
+	addServerCmd.Flags().String("git", "", "Set the user, address and port for the git server.")
+	return addServerCmd
 }

--- a/gincmd/addserver.go
+++ b/gincmd/addserver.go
@@ -98,7 +98,7 @@ func fetchHostKey(gitconf *config.GitCfg) {
 	if err != nil && !strings.Contains(err.Error(), "unable to authenticate") {
 		Die(fmt.Sprintf("connection test failed: %s", err))
 	}
-	fmt.Printf(":: Host key fingerprint: %s\n", fingerprint)
+	fmt.Printf(":: Host key fingerprint for [%s]: %s\n", gitconf.AddressStr(), fingerprint)
 	fmt.Print("Accept [yes/no]: ")
 	var response string
 	fmt.Scanln(&response)

--- a/gincmd/addserver.go
+++ b/gincmd/addserver.go
@@ -83,6 +83,11 @@ func parseGitstring(gitstring string) (gitconf config.GitCfg) {
 
 func addServer(cmd *cobra.Command, args []string) {
 	alias := args[0]
+
+	if alias == "dir" {
+		Die(fmt.Sprintf("invalid server alias '%s': this word is reserved", alias))
+	}
+
 	webstring, _ := cmd.Flags().GetString("web")
 	gitstring, _ := cmd.Flags().GetString("git")
 
@@ -110,7 +115,7 @@ func AddServerCmd() *cobra.Command {
 
 The command requires only one argument, the alias for the server. All other information can be provided on the command line using the flags described below. You will be prompted for any required information that is not provided.
 
-When configuring a server, you must specify an alias (name) for it, which will be used to refer to the configured server. This alias is then used when adding a remote to a repository. See 'gin help add-remote'.
+When configuring a server, you must specify an alias (name) for it, which will be used to refer to the configured server. This alias is then used when adding a remote to a repository. The default G-Node GIN server is available under the name 'gin', but this may be overridden. The word 'dir' cannot be used as is has special meaning when adding a remote to a repository. See 'gin help add-remote'.
 
 The following information is required to configure a new server:
 

--- a/gincmd/annexcmd.go
+++ b/gincmd/annexcmd.go
@@ -5,14 +5,12 @@ import (
 	"os"
 
 	"github.com/G-Node/gin-cli/ginclient"
-	"github.com/G-Node/gin-cli/ginclient/config"
 	"github.com/G-Node/gin-cli/git"
 	"github.com/spf13/cobra"
 )
 
 func annexrun(cmd *cobra.Command, args []string) {
-	conf := config.Read()
-	gincl := ginclient.New(conf.GinHost)
+	gincl := ginclient.New("")
 	_ = gincl.LoadToken() // OK to run without token
 	annexcmd := git.AnnexCommand(args...)
 	err := annexcmd.Start()

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -297,6 +297,9 @@ func SetUpCommands(verstr string) *cobra.Command {
 	// Add remote
 	rootCmd.AddCommand(AddRemoteCmd())
 
+	// Use remote
+	rootCmd.AddCommand(UseRemoteCmd())
+
 	// Create repo
 	rootCmd.AddCommand(CreateCmd())
 

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -298,6 +298,9 @@ func SetUpCommands(verstr string) *cobra.Command {
 	// Add remote
 	rootCmd.AddCommand(AddRemoteCmd())
 
+	// Remove remote
+	rootCmd.AddCommand(RemoveRemoteCmd())
+
 	// Use remote
 	rootCmd.AddCommand(UseRemoteCmd())
 

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -207,6 +207,7 @@ func printProgressOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[
 }
 
 func formatOutput(statuschan <-chan git.RepoFileStatus, nitems int, jsonout bool) {
+	// TODO: instead of a true/false success, add an error for every file and then group the errors by type and print a report
 	var filesuccess map[string]bool
 	if jsonout {
 		filesuccess = printJSON(statuschan)

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -296,7 +296,7 @@ func SetUpCommands(verstr string) *cobra.Command {
 	rootCmd.AddCommand(InitCmd())
 
 	// New remote
-	rootCmd.AddCommand(NewRemoteCmd())
+	rootCmd.AddCommand(AddServerCmd())
 
 	// Add remote
 	rootCmd.AddCommand(AddRemoteCmd())

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -295,6 +295,9 @@ func SetUpCommands(verstr string) *cobra.Command {
 	// Init repo
 	rootCmd.AddCommand(InitCmd())
 
+	// New remote
+	rootCmd.AddCommand(NewRemoteCmd())
+
 	// Add remote
 	rootCmd.AddCommand(AddRemoteCmd())
 

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -300,6 +300,9 @@ func SetUpCommands(verstr string) *cobra.Command {
 	// Use remote
 	rootCmd.AddCommand(UseRemoteCmd())
 
+	// Remotes
+	rootCmd.AddCommand(RemotesCmd())
+
 	// Create repo
 	rootCmd.AddCommand(CreateCmd())
 

--- a/gincmd/createcmd.go
+++ b/gincmd/createcmd.go
@@ -50,7 +50,7 @@ func createRepo(cmd *cobra.Command, args []string) {
 		err = git.RemoteAdd("origin", url)
 		CheckError(err)
 		defaultIfUnset("origin")
-		_, err := git.CommitIfNew("origin")
+		_, err := git.CommitIfNew()
 		CheckError(err)
 	} else if !noclone {
 		// Clone repository after creation

--- a/gincmd/createcmd.go
+++ b/gincmd/createcmd.go
@@ -49,7 +49,7 @@ func createRepo(cmd *cobra.Command, args []string) {
 		url := fmt.Sprintf("ssh://%s@%s/%s", conf.GitUser, conf.GitHost, repoPath)
 		err = git.RemoteAdd("origin", url)
 		CheckError(err)
-		defaultIfUnset("origin")
+		defaultRemoteIfUnset("origin")
 		new, err := ginclient.CommitIfNew()
 		CheckError(err)
 		if new {

--- a/gincmd/createcmd.go
+++ b/gincmd/createcmd.go
@@ -50,7 +50,7 @@ func createRepo(cmd *cobra.Command, args []string) {
 		err = git.RemoteAdd("origin", url)
 		CheckError(err)
 		defaultIfUnset("origin")
-		_, err := git.CommitIfNew()
+		_, err := ginclient.CommitIfNew()
 		CheckError(err)
 	} else if !noclone {
 		// Clone repository after creation

--- a/gincmd/createcmd.go
+++ b/gincmd/createcmd.go
@@ -47,7 +47,7 @@ func createRepo(cmd *cobra.Command, args []string) {
 		err = gincl.InitDir()
 		CheckError(err)
 		url := fmt.Sprintf("ssh://%s@%s/%s", conf.GitUser, conf.GitHost, repoPath)
-		err = git.AddRemote("origin", url)
+		err = git.RemoteAdd("origin", url)
 		CheckError(err)
 		_, err := git.CommitIfNew("origin")
 		CheckError(err)

--- a/gincmd/createcmd.go
+++ b/gincmd/createcmd.go
@@ -50,8 +50,14 @@ func createRepo(cmd *cobra.Command, args []string) {
 		err = git.RemoteAdd("origin", url)
 		CheckError(err)
 		defaultIfUnset("origin")
-		_, err := ginclient.CommitIfNew()
+		new, err := ginclient.CommitIfNew()
 		CheckError(err)
+		if new {
+			// Push the new commit to initialise origin
+			uploadchan := make(chan git.RepoFileStatus)
+			go gincl.Upload(nil, []string{"origin"}, uploadchan)
+			<-uploadchan
+		}
 	} else if !noclone {
 		// Clone repository after creation
 		getRepo(cmd, []string{repoPath})

--- a/gincmd/createcmd.go
+++ b/gincmd/createcmd.go
@@ -44,7 +44,7 @@ func createRepo(cmd *cobra.Command, args []string) {
 
 	if here {
 		// Init cwd
-		err = gincl.InitDir()
+		err = gincl.InitDir(false)
 		CheckError(err)
 		url := fmt.Sprintf("ssh://%s@%s/%s", conf.GitUser, conf.GitHost, repoPath)
 		err = git.RemoteAdd("origin", url)

--- a/gincmd/createcmd.go
+++ b/gincmd/createcmd.go
@@ -49,6 +49,7 @@ func createRepo(cmd *cobra.Command, args []string) {
 		url := fmt.Sprintf("ssh://%s@%s/%s", conf.GitUser, conf.GitHost, repoPath)
 		err = git.RemoteAdd("origin", url)
 		CheckError(err)
+		defaultIfUnset("origin")
 		_, err := git.CommitIfNew("origin")
 		CheckError(err)
 	} else if !noclone {

--- a/gincmd/deletecmd.go
+++ b/gincmd/deletecmd.go
@@ -11,7 +11,8 @@ import (
 
 func deleteRepo(cmd *cobra.Command, args []string) {
 	conf := config.Read()
-	gincl := ginclient.New(conf.GinHost)
+	srvcfg := conf.Servers["gin"] // TODO: Support aliases
+	gincl := ginclient.New(srvcfg.Web.AddressStr())
 	requirelogin(cmd, gincl, true)
 	var repostr, confirmation string
 

--- a/gincmd/downloadcmd.go
+++ b/gincmd/downloadcmd.go
@@ -15,15 +15,15 @@ import (
 func download(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
 	conf := config.Read()
-	gincl := ginclient.New(conf.GinHost)
+	srvcfg := conf.Servers["gin"] // TODO: Support aliases
+	gincl := ginclient.New(srvcfg.Web.AddressStr())
 	requirelogin(cmd, gincl, !jsonout)
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
 	}
 
 	content, _ := cmd.Flags().GetBool("content")
-	gincl.GitHost = conf.GitHost
-	gincl.GitUser = conf.GitUser
+	gincl.GitAddress = srvcfg.Git.AddressStr()
 	lockchan := make(chan git.RepoFileStatus)
 	go gincl.LockContent([]string{}, lockchan)
 	formatOutput(lockchan, 0, jsonout)

--- a/gincmd/getcmd.go
+++ b/gincmd/getcmd.go
@@ -31,7 +31,7 @@ func getRepo(cmd *cobra.Command, args []string) {
 	go gincl.CloneRepo(repostr, clonechan)
 	formatOutput(clonechan, 0, jsonout)
 	defaultIfUnset("origin")
-	_, err := git.CommitIfNew("origin")
+	_, err := git.CommitIfNew()
 	CheckError(err)
 }
 

--- a/gincmd/getcmd.go
+++ b/gincmd/getcmd.go
@@ -18,15 +18,15 @@ func getRepo(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
 	repostr := args[0]
 	conf := config.Read()
-	gincl := ginclient.New(conf.GinHost)
+	srvcfg := conf.Servers["gin"] // TODO: Support aliases
+	gincl := ginclient.New(srvcfg.Web.AddressStr())
 	requirelogin(cmd, gincl, !jsonout)
 
 	if !isValidRepoPath(repostr) {
 		Die(fmt.Sprintf("Invalid repository path '%s'. Full repository name should be the owner's username followed by the repository name, separated by a '/'.\nType 'gin help get' for information and examples.", repostr))
 	}
 
-	gincl.GitHost = conf.GitHost
-	gincl.GitUser = conf.GitUser
+	gincl.GitAddress = srvcfg.Git.AddressStr()
 	clonechan := make(chan git.RepoFileStatus)
 	go gincl.CloneRepo(repostr, clonechan)
 	formatOutput(clonechan, 0, jsonout)

--- a/gincmd/getcmd.go
+++ b/gincmd/getcmd.go
@@ -30,7 +30,7 @@ func getRepo(cmd *cobra.Command, args []string) {
 	clonechan := make(chan git.RepoFileStatus)
 	go gincl.CloneRepo(repostr, clonechan)
 	formatOutput(clonechan, 0, jsonout)
-	defaultIfUnset("origin")
+	defaultRemoteIfUnset("origin")
 	new, err := ginclient.CommitIfNew()
 	if new {
 		// Push the new commit to initialise origin

--- a/gincmd/getcmd.go
+++ b/gincmd/getcmd.go
@@ -30,6 +30,7 @@ func getRepo(cmd *cobra.Command, args []string) {
 	clonechan := make(chan git.RepoFileStatus)
 	go gincl.CloneRepo(repostr, clonechan)
 	formatOutput(clonechan, 0, jsonout)
+	defaultIfUnset("origin")
 	_, err := git.CommitIfNew("origin")
 	CheckError(err)
 }

--- a/gincmd/getcmd.go
+++ b/gincmd/getcmd.go
@@ -31,7 +31,7 @@ func getRepo(cmd *cobra.Command, args []string) {
 	go gincl.CloneRepo(repostr, clonechan)
 	formatOutput(clonechan, 0, jsonout)
 	defaultIfUnset("origin")
-	_, err := git.CommitIfNew()
+	_, err := ginclient.CommitIfNew()
 	CheckError(err)
 }
 

--- a/gincmd/getcmd.go
+++ b/gincmd/getcmd.go
@@ -31,7 +31,13 @@ func getRepo(cmd *cobra.Command, args []string) {
 	go gincl.CloneRepo(repostr, clonechan)
 	formatOutput(clonechan, 0, jsonout)
 	defaultIfUnset("origin")
-	_, err := ginclient.CommitIfNew()
+	new, err := ginclient.CommitIfNew()
+	if new {
+		// Push the new commit to initialise origin
+		uploadchan := make(chan git.RepoFileStatus)
+		go gincl.Upload(nil, []string{"origin"}, uploadchan)
+		<-uploadchan
+	}
 	CheckError(err)
 }
 

--- a/gincmd/getcontentcmd.go
+++ b/gincmd/getcontentcmd.go
@@ -11,14 +11,14 @@ import (
 func getContent(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
 	conf := config.Read()
-	gincl := ginclient.New(conf.GinHost)
+	srvcfg := conf.Servers["gin"] // TODO: Support aliases
+	gincl := ginclient.New(srvcfg.Web.AddressStr())
 	requirelogin(cmd, gincl, !jsonout)
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
 	}
 
-	gincl.GitHost = conf.GitHost
-	gincl.GitUser = conf.GitUser
+	gincl.GitAddress = srvcfg.Git.AddressStr()
 	getcchan := make(chan git.RepoFileStatus)
 	go gincl.GetContent(args, getcchan)
 	formatOutput(getcchan, 0, jsonout)

--- a/gincmd/ginerrors/errors.go
+++ b/gincmd/ginerrors/errors.go
@@ -1,7 +1,12 @@
 package ginerrors
 
-// NotInRepo is returned when a command needs to be run from within a repository
-const NotInRepo = "this command must be run from inside a gin repository"
+const (
+	// NotInRepo is returned when a command needs to be run from within a repository
+	NotInRepo = "this command must be run from inside a gin repository"
 
-// RequiresLogin is returned when a command requires the user to be logged in
-const RequiresLogin = "this operation requires login"
+	// RequiresLogin is returned when a command requires the user to be logged in
+	RequiresLogin = "this operation requires login"
+
+	// BadPort is returned when a port number is outside the valid range (1..65535)
+	BadPort = "port must be between 0 and 65535 (inclusive)"
+)

--- a/gincmd/gitcmd.go
+++ b/gincmd/gitcmd.go
@@ -5,14 +5,12 @@ import (
 	"os"
 
 	ginclient "github.com/G-Node/gin-cli/ginclient"
-	"github.com/G-Node/gin-cli/ginclient/config"
 	"github.com/G-Node/gin-cli/git"
 	"github.com/spf13/cobra"
 )
 
 func gitrun(cmd *cobra.Command, args []string) {
-	conf := config.Read()
-	gincl := ginclient.New(conf.GinHost)
+	gincl := ginclient.New("")
 	_ = gincl.LoadToken() // OK to run without token
 
 	gitcmd := git.Command(args...)

--- a/gincmd/helptemplate.go
+++ b/gincmd/helptemplate.go
@@ -23,7 +23,9 @@ var usageTemplate = `{{if gt (len .Aliases) 0}}
 
 Aliases:
 
-  {{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}
+
+Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
 Flags:
@@ -40,5 +42,5 @@ Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
 Examples:
 {{.Example}}{{end}}{{if .HasAvailableSubCommands}}
 
-Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+Use "{{.CommandPath}} help [command]" for more information about a command.{{end}}
 `

--- a/gincmd/infocmd.go
+++ b/gincmd/infocmd.go
@@ -13,7 +13,8 @@ func printAccountInfo(cmd *cobra.Command, args []string) {
 	var username string
 
 	conf := config.Read()
-	gincl := ginclient.New(conf.GinHost)
+	srvcfg := conf.Servers["gin"] // TODO: Support aliases
+	gincl := ginclient.New(srvcfg.Web.AddressStr())
 	_ = gincl.LoadToken() // does not REQUIRE login
 
 	if len(args) == 0 {

--- a/gincmd/initcmd.go
+++ b/gincmd/initcmd.go
@@ -10,7 +10,8 @@ import (
 
 func initRepo(cmd *cobra.Command, args []string) {
 	conf := config.Read()
-	gincl := ginclient.New(conf.GinHost)
+	srvcfg := conf.Servers["gin"] // TODO: Support aliases
+	gincl := ginclient.New(srvcfg.Web.AddressStr())
 	fmt.Print(":: Initialising local storage ")
 	err := gincl.InitDir(false)
 	CheckError(err)

--- a/gincmd/initcmd.go
+++ b/gincmd/initcmd.go
@@ -13,7 +13,7 @@ func initRepo(cmd *cobra.Command, args []string) {
 	conf := config.Read()
 	gincl := ginclient.New(conf.GinHost)
 	fmt.Print(":: Initialising local storage ")
-	err := gincl.InitDir()
+	err := gincl.InitDir(false)
 	CheckError(err)
 	_, err = git.CommitIfNew()
 	CheckError(err)

--- a/gincmd/initcmd.go
+++ b/gincmd/initcmd.go
@@ -15,7 +15,7 @@ func initRepo(cmd *cobra.Command, args []string) {
 	fmt.Print(":: Initialising local storage ")
 	err := gincl.InitDir()
 	CheckError(err)
-	_, err = git.CommitIfNew("")
+	_, err = git.CommitIfNew()
 	CheckError(err)
 	fmt.Println(green("OK"))
 }

--- a/gincmd/initcmd.go
+++ b/gincmd/initcmd.go
@@ -5,7 +5,6 @@ import (
 
 	ginclient "github.com/G-Node/gin-cli/ginclient"
 	"github.com/G-Node/gin-cli/ginclient/config"
-	"github.com/G-Node/gin-cli/git"
 	"github.com/spf13/cobra"
 )
 
@@ -15,7 +14,7 @@ func initRepo(cmd *cobra.Command, args []string) {
 	fmt.Print(":: Initialising local storage ")
 	err := gincl.InitDir(false)
 	CheckError(err)
-	_, err = git.CommitIfNew()
+	_, err = ginclient.CommitIfNew()
 	CheckError(err)
 	fmt.Println(green("OK"))
 }

--- a/gincmd/keyscmd.go
+++ b/gincmd/keyscmd.go
@@ -19,7 +19,8 @@ func keys(cmd *cobra.Command, args []string) {
 	}
 
 	conf := config.Read()
-	gincl := ginclient.New(conf.GinHost)
+	srvcfg := conf.Servers["gin"] // TODO: Support aliases
+	gincl := ginclient.New(srvcfg.Web.AddressStr())
 	requirelogin(cmd, gincl, true)
 
 	keyfilename, _ := flags.GetString("add")

--- a/gincmd/lockcmd.go
+++ b/gincmd/lockcmd.go
@@ -11,7 +11,7 @@ import (
 func countItemsLock(paths []string) (count int) {
 	statchan := make(chan git.AnnexStatusRes)
 	go git.AnnexStatus(paths, statchan)
-	for _ = range statchan {
+	for range statchan {
 		count++
 	}
 	return
@@ -27,7 +27,8 @@ func lock(cmd *cobra.Command, args []string) {
 		return
 	}
 	conf := config.Read()
-	gincl := ginclient.New(conf.GinHost)
+	srvcfg := conf.Servers["gin"] // TODO: Support aliases
+	gincl := ginclient.New(srvcfg.Web.AddressStr())
 	nitems := countItemsLock(args)
 	lockchan := make(chan git.RepoFileStatus)
 	go gincl.LockContent(args, lockchan)

--- a/gincmd/logincmd.go
+++ b/gincmd/logincmd.go
@@ -46,7 +46,8 @@ func login(cmd *cobra.Command, args []string) {
 	}
 
 	conf := config.Read()
-	gincl := ginclient.New(conf.GinHost)
+	srvcfg := conf.Servers["gin"] // TODO: Support aliases
+	gincl := ginclient.New(srvcfg.Web.AddressStr())
 	err = gincl.Login(username, password, "gin-cli")
 	CheckError(err)
 	info, err := gincl.RequestAccount(username)

--- a/gincmd/logoutcmd.go
+++ b/gincmd/logoutcmd.go
@@ -13,7 +13,8 @@ func logout(cmd *cobra.Command, args []string) {
 		usageDie(cmd)
 	}
 	conf := config.Read()
-	gincl := ginclient.New(conf.GinHost)
+	srvcfg := conf.Servers["gin"] // TODO: Support aliases
+	gincl := ginclient.New(srvcfg.Web.AddressStr())
 	err := gincl.LoadToken()
 	if err != nil {
 		Die("You are not logged in.")

--- a/gincmd/lscmd.go
+++ b/gincmd/lscmd.go
@@ -26,9 +26,9 @@ func lsRepo(cmd *cobra.Command, args []string) {
 	short, _ := flags.GetBool("short")
 
 	conf := config.Read()
-	gincl := ginclient.New(conf.GinHost)
-	gincl.GitHost = conf.GitHost
-	gincl.GitUser = conf.GitUser
+	srvcfg := conf.Servers["gin"] // TODO: Support aliases
+	gincl := ginclient.New(srvcfg.Web.AddressStr())
+	gincl.GitAddress = srvcfg.Git.AddressStr()
 
 	filesStatus, err := gincl.ListFiles(args...)
 	CheckError(err)

--- a/gincmd/newremote.go
+++ b/gincmd/newremote.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func promptForWeb() (webconf config.WebConfiguration) {
+func promptForWeb() (webconf config.WebCfg) {
 	fmt.Println(":: Web server configuration")
 	fmt.Print("  Protocol (e.g., http, https): ")
 	fmt.Scanln(&webconf.Protocol)
@@ -19,7 +19,7 @@ func promptForWeb() (webconf config.WebConfiguration) {
 	return
 }
 
-func promptForGit() (gitconf config.GitConfiguration) {
+func promptForGit() (gitconf config.GitCfg) {
 	fmt.Println(":: Git server configuration")
 	fmt.Print("  Username: ")
 	fmt.Scanln(&gitconf.User)
@@ -30,7 +30,7 @@ func promptForGit() (gitconf config.GitConfiguration) {
 	return
 }
 
-func parseWebstring(webstring string) (webconf config.WebConfiguration) {
+func parseWebstring(webstring string) (webconf config.WebCfg) {
 	errmsg := fmt.Sprintf("invalid web configuration line %s", webstring)
 	split := strings.SplitN(webstring, "://", 2)
 	if len(split) != 2 {
@@ -46,7 +46,7 @@ func parseWebstring(webstring string) (webconf config.WebConfiguration) {
 	return
 }
 
-func parseGitstring(gitstring string) (gitconf config.GitConfiguration) {
+func parseGitstring(gitstring string) (gitconf config.GitCfg) {
 	errmsg := fmt.Sprintf("invalid git configuration line %s", gitstring)
 	split := strings.SplitN(gitstring, "@", 2)
 	if len(split) != 2 {
@@ -67,7 +67,7 @@ func newRemote(cmd *cobra.Command, args []string) {
 	webstring, _ := cmd.Flags().GetString("web")
 	gitstring, _ := cmd.Flags().GetString("git")
 
-	serverConf := config.ServerConfiguration{}
+	serverConf := config.ServerCfg{}
 
 	if webstring == "" {
 		serverConf.Web = promptForWeb()

--- a/gincmd/newremote.go
+++ b/gincmd/newremote.go
@@ -1,15 +1,32 @@
 package gincmd
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/G-Node/gin-cli/ginclient/config"
 	"github.com/spf13/cobra"
 )
 
 func promptForWeb() (webconf config.WebConfiguration) {
+	fmt.Println(":: Web server configuration")
+	fmt.Print("  Protocol (e.g., http, https): ")
+	fmt.Scanln(&webconf.Protocol)
+	fmt.Print("  Host or address: ")
+	fmt.Scanln(&webconf.Host)
+	fmt.Print("  Port (e.g., 80, 443): ")
+	fmt.Scanln(&webconf.Port)
 	return
 }
 
 func promptForGit() (gitconf config.GitConfiguration) {
+	fmt.Println(":: Git server configuration")
+	fmt.Print("  Username: ")
+	fmt.Scanln(&gitconf.User)
+	fmt.Print("  Host or address: ")
+	fmt.Scanln(&gitconf.Host)
+	fmt.Print("  Port (e.g., 22, 2222): ")
+	fmt.Scanln(&gitconf.Port)
 	return
 }
 

--- a/gincmd/newremote.go
+++ b/gincmd/newremote.go
@@ -1,10 +1,47 @@
 package gincmd
 
 import (
+	"github.com/G-Node/gin-cli/ginclient/config"
 	"github.com/spf13/cobra"
 )
 
+func promptForWeb() (webconf config.WebConfiguration) {
+	return
+}
+
+func promptForGit() (gitconf config.GitConfiguration) {
+	return
+}
+
+func parseWebstring(webstring string) (webconf config.WebConfiguration) {
+	return
+}
+
+func parseGitstring(gitstring string) (gitconf config.GitConfiguration) {
+	return
+}
+
 func newRemote(cmd *cobra.Command, args []string) {
+	alias := args[0]
+	webstring, _ := cmd.Flags().GetString("web")
+	gitstring, _ := cmd.Flags().GetString("git")
+
+	serverConf := config.ServerConfiguration{}
+
+	if webstring == "" {
+		serverConf.Web = promptForWeb()
+	} else {
+		serverConf.Web = parseWebstring(webstring)
+	}
+
+	if gitstring == "" {
+		serverConf.Git = promptForGit()
+	} else {
+		serverConf.Git = parseGitstring(gitstring)
+	}
+
+	// Save to config
+	config.WriteServerConf(alias, serverConf)
 }
 
 // NewRemoteCmd sets up the 'use-remote' repository subcommand
@@ -41,7 +78,7 @@ See the Examples section for a full example.
 		Use:     "new-remote [--web http[s]://<hostname>[:<port>]] [--git [<gituser>@]<hostname>[:<port>]] <alias>",
 		Short:   "Set the repository's default upload remote",
 		Long:    formatdesc(description, args),
-		Args:    cobra.MaximumNArgs(1),
+		Args:    cobra.ExactArgs(1),
 		Example: formatexamples(examples),
 		Run:     newRemote,
 		DisableFlagsInUseLine: true,

--- a/gincmd/newremote.go
+++ b/gincmd/newremote.go
@@ -2,9 +2,11 @@ package gincmd
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/G-Node/gin-cli/ginclient/config"
+	"github.com/G-Node/gin-cli/gincmd/ginerrors"
 	"github.com/spf13/cobra"
 )
 
@@ -14,8 +16,13 @@ func promptForWeb() (webconf config.WebCfg) {
 	fmt.Scanln(&webconf.Protocol)
 	fmt.Print("  Host or address: ")
 	fmt.Scanln(&webconf.Host)
+
+	var port uint16
 	fmt.Print("  Port (e.g., 80, 443): ")
-	fmt.Scanln(&webconf.Port)
+	_, err := fmt.Scanln(&port)
+	if err != nil {
+		Die(ginerrors.BadPort)
+	}
 	return
 }
 
@@ -25,8 +32,12 @@ func promptForGit() (gitconf config.GitCfg) {
 	fmt.Scanln(&gitconf.User)
 	fmt.Print("  Host or address: ")
 	fmt.Scanln(&gitconf.Host)
+	var port uint16
 	fmt.Print("  Port (e.g., 22, 2222): ")
-	fmt.Scanln(&gitconf.Port)
+	_, err := fmt.Scanln(&port)
+	if err != nil {
+		Die(ginerrors.BadPort)
+	}
 	return
 }
 
@@ -42,7 +53,11 @@ func parseWebstring(webstring string) (webconf config.WebCfg) {
 	if len(split) != 2 {
 		Die(errmsg)
 	}
-	webconf.Host, webconf.Port = split[0], split[1]
+	port, err := strconv.ParseUint(split[1], 10, 16)
+	if err != nil {
+		Die(fmt.Sprintf("%s: %s", errmsg, ginerrors.BadPort))
+	}
+	webconf.Host, webconf.Port = split[0], uint16(port)
 	return
 }
 
@@ -58,7 +73,11 @@ func parseGitstring(gitstring string) (gitconf config.GitCfg) {
 	if len(split) != 2 {
 		Die(errmsg)
 	}
-	gitconf.Host, gitconf.Port = split[0], split[1]
+	port, err := strconv.ParseUint(split[1], 10, 16)
+	if err != nil {
+		Die(fmt.Sprintf("%s: %s", errmsg, ginerrors.BadPort))
+	}
+	gitconf.Host, gitconf.Port = split[0], uint16(port)
 	return
 }
 

--- a/gincmd/newremote.go
+++ b/gincmd/newremote.go
@@ -31,10 +31,34 @@ func promptForGit() (gitconf config.GitConfiguration) {
 }
 
 func parseWebstring(webstring string) (webconf config.WebConfiguration) {
+	errmsg := fmt.Sprintf("invalid web configuration line %s", webstring)
+	split := strings.SplitN(webstring, "://", 2)
+	if len(split) != 2 {
+		Die(errmsg)
+	}
+	webconf.Protocol = split[0]
+
+	split = strings.SplitN(split[1], ":", 2)
+	if len(split) != 2 {
+		Die(errmsg)
+	}
+	webconf.Host, webconf.Port = split[0], split[1]
 	return
 }
 
 func parseGitstring(gitstring string) (gitconf config.GitConfiguration) {
+	errmsg := fmt.Sprintf("invalid git configuration line %s", gitstring)
+	split := strings.SplitN(gitstring, "@", 2)
+	if len(split) != 2 {
+		Die(errmsg)
+	}
+	gitconf.User = split[0]
+
+	split = strings.SplitN(split[1], ":", 2)
+	if len(split) != 2 {
+		Die(errmsg)
+	}
+	gitconf.Host, gitconf.Port = split[0], split[1]
 	return
 }
 

--- a/gincmd/newremote.go
+++ b/gincmd/newremote.go
@@ -1,0 +1,52 @@
+package gincmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func newRemote(cmd *cobra.Command, args []string) {
+}
+
+// NewRemoteCmd sets up the 'use-remote' repository subcommand
+func NewRemoteCmd() *cobra.Command {
+	description := `Configure a new GIN server that can be added as a remote to repositories.
+
+The command requires only one argument, the alias for the server. All other information can be provided on the command line using the flags described below. You will be prompted for any required information that is not provided.
+
+When configuring a server, you must specify an alias (name) for it, which will be used to refer to the configured server. This alias is then used when adding a remote to a repository. See 'gin help add-remote'.
+
+The following information is required to configure a new server:
+
+For the web server: the protocol, hostname, and port
+
+    The protocol should be either 'http' or 'https'.
+    The hostname for the server (e.g., web.gin.g-node.org).
+    The web port for the server (e.g., 80, 443).
+
+For the git server: the git user, hostname, and port
+
+    The git user is the username set on the server for managing the repositories. It is almost always 'git'.
+    The hostname for the git server (e.g., git.g-node.org).
+    The git port for the server (e.g., 22, 2222).
+
+See the Examples section for a full example.
+`
+	args := map[string]string{
+		"<alias>": "The alias (name) for the server.",
+	}
+	examples := map[string]string{
+		"This is what configuring the built-in GIN remote would look like (note: this is already configured)": "$ gin new-remote --web https://web.gin.g-node.org:443 --git git@git.g-node.org:22 gin",
+	}
+	var newRemoteCmd = &cobra.Command{
+		Use:     "new-remote [--web http[s]://<hostname>[:<port>]] [--git [<gituser>@]<hostname>[:<port>]] <alias>",
+		Short:   "Set the repository's default upload remote",
+		Long:    formatdesc(description, args),
+		Args:    cobra.MaximumNArgs(1),
+		Example: formatexamples(examples),
+		Run:     newRemote,
+		DisableFlagsInUseLine: true,
+	}
+	newRemoteCmd.Flags().String("web", "", "Set the address and port for the web server.")
+	newRemoteCmd.Flags().String("git", "", "Set the user, address and port for the git server.")
+	return newRemoteCmd
+}

--- a/gincmd/remotes.go
+++ b/gincmd/remotes.go
@@ -1,0 +1,44 @@
+package gincmd
+
+import (
+	"fmt"
+
+	ginclient "github.com/G-Node/gin-cli/ginclient"
+	"github.com/G-Node/gin-cli/gincmd/ginerrors"
+	"github.com/G-Node/gin-cli/git"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+func remotes(cmd *cobra.Command, args []string) {
+	if !git.IsRepo() {
+		Die(ginerrors.NotInRepo)
+	}
+
+	remotes, err := git.RemoteShow()
+	CheckError(err)
+	defremote, err := ginclient.DefaultRemote()
+	CheckError(err)
+	fmt.Println(":: Configured remotes")
+	for name, loc := range remotes {
+		fmt.Printf(" %s: %s", name, loc)
+		if name == defremote {
+			fmt.Fprintf(color.Output, green(" [default]"))
+		}
+		fmt.Println()
+	}
+}
+
+// RemotesCmd sets up the 'remotes' subcommand
+func RemotesCmd() *cobra.Command {
+	description := `List configured remotes and their information.`
+	var addRemoteCmd = &cobra.Command{
+		Use:   "remotes",
+		Short: "List the repository's configured remotes",
+		Long:  formatdesc(description, nil),
+		Args:  cobra.NoArgs,
+		Run:   remotes,
+		DisableFlagsInUseLine: true,
+	}
+	return addRemoteCmd
+}

--- a/gincmd/removecontentcmd.go
+++ b/gincmd/removecontentcmd.go
@@ -19,13 +19,13 @@ func countItemsRemove(paths []string) int {
 func remove(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
 	conf := config.Read()
-	gincl := ginclient.New(conf.GinHost)
+	srvcfg := conf.Servers["gin"] // TODO: Support aliases
+	gincl := ginclient.New(srvcfg.Web.AddressStr())
 	requirelogin(cmd, gincl, !jsonout)
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
 	}
-	gincl.GitHost = conf.GitHost
-	gincl.GitUser = conf.GitUser
+	gincl.GitAddress = srvcfg.Git.AddressStr()
 	lock(cmd, args)
 	nitems := countItemsRemove(args)
 	rmchan := make(chan git.RepoFileStatus)

--- a/gincmd/removeremote.go
+++ b/gincmd/removeremote.go
@@ -33,7 +33,7 @@ func RemoveRemoteCmd() *cobra.Command {
 	}
 	var removeRemoteCmd = &cobra.Command{
 		Use:                   "remove-remote <name>",
-		Short:                 description,
+		Short:                 "Remove a remote from the current repository",
 		Long:                  formatdesc(description, args),
 		Args:                  cobra.ExactArgs(1),
 		Run:                   rmRemote,

--- a/gincmd/removeremote.go
+++ b/gincmd/removeremote.go
@@ -1,0 +1,44 @@
+package gincmd
+
+import (
+	"fmt"
+
+	ginclient "github.com/G-Node/gin-cli/ginclient"
+	"github.com/G-Node/gin-cli/gincmd/ginerrors"
+	"github.com/G-Node/gin-cli/git"
+	"github.com/spf13/cobra"
+)
+
+func rmRemote(cmd *cobra.Command, args []string) {
+	if !git.IsRepo() {
+		Die(ginerrors.NotInRepo)
+	}
+	name := args[0]
+	err := ginclient.RemoveRemote(name)
+	CheckError(err)
+	fmt.Printf(":: Remote removed: %s\n", name)
+	defremote, _ := ginclient.DefaultRemote()
+	if defremote == name {
+		ginclient.SetDefaultRemote("")
+		fmt.Printf(":: %s was the default remote. Current default is unset.\n:: Use 'gin use-remote' to set a new default.\n", name)
+	}
+}
+
+// RemoveRemoteCmd sets up the 'remove-remote' repository subcommand
+func RemoveRemoteCmd() *cobra.Command {
+	description := `Remove a remote from the current repository.`
+
+	args := map[string]string{
+		"<name>": "The name of the remote",
+	}
+	var removeRemoteCmd = &cobra.Command{
+		Use:                   "remove-remote <name>",
+		Short:                 description,
+		Long:                  formatdesc(description, args),
+		Args:                  cobra.ExactArgs(1),
+		Run:                   rmRemote,
+		Aliases:               []string{"rm-remote"},
+		DisableFlagsInUseLine: true,
+	}
+	return removeRemoteCmd
+}

--- a/gincmd/repoinfocmd.go
+++ b/gincmd/repoinfocmd.go
@@ -31,7 +31,8 @@ func repoinfo(cmd *cobra.Command, args []string) {
 	flags := cmd.Flags()
 	jsonout, _ := flags.GetBool("json")
 	conf := config.Read()
-	gincl := ginclient.New(conf.GinHost)
+	srvcfg := conf.Servers["gin"] // TODO: Support aliases
+	gincl := ginclient.New(srvcfg.Web.AddressStr())
 	requirelogin(cmd, gincl, true)
 	repoinfo, err := gincl.GetRepo(args[0])
 	CheckError(err)

--- a/gincmd/reposcmd.go
+++ b/gincmd/reposcmd.go
@@ -25,7 +25,8 @@ func repos(cmd *cobra.Command, args []string) {
 		usageDie(cmd)
 	}
 	conf := config.Read()
-	gincl := ginclient.New(conf.GinHost)
+	srvcfg := conf.Servers["gin"] // TODO: Support aliases
+	gincl := ginclient.New(srvcfg.Web.AddressStr())
 	requirelogin(cmd, gincl, true)
 	username := gincl.Username
 	if len(args) == 1 && args[0] != username {

--- a/gincmd/unlockcmd.go
+++ b/gincmd/unlockcmd.go
@@ -27,7 +27,8 @@ func unlock(cmd *cobra.Command, args []string) {
 		return
 	}
 	conf := config.Read()
-	gincl := ginclient.New(conf.GinHost)
+	srvcfg := conf.Servers["gin"] // TODO: Support aliases
+	gincl := ginclient.New(srvcfg.Web.AddressStr())
 	nitems := countItemsUnlock(args)
 	unlockchan := make(chan git.RepoFileStatus)
 	go gincl.UnlockContent(args, unlockchan)

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -40,14 +40,22 @@ func upload(cmd *cobra.Command, args []string) {
 func UploadCmd() *cobra.Command {
 	description := "Upload changes made in a local repository clone to the remote repository on the GIN server. This command must be called from within the local repository clone. Specific files or directories may be specified. All changes made will be sent to the server, including addition of new files, modifications and renaming of existing files, and file deletions.\n\nIf no arguments are specified, only changes to files already being tracked are uploaded."
 	args := map[string]string{"<filenames>": "One or more directories or files to upload and update."}
+	examples := map[string]string{
+		"Upload 'data1.dat' and 'values.csv' to default remote":             "$ gin upload data1.dat values.csv",
+		"Upload all files in current directory to default remote":           "$ gin upload .",
+		"Upload all previously committed changes to remote named 'labdata'": "$ gin upload --to labdata",
+		"Upload all '.zip' files to remotes named 'gin' and 'labdata'":      "$ gin upload --to gin --to labdata *.zip\n    or\n$ gin upload --to gin,labdata *.zip",
+	}
 	var uploadCmd = &cobra.Command{
-		Use:   "upload [--json] [<filenames>]...",
-		Short: "Upload local changes to a remote repository",
-		Long:  formatdesc(description, args),
-		Args:  cobra.ArbitraryArgs,
-		Run:   upload,
+		Use:     "upload [--json] [--to <remote>] [<filenames>]...",
+		Short:   "Upload local changes to a remote repository",
+		Long:    formatdesc(description, args),
+		Args:    cobra.ArbitraryArgs,
+		Example: formatexamples(examples),
+		Run:     upload,
 		DisableFlagsInUseLine: true,
 	}
 	uploadCmd.Flags().Bool("json", false, "Print output in JSON format.")
+	uploadCmd.Flags().StringSliceP("to", "t", nil, "Upload to specific `remote`. Supports multiple remotes, either by specifying multiple times or as a comma separated list (see Examples).")
 	return uploadCmd
 }

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -1,8 +1,6 @@
 package gincmd
 
 import (
-	"strings"
-
 	ginclient "github.com/G-Node/gin-cli/ginclient"
 	"github.com/G-Node/gin-cli/ginclient/config"
 	"github.com/G-Node/gin-cli/gincmd/ginerrors"
@@ -19,12 +17,9 @@ func upload(cmd *cobra.Command, args []string) {
 		Die(ginerrors.NotInRepo)
 	}
 
-	// Abort if there are no remotes configured
-	if _, err := git.LsRemote(""); err != nil {
-		if strings.Contains(err.Error(), "No remote configured") {
-			Die("upload failed: no remote configured")
-		}
-		// Ignore any other type of error and try to upload
+	// Fail early if no default remote
+	if _, err := ginclient.DefaultRemote(); err != nil {
+		Die("upload failed: no remote configured")
 	}
 
 	gincl.GitHost = conf.GitHost

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -14,8 +14,8 @@ func upload(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
 	remotes, _ := cmd.Flags().GetStringSlice("to")
 	conf := config.Read()
-	gincl := ginclient.New(conf.GinHost)
-	// requirelogin(cmd, gincl, !jsonout) // re-enable only for gin remotes
+	srvcfg := conf.Servers["gin"] // TODO: Is this necessary? What about other servers
+	gincl := ginclient.New(srvcfg.Web.AddressStr())
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
 	}
@@ -38,11 +38,7 @@ func upload(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	gincl.GitHost = conf.GitHost
-	gincl.GitUser = conf.GitUser
-
 	paths := args
-
 	if len(paths) > 0 {
 		commit(cmd, paths)
 	}

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -19,7 +19,7 @@ func upload(cmd *cobra.Command, args []string) {
 	}
 
 	// Fail early if no default remote
-	if _, err := ginclient.DefaultRemote(); err != nil {
+	if _, err := ginclient.DefaultRemote(); err != nil && len(remotes) == 0 {
 		Die("upload failed: no remote configured")
 	}
 

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -12,7 +12,7 @@ func upload(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
 	conf := config.Read()
 	gincl := ginclient.New(conf.GinHost)
-	requirelogin(cmd, gincl, !jsonout)
+	// requirelogin(cmd, gincl, !jsonout) // re-enable only for gin remotes
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
 	}

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -10,6 +10,7 @@ import (
 
 func upload(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
+	remotes, _ := cmd.Flags().GetStringSlice("to")
 	conf := config.Read()
 	gincl := ginclient.New(conf.GinHost)
 	// requirelogin(cmd, gincl, !jsonout) // re-enable only for gin remotes
@@ -32,7 +33,7 @@ func upload(cmd *cobra.Command, args []string) {
 	}
 
 	uploadchan := make(chan git.RepoFileStatus)
-	go gincl.Upload(paths, uploadchan)
+	go gincl.Upload(paths, remotes, uploadchan)
 	formatOutput(uploadchan, 0, jsonout)
 }
 

--- a/gincmd/useremote.go
+++ b/gincmd/useremote.go
@@ -13,23 +13,29 @@ func setRemote(cmd *cobra.Command, args []string) {
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
 	}
-	name := args[0]
-	err := ginclient.SetDefaultRemote(name)
+	if len(args) > 0 {
+		name := args[0]
+		err := ginclient.SetDefaultRemote(name)
+		CheckError(err)
+	}
+	name, err := ginclient.DefaultRemote()
 	CheckError(err)
 	fmt.Printf(":: Default remote: %s\n", name)
 }
 
 // UseRemoteCmd sets up the 'use-remote' repository subcommand
 func UseRemoteCmd() *cobra.Command {
-	description := "Set the default remote for uploading. The default remote is used when 'gin upload' is invoked without specifying the --to option."
+	description := `Set the default remote for uploading. The default remote is used when 'gin upload' is invoked without specifying the --to option.
+	
+With no arguments, this command simply prints the currently configured default remote.`
 	args := map[string]string{
 		"<name>": "The name of the remote to use by default",
 	}
 	var addRemoteCmd = &cobra.Command{
-		Use:   "use-remote <name>",
+		Use:   "use-remote [<name>]",
 		Short: "Set the repository's default upload remote",
 		Long:  formatdesc(description, args),
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		Run:   setRemote,
 		DisableFlagsInUseLine: true,
 	}

--- a/gincmd/useremote.go
+++ b/gincmd/useremote.go
@@ -1,0 +1,37 @@
+package gincmd
+
+import (
+	"fmt"
+
+	ginclient "github.com/G-Node/gin-cli/ginclient"
+	"github.com/G-Node/gin-cli/gincmd/ginerrors"
+	"github.com/G-Node/gin-cli/git"
+	"github.com/spf13/cobra"
+)
+
+func setRemote(cmd *cobra.Command, args []string) {
+	if !git.IsRepo() {
+		Die(ginerrors.NotInRepo)
+	}
+	name := args[0]
+	err := ginclient.SetDefaultRemote(name)
+	CheckError(err)
+	fmt.Printf(":: Default remote: %s\n", name)
+}
+
+// UseRemoteCmd sets up the 'use-remote' repository subcommand
+func UseRemoteCmd() *cobra.Command {
+	description := "Set the default remote for uploading. The default remote is used when 'gin upload' is invoked without specifying the --to option."
+	args := map[string]string{
+		"<name>": "The name of the remote to use by default",
+	}
+	var addRemoteCmd = &cobra.Command{
+		Use:   "use-remote <name>",
+		Short: "Set the repository's default upload remote",
+		Long:  formatdesc(description, args),
+		Args:  cobra.ExactArgs(1),
+		Run:   setRemote,
+		DisableFlagsInUseLine: true,
+	}
+	return addRemoteCmd
+}

--- a/git/annex.go
+++ b/git/annex.go
@@ -124,12 +124,9 @@ func AnnexInit(description string) error {
 		logstd(stdout, stderr)
 		return initError
 	}
-	cmd = Command("config", "annex.backends", "MD5")
-	stdout, stderr, err = cmd.OutputError()
+	err = ConfigSet("annex.backends", "MD5")
 	if err != nil {
 		log.Write("Failed to set default annex backend MD5")
-		log.Write("[Error]: %v", string(stderr))
-		logstd(stdout, stderr)
 	}
 	return nil
 }

--- a/git/annex.go
+++ b/git/annex.go
@@ -239,7 +239,13 @@ func AnnexPush(paths []string, remote string, pushchan chan<- RepoFileStatus) {
 		return
 	}
 
-	cmd = AnnexCommand("copy", "--all", "--json-progress", fmt.Sprintf("--to=%s", remote))
+	args := []string{"copy", "--json-progress", fmt.Sprintf("--to=%s", remote)}
+	if len(paths) == 0 {
+		paths = []string{"--all"}
+	}
+	args = append(args, paths...)
+
+	cmd = AnnexCommand(args...)
 	err = cmd.Start()
 	if err != nil {
 		pushchan <- RepoFileStatus{Err: err}

--- a/git/annex.go
+++ b/git/annex.go
@@ -272,8 +272,9 @@ func AnnexPush(paths []string, remote string, pushchan chan<- RepoFileStatus) {
 		for rerr = nil; rerr == nil; errline, rerr = cmd.OutReader.ReadBytes('\000') {
 			stderr = append(stderr, errline...)
 		}
-		log.Write("Error during AnnexGet")
+		log.Write("Error during AnnexPush")
 		log.Write(string(stderr))
+		pushchan <- RepoFileStatus{Err: fmt.Errorf(string(stderr))}
 	}
 	return
 }

--- a/git/annex.go
+++ b/git/annex.go
@@ -556,12 +556,26 @@ func AnnexStatus(paths []string, statuschan chan<- AnnexStatusRes) {
 	return
 }
 
+// AnnexDescribe changes the description of a repository.
+// (git annex describe)
+func AnnexDescribe(repository, description string) error {
+	fn := fmt.Sprintf("AnnexDescribe(%s, %s)", repository, description)
+	cmd := AnnexCommand("describe", repository, description)
+	stdout, stderr, err := cmd.OutputError()
+	if err != nil {
+		log.Write("Error during Describe")
+		logstd(stdout, stderr)
+		return giterror{Origin: fn, UError: string(stderr)}
+	}
+	return nil
+}
+
 // AnnexInfo returns the annex information for a given repository
 // (git annex info)
 func AnnexInfo() (AnnexInfoRes, error) {
 	cmd := AnnexCommand("info", "--json")
 	stdout, stderr, err := cmd.OutputError()
-	if err != nil || cmd.Wait() != nil {
+	if err != nil {
 		log.Write("Error during AnnexInfo")
 		logstd(stdout, stderr)
 		return AnnexInfoRes{}, fmt.Errorf("Error retrieving annex info")

--- a/git/annex.go
+++ b/git/annex.go
@@ -196,7 +196,7 @@ func AnnexPush(paths []string, remote string, pushchan chan<- RepoFileStatus) {
 	}
 
 	var status RepoFileStatus
-	status.State = "Uploading"
+	status.State = fmt.Sprintf("Uploading (to: %s)", remote)
 
 	var outline []byte
 	var rerr error

--- a/git/annex.go
+++ b/git/annex.go
@@ -217,14 +217,8 @@ func AnnexPull() error {
 // AnnexPush uploads all changes and new content to the default remote.
 // The status channel 'pushchan' is closed when this function returns.
 // (git annex sync --no-pull; git annex copy --to=<defaultremote>)
-func AnnexPush(paths []string, pushchan chan<- RepoFileStatus) {
+func AnnexPush(paths []string, remote string, pushchan chan<- RepoFileStatus) {
 	defer close(pushchan)
-	defremote, err := DefaultRemote()
-	if err != nil {
-		log.Write(err.Error())
-		pushchan <- RepoFileStatus{Err: err}
-		return
-	}
 	cmd := AnnexCommand("sync", "--no-pull", "--no-commit") // NEVER commit changes when doing annex-sync
 	stdout, stderr, err := cmd.OutputError()
 	// TODO: Parse git push output for progress
@@ -245,7 +239,7 @@ func AnnexPush(paths []string, pushchan chan<- RepoFileStatus) {
 		return
 	}
 
-	cmd = AnnexCommand("copy", "--all", "--json-progress", fmt.Sprintf("--to=%s", defremote))
+	cmd = AnnexCommand("copy", "--all", "--json-progress", fmt.Sprintf("--to=%s", remote))
 	err = cmd.Start()
 	if err != nil {
 		pushchan <- RepoFileStatus{Err: err}

--- a/git/git.go
+++ b/git/git.go
@@ -41,6 +41,8 @@ type RepoFileStatus struct {
 	Err error `json:"err"`
 }
 
+// TODO: Create structs to accommodate extra information for other operations
+
 // GinCommit describes a commit, retrieved from the git log.
 type GinCommit struct {
 	Hash            string    `json:"hash"`

--- a/git/git.go
+++ b/git/git.go
@@ -397,9 +397,8 @@ func LsRemote(remote string) (string, error) {
 }
 
 // CommitIfNew creates an empty initial git commit if the current repository is completely new.
-// If 'upstream' is not an empty string, and an initial commit was created, it sets the current branch to track the same-named branch at the specified remote.
 // Returns 'true' if (and only if) a commit was created.
-func CommitIfNew(upstream string) (bool, error) {
+func CommitIfNew() (bool, error) {
 	if !IsRepo() {
 		return false, fmt.Errorf("not a repository")
 	}
@@ -410,7 +409,7 @@ func CommitIfNew(upstream string) (bool, error) {
 		return false, nil
 	}
 
-	// Create an empty initial commit and run annex sync to synchronise everything
+	// Create an empty initial commit
 	hostname, err := os.Hostname()
 	if err != nil {
 		hostname = unknownhostname
@@ -423,17 +422,6 @@ func CommitIfNew(upstream string) (bool, error) {
 		return false, fmt.Errorf(string(stderr))
 	}
 
-	if upstream == "" {
-		return true, nil
-	}
-
-	cmd = Command("push", "--set-upstream", upstream, "HEAD")
-	stdout, stderr, err = cmd.OutputError()
-	if err != nil {
-		log.Write("Error while creating initial commit")
-		logstd(stdout, stderr)
-		return false, fmt.Errorf(string(stderr))
-	}
 	return true, nil
 }
 

--- a/git/git.go
+++ b/git/git.go
@@ -257,7 +257,16 @@ func SetGitUser(name, email string) error {
 // The returned key is always a string.
 // (git config --get)
 func ConfigGet(key string) (string, error) {
-	return "", nil
+	fn := fmt.Sprintf("ConfigGet(%s)", key)
+	cmd := Command("config", "--get", key)
+	stdout, stderr, err := cmd.OutputError()
+	if err != nil {
+		gerr := giterror{UError: string(stderr), Origin: fn}
+		log.Write("Error during config get")
+		logstd(stdout, stderr)
+		return "", gerr
+	}
+	return string(stdout), nil
 }
 
 // RemoteShow returns the configured remotes and their URL.

--- a/git/git.go
+++ b/git/git.go
@@ -446,16 +446,19 @@ func Commit(commitmsg string) error {
 }
 
 // DiffUpstream returns, through the provided channel, the names of all files that differ from the default remote branch.
-// The output channel 'diffchan' is closed when this function returns
+// The output channel 'diffchan' is closed when this function returns.
 // (git diff --name-only --relative @{upstream})
 func DiffUpstream(paths []string, diffchan chan<- string) {
 	defer close(diffchan)
-	// FIXME: Direct mode gets weird with the branches, so we explicitly state origin/master
-	// Should be fixed when we add configurable remotes
-	diffargs := []string{"diff", "-z", "--name-only", "--relative", "origin/master"} // "@{upstream}"}
+	defremote, err := DefaultRemote()
+	if err != nil {
+		log.Write(err.Error())
+		return
+	}
+	diffargs := []string{"diff", "-z", "--name-only", "--relative", fmt.Sprintf("%s/master", defremote)}
 	diffargs = append(diffargs, paths...)
 	cmd := Command(diffargs...)
-	err := cmd.Start()
+	err = cmd.Start()
 	if err != nil {
 		log.Write("ls-files command set up failed: %s", err)
 		return

--- a/git/git.go
+++ b/git/git.go
@@ -337,7 +337,7 @@ func RemoteShow() (map[string]string, error) {
 	return remotes, nil
 }
 
-// RemoteAdd adds a remote named name for the repository at url.
+// RemoteAdd adds a remote named name for the repository at URL.
 func RemoteAdd(name, url string) error {
 	fn := fmt.Sprintf("RemoteAdd(%s, %s)", name, url)
 	cmd := Command("remote", "add", name, url)
@@ -358,6 +358,24 @@ func RemoteAdd(name, url string) error {
 	stdout, stderr, err = cmd.OutputError()
 	if err != nil {
 		logstd(stdout, stderr)
+	}
+	return nil
+}
+
+// RemoteRemove removes the remote named name from the repository configuration.
+func RemoteRemove(name string) error {
+	fn := fmt.Sprintf("RemoteRm(%s)", name)
+	cmd := Command("remote", "remove", name)
+	stdout, stderr, err := cmd.OutputError()
+	if err != nil {
+		sstderr := string(stderr)
+		gerr := giterror{UError: sstderr, Origin: fn}
+		log.Write("Error during remote remove command")
+		logstd(stdout, stderr)
+		if strings.Contains(sstderr, "No such remote") {
+			gerr.Description = fmt.Sprintf("remote with name '%s' does not exist", name)
+		}
+		return gerr
 	}
 	return nil
 }

--- a/git/git.go
+++ b/git/git.go
@@ -266,7 +266,9 @@ func ConfigGet(key string) (string, error) {
 		logstd(stdout, stderr)
 		return "", gerr
 	}
-	return string(stdout), nil
+	value := string(stdout)
+	value = strings.TrimSpace(value)
+	return value, nil
 }
 
 // DefaultRemote returns the name of the configured default remote.

--- a/git/git.go
+++ b/git/git.go
@@ -85,6 +85,26 @@ func (s RepoFileStatus) MarshalJSON() ([]byte, error) {
 
 // Git commands
 
+// Init initialises the current directory as a git repository.
+// The repository is optionally initialised as bare.
+// (git init [--bare])
+func Init(bare bool) error {
+	fn := fmt.Sprintf("Init(%v)", bare)
+	args := []string{"init"}
+	if bare {
+		args = append(args, "--bare")
+	}
+	cmd := Command(args...)
+	stdout, stderr, err := cmd.OutputError()
+	if err != nil {
+		log.Write("Error during init command")
+		logstd(stdout, stderr)
+		gerr := giterror{UError: string(stderr), Origin: fn}
+		return gerr
+	}
+	return nil
+}
+
 // Clone downloads a repository and sets the remote fetch and push urls.
 // The status channel 'clonechan' is closed when this function returns.
 // (git clone ...)

--- a/git/git.go
+++ b/git/git.go
@@ -269,6 +269,15 @@ func ConfigGet(key string) (string, error) {
 	return string(stdout), nil
 }
 
+// DefaultRemote returns the name of the configured default remote.
+func DefaultRemote() (string, error) {
+	defremote, err := ConfigGet("branch.master.remote")
+	if err != nil {
+		err = fmt.Errorf("could not determine default remote")
+	}
+	return defremote, err
+}
+
 // RemoteShow returns the configured remotes and their URL.
 // (git remote -v show -n)
 func RemoteShow() (map[string]string, error) {

--- a/git/git.go
+++ b/git/git.go
@@ -264,13 +264,11 @@ func SetGitUser(name, email string) error {
 	if !IsRepo() {
 		return fmt.Errorf("not a repository")
 	}
-	cmd := Command("config", "--local", "user.name", name)
-	err := cmd.Run()
+	err := ConfigSet("user.name", name)
 	if err != nil {
 		return err
 	}
-	cmd = Command("config", "--local", "user.email", email)
-	return cmd.Run()
+	return ConfigSet("user.email", email)
 }
 
 // ConfigGet returns the value of a given git configuration key.

--- a/git/git.go
+++ b/git/git.go
@@ -375,16 +375,12 @@ func BranchSetUpstream(name string) error {
 	return nil
 }
 
-// LsRemote performs a git ls-remote of a specific remote. If no remote is specified (empty string), it's run against all the default remote.
+// LsRemote performs a git ls-remote of a specific remote.
 // The argument can be a name or a URL.
 // (git ls-remote)
 func LsRemote(remote string) (string, error) {
 	fn := fmt.Sprintf("LsRemote(%s)", remote)
-	args := []string{"ls-remote"}
-	if len(remote) > 0 {
-		args = append(args, remote)
-	}
-	cmd := Command(args...)
+	cmd := Command("ls-remote", remote)
 	stdout, stderr, err := cmd.OutputError()
 	if err != nil {
 		sstderr := string(stderr)

--- a/git/git.go
+++ b/git/git.go
@@ -305,9 +305,9 @@ func RemoteShow() (map[string]string, error) {
 	return remotes, nil
 }
 
-// AddRemote adds a remote named name for the repository at url.
-func AddRemote(name, url string) error {
-	fn := fmt.Sprintf("AddRemote(%s, %s)", name, url)
+// RemoteAdd adds a remote named name for the repository at url.
+func RemoteAdd(name, url string) error {
+	fn := fmt.Sprintf("RemoteAdd(%s, %s)", name, url)
 	cmd := Command("remote", "add", name, url)
 	stdout, stderr, err := cmd.OutputError()
 	if err != nil {

--- a/web/web.go
+++ b/web/web.go
@@ -159,8 +159,8 @@ func (cl *Client) Delete(address string) (*http.Response, error) {
 	return resp, err
 }
 
-// NewClient creates a new client for a given host.
-func NewClient(host string) *Client {
+// New creates a new client for a given host.
+func New(host string) *Client {
 	return &Client{Host: host, web: &http.Client{}}
 }
 


### PR DESCRIPTION
This PR introduces the ability to add new remotes to a repository. To accompany the add-remote command, a number of other commands for remote management are added. Here's a rundown of everything:

- add-remote: Add a remote for a local repository as an upload destination. This can be a local directory, a gin server, or any other kind of server.
- remove-remote: Pretty self explanatory. Removes a remote from the local configuration.
- use-remote: Set default remote. Specifies the default remote where annexed content will be uploaded when performing a `gin upload`.
- remotes: List configured remotes. The current default is noted.
- add-server: Add a GIN server configuration. This adds a GIN server to the client configuration that can be used to create and add remotes to repositories. Full usage of multiple servers will be in the next PR.

### Notes
The gin client tracks the default remote separately from git. It stores a config key in the local git configuration called `gin.remote`. This is used to upload the annexed content when performing a `gin upload` with no `--to` argument. The `--to` argument can be used to override the default. The special keyword `all` can be used to upload annexed content to all configured remotes.