### PR TITLE
Disable commands that rely on git/annex when either is not available

### DIFF
--- a/doc/genhelp.go
+++ b/doc/genhelp.go
@@ -114,7 +114,7 @@ func gendoc(cmd *cobra.Command) string {
 }
 
 func main() {
-	rootcmd := gincmd.SetUpCommands("")
+	rootcmd := gincmd.SetUpCommands(gincmd.VersionInfo{})
 	fmt.Println("Generating help file")
 
 	buf := new(bytes.Buffer)

--- a/gincmd/cliversion.go
+++ b/gincmd/cliversion.go
@@ -58,13 +58,12 @@ func (v *VersionInfo) AnnexOK() (bool, error) {
 	systemver, err := version.NewVersion(v.Annex)
 	if err != nil {
 		// Special case for neurodebian git-annex version
-		// The versionn string contains a tilde as a separator for the arch suffix
+		// The version string contains a tilde as a separator for the arch suffix
 		// Cutting off the suffix and checking again
 		verstring := strings.Split(v.Annex, "~")[0]
 		systemver, err = version.NewVersion(verstring)
 		if err != nil {
 			// Can't figure out the version: print error from AnnexVersion
-			// return false, fmt.Errorf("%s\ngit-annex version %s not understood", errmsg, v.Annex)
 			return false, fmt.Errorf(v.Annex)
 		}
 	}

--- a/gincmd/cliversion.go
+++ b/gincmd/cliversion.go
@@ -1,0 +1,59 @@
+package gincmd
+
+import (
+	"fmt"
+	"strings"
+
+	version "github.com/hashicorp/go-version"
+)
+
+const minAnnexVersion = "6.20160126" // Introduction of git-annex add --json
+
+// VersionInfo holds the version numbers supplied by the linker flags in a convenient struct.
+type VersionInfo struct {
+	Version string
+	Build   string
+	Commit  string
+	Git     string
+	Annex   string
+}
+
+// String constructs a human-readable string that contains the version numbers.
+func (v *VersionInfo) String() string {
+	if v.Version == "" {
+		return "GIN command line client [dev build]"
+	}
+	return fmt.Sprintf("GIN command line client %s Build %s (%s)\n  git: %s\n  git-annex: %s", v.Version, v.Build, v.Commit, v.Git, v.Annex)
+}
+
+// GitOK checks if the system git version is higher than the required one.
+// If it is not, or the git binary is not found, an appropriate error message is returned.
+func (v *VersionInfo) GitOK() (bool, error) {
+	if v.Git == "" {
+		return false, fmt.Errorf("The GIN Client requires git to be installed and accessible")
+	}
+	return true, nil
+}
+
+// AnnexOK checks if the system annex version is higher than the required one.
+// If it is not, or the git-annex binary is not found, an appropriate error message is returned.
+func (v *VersionInfo) AnnexOK() (bool, error) {
+	errmsg := fmt.Sprintf("The GIN Client requires git-annex %s or newer", minAnnexVersion)
+	systemver, err := version.NewVersion(v.Annex)
+	if err != nil {
+		// Special case for neurodebian git-annex version
+		// The versionn string contains a tilde as a separator for the arch suffix
+		// Cutting off the suffix and checking again
+		verstring := strings.Split(v.Annex, "~")[0]
+		systemver, err = version.NewVersion(verstring)
+		if err != nil {
+			// Can't figure out the version. Giving up.
+			return false, fmt.Errorf("%s\ngit-annex version %s not understood", errmsg, v.Annex)
+		}
+	}
+	minver, _ := version.NewVersion(minAnnexVersion)
+	if systemver.LessThan(minver) {
+		return false, fmt.Errorf("%s\nFound version %s", errmsg, v.Annex)
+	}
+	return true, nil
+}

--- a/gincmd/commitcmd.go
+++ b/gincmd/commitcmd.go
@@ -73,7 +73,7 @@ func makeCommitMessage(action string, paths []string) (commitmsg string) {
 // CommitCmd sets up the 'commit' subcommand
 func CommitCmd() *cobra.Command {
 	description := "Record changes made in a local repository. This command must be called from within the local repository clone. Specific files or directories may be specified. All changes made to the files and directories that are specified will be recorded, including addition of new files, modifications and renaming of existing files, and file deletions.\n\nIf no arguments are specified, no changes are recorded."
-	args := map[string]string{"<filenames>": "One or more directories or files to upload and update."}
+	args := map[string]string{"<filenames>": "One or more directories or files to commit."}
 	var cmd = &cobra.Command{
 		Use:   "commit [<filenames>]...",
 		Short: "Record changes in local repository",

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -275,7 +275,8 @@ func formatexamples(examples map[string]string) (exdesc string) {
 }
 
 // SetUpCommands sets up all the subcommands for the client and returns the root command, ready to execute.
-func SetUpCommands(verstr string) *cobra.Command {
+func SetUpCommands(verinfo VersionInfo) *cobra.Command {
+	verstr := verinfo.String()
 	var rootCmd = &cobra.Command{
 		Use:                   "gin",
 		Long:                  "GIN Command Line Interface and client for the GIN services", // TODO: Add license and web info

--- a/gincmd/getcontentcmd.go
+++ b/gincmd/getcontentcmd.go
@@ -27,7 +27,7 @@ func getContent(cmd *cobra.Command, args []string) {
 func GetContentCmd() *cobra.Command {
 	description := "Download the content of the listed files. The get-content command is intended to be used to retrieve the content of placeholder files in a local repository. This command must be called from within the local repository clone. With no arguments, downloads the content for all files under the working directory, recursively."
 	args := map[string]string{
-		"<filenames>": "One or more directories or files to lock.",
+		"<filenames>": "One or more directories or files to download.",
 	}
 	var cmd = &cobra.Command{
 		Use:                   "get-content [--json] [<filenames>]...",

--- a/git/annex.go
+++ b/git/annex.go
@@ -779,7 +779,6 @@ func GetAnnexVersion() (string, error) {
 		return "", err
 
 	}
-	log.Write(string(stdout))
 	return string(stdout), nil
 }
 

--- a/git/git.go
+++ b/git/git.go
@@ -941,6 +941,31 @@ func gitAddDirect(paths []string) (filtered []string) {
 	return
 }
 
+// GetGitVersion returns the version string of the system's git binary.
+func GetGitVersion() (string, error) {
+	cmd := Command("version")
+	stdout, stderr, err := cmd.OutputError()
+	if err != nil {
+		errmsg := string(stderr)
+		log.Write("Error while preparing git version command")
+		if strings.Contains(err.Error(), "executable file not found") {
+			return "", fmt.Errorf("git executable not found: %s", err.Error())
+		}
+		if strings.Contains(errmsg, "no such file or directory") {
+			return "", fmt.Errorf("git executable not found: %s", errmsg)
+		}
+		if errmsg != "" {
+			return "", fmt.Errorf(errmsg)
+		}
+		return "", err
+
+	}
+	verstr := string(stdout)
+	verstr = strings.TrimSpace(verstr)
+	verstr = strings.TrimPrefix(verstr, "git version ")
+	return verstr, nil
+}
+
 // Command sets up an external git command with the provided arguments and returns a GinCmd struct.
 func Command(args ...string) shell.Cmd {
 	config := config.Read()

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ var gincliversion string
 var build string
 var commit string
 var verstr string
-var minAnnexVersion = "6.20160126" // Introduction of git-annex add --json
+const minAnnexVersion = "6.20160126" // Introduction of git-annex add --json
 
 func checkAnnexVersion() {
 	errmsg := fmt.Sprintf("The GIN Client requires git-annex %s or newer", minAnnexVersion)

--- a/main.go
+++ b/main.go
@@ -27,11 +27,15 @@ func init() {
 	verinfo.Commit = commit
 
 	gitVer, err := git.GetGitVersion()
-	gincmd.CheckError(err)
+	if err != nil {
+		gitVer = err.Error()
+	}
 	verinfo.Git = gitVer
 
 	annexVer, err := git.GetAnnexVersion()
-	gincmd.CheckError(err)
+	if err != nil {
+		annexVer = err.Error()
+	}
 	verinfo.Annex = annexVer
 }
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -9,66 +8,35 @@ import (
 	"github.com/G-Node/gin-cli/ginclient/log"
 	"github.com/G-Node/gin-cli/gincmd"
 	"github.com/G-Node/gin-cli/git"
-	version "github.com/hashicorp/go-version"
 )
 
-var gincliversion string
-var build string
-var commit string
-var verstr string
-const minAnnexVersion = "6.20160126" // Introduction of git-annex add --json
+// Version strings are populated using linker flags //
 
-func checkAnnexVersion() {
-	errmsg := fmt.Sprintf("The GIN Client requires git-annex %s or newer", minAnnexVersion)
-	verstring, err := git.GetAnnexVersion()
-	gincmd.CheckError(err)
-	systemver, err := version.NewVersion(verstring)
-	if err != nil {
-		// Special case for neurodebian git-annex version
-		// The versionn string contains a tilde as a separator for the arch suffix
-		// Cutting off the suffix and checking again
-		verstring = strings.Split(verstring, "~")[0]
-		systemver, err = version.NewVersion(verstring)
-		if err != nil {
-			// Can't figure out the version. Giving up.
-			gincmd.Die(fmt.Sprintf("%s\ngit-annex version %s not understood", errmsg, verstring))
-		}
-	}
-	minver, _ := version.NewVersion(minAnnexVersion)
-	if systemver.LessThan(minver) {
-		gincmd.Die(fmt.Sprintf("%s\nFound version %s", errmsg, verstring))
-	}
-}
+var (
+	gincliversion string
+	build         string
+	commit        string
+	verinfo       gincmd.VersionInfo
+)
 
-func printversion(args []string) {
-	jsonout := true // TODO: make this a new command
-	if jsonout {
-		verjson := struct {
-			Version string `json:"version"`
-			Build   string `json:"build"`
-			Commit  string `json:"commit"`
-		}{
-			gincliversion,
-			build,
-			commit,
-		}
-		verjsonstr, _ := json.Marshal(verjson)
-		fmt.Println(string(verjsonstr))
-	} else {
-		fmt.Println(verstr)
-	}
-}
+// ================================================ //
 
 func init() {
-	if gincliversion == "" {
-		verstr = "GIN command line client [dev build]"
-	} else {
-		verstr = fmt.Sprintf("GIN command line client %s Build %s (%s)", gincliversion, build, commit)
-	}
+	verinfo.Version = gincliversion
+	verinfo.Build = build
+	verinfo.Commit = commit
+
+	gitVer, err := git.GetGitVersion()
+	gincmd.CheckError(err)
+	verinfo.Git = gitVer
+
+	annexVer, err := git.GetAnnexVersion()
+	gincmd.CheckError(err)
+	verinfo.Annex = annexVer
 }
 
 func main() {
-	err := log.Init(verstr)
+	err := log.Init(verinfo.String())
 	gincmd.CheckError(err)
 	defer log.Close()
 
@@ -83,9 +51,7 @@ func main() {
 	cwd, _ := os.Getwd()
 	log.Write("CWD: %s", cwd)
 
-	checkAnnexVersion()
-
-	rootCmd := gincmd.SetUpCommands(verstr)
+	rootCmd := gincmd.SetUpCommands(verinfo)
 	rootCmd.SetVersionTemplate("{{ .Version }}")
 
 	// Engage


### PR DESCRIPTION
When git or git-annex aren't available (or git-annex is not the required version) allow the user to run commands that don't require git, but disable the commands that do and show an appropriate error message.

This isn't very useful since there's not that much the client can do without git and git-annex, but I think it provides better information to the user about missing dependencies (git and/or git-annex).

The explanation of what is missing is shown in three situations:
- `gin --version`: prints git and git-annex versions when available, a `not found` message when they're not, and an appropriate error message when git-annex is available but the version is too old.
- `gin help`: highlights all disabled commands with `[not available]` and provides the same error message as above at the end of the help text.
- When the user attempts to run a command that requires git/annex and one or both are not available, the error message is displayed.

The error or warning message also links to https://web.gin.g-node.org/G-Node/Info/wiki/GinCli as a guide for where information about installing the client properly can be found (closes #195).

### Sample output
<details><summary>Changing the git binary to notexist produces the following outputs (click to expand)</summary>

```
$ gin --version
GIN command line client 1.0beta Build 001160 (3d4869296a0897d393777f29183fee55d7bb6770)
  git: not found
  git-annex: 6.20180719-ge8ff5d8c66
$ gin help
gUsage:

  gin [command]

GIN Command Line Interface and client for the GIN services

Available Commands:
  add-remote     [not available] Add a remote to the current repository for uploading and downloading
  add-server     Add a new GIN server configuration
  commit         [not available] Record changes in local repository
  create         [not available] Create a new repository on the GIN server
  download       [not available] Download all new information from a remote repository
  get            [not available] Retrieve (clone) a repository from the remote server
  get-content    [not available] Download the content of files from a remote repository
  help           Help about any command
  info           Print a user's information
  init           [not available] Initialise the current directory as a gin repository
  keys           List, add, or delete public keys on the GIN services
  lock           [not available] Lock files
  login          Login to the GIN services
  logout         Logout of the GIN services
  ls             [not available] List the sync status of files in the local repository
  remotes        [not available] List the repository's configured remotes
  remove-content [not available] Remove the content of local files that have already been uploaded
  remove-remote  [not available] Remove a remote from the current repository
  remove-server  Remove a server from the global configuration
  repoinfo       Show the information for a specific repository
  repos          List available remote repositories
  servers        List the globally configured servers
  unlock         [not available] Unlock files for editing
  upload         [not available] Upload local changes to a remote repository
  use-remote     [not available] Set the repository's default upload remote
  use-server     Set the default server for the client
  version        [not available] Roll back files or directories to older versions

Flags:

  -h, --help   help for gin

Use "gin help [command]" for more information about a command.

Some commands are not available:
  git executable not found: exec: "notexist": executable file not found in $PATH
  Visit https://web.gin.g-node.org/G-Node/Info/wiki/GinCli#linux for information on installing all the required software
$ gin init
[error] The 'init' command is not available because it requires git and git-annex:
  git executable not found: exec: "notexist": executable file not found in $PATH
  Visit https://web.gin.g-node.org/G-Node/Info/wiki/GinCli#linux for information on installing all the required software
```
</details>

<details><summary>Similarly, changing git-annex to notexist in the config produces (click to expand)</summary>

```
$ gin --version
GIN command line client 1.0beta Build 001160 (3d4869296a0897d393777f29183fee55d7bb6770)
  git: 2.18.0
  git-annex: not found
$ gin init
[error] The 'init' command is not available because it requires git and git-annex:
  git-annex executable not found: exec: "notexist": executable file not found in $PATH
  Visit https://web.gin.g-node.org/G-Node/Info/wiki/GinCli#linux for information on installing all the required software
```
</details>

<details><summary>Changing the minimum annex version to simulate a version mismatch produces (click to expand)</summary>

```
$ gin ls
[error] The 'ls' command is not available because it requires git and git-annex:
  git-annex version 6.20180719-ge8ff5d8c66 found, but 7.20160126 or newer is required
  Visit https://web.gin.g-node.org/G-Node/Info/wiki/GinCli#linux for information on installing all the required software
```
</details>