### PR TITLE
Git transfer output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,13 @@ INSTLOC = $(GOPATH)/bin
 TESTBINLOC = tests/bin
 
 # Build flags
-VERNUM = $(shell grep -o -E '[0-9.]+(dev|beta){0,1}' version)
+VERNUM = $(shell cut -d= -f2 version)
 ncommits = $(shell git rev-list --count HEAD)
 BUILDNUM = $(shell printf '%06d' $(ncommits))
 COMMITHASH = $(shell git rev-parse HEAD)
 LDFLAGS = -ldflags=$(PKG)="-X main.gincliversion=$(VERNUM) -X main.build=$(BUILDNUM) -X main.commit=$(COMMITHASH)"
 
-SOURCES = $(shell find . -type f -iname "*.go")
+SOURCES = $(shell find . -type f -iname "*.go") version
 
 .PHONY: gin allplatforms Install linux windows macos clean uninstall
 

--- a/dorelease.py
+++ b/dorelease.py
@@ -11,7 +11,6 @@ Build gin-cli binaries and package them for distribution.
 import pickle
 import sys
 import os
-import stat
 import shutil
 import json
 import re
@@ -115,8 +114,7 @@ def build():
     with open(verfilename) as verfile:
         verinfo = verfile.read()
 
-    VERSION["version"] = re.search(r"version=([0-9\.]+(dev|beta){0,1})",
-                                   verinfo).group(1)
+    VERSION["version"] = re.search(r"version=(.*)", verinfo).group(1)
     cmd = ["git", "rev-list", "--count", "HEAD"]
     VERSION["build"] = int(check_output(cmd).strip().decode())
     cmd = ["git", "rev-parse", "HEAD"]

--- a/ginclient/repos.go
+++ b/ginclient/repos.go
@@ -284,6 +284,13 @@ func (gincl *Client) Upload(paths []string, remotes []string, uploadchan chan<- 
 			uploadchan <- git.RepoFileStatus{FileName: remote, Err: fmt.Errorf("unknown remote name '%s': skipping", remote)}
 			continue
 		}
+
+		gitpushchan := make(chan git.RepoFileStatus)
+		go git.Push(remote, gitpushchan)
+		for stat := range gitpushchan {
+			uploadchan <- stat
+		}
+
 		annexpushchan := make(chan git.RepoFileStatus)
 		go git.AnnexPush(paths, remote, annexpushchan)
 		for stat := range annexpushchan {

--- a/gincmd/createcmd.go
+++ b/gincmd/createcmd.go
@@ -59,7 +59,9 @@ func createRepo(cmd *cobra.Command, args []string) {
 			// Push the new commit to initialise origin
 			uploadchan := make(chan git.RepoFileStatus)
 			go gincl.Upload(nil, []string{"origin"}, uploadchan)
-			<-uploadchan
+			for range uploadchan {
+				// Wait for channel to close
+			}
 		}
 	} else if !noclone {
 		// Clone repository after creation

--- a/gincmd/getcmd.go
+++ b/gincmd/getcmd.go
@@ -39,7 +39,9 @@ func getRepo(cmd *cobra.Command, args []string) {
 		// Push the new commit to initialise origin
 		uploadchan := make(chan git.RepoFileStatus)
 		go gincl.Upload(nil, []string{"origin"}, uploadchan)
-		<-uploadchan
+		for range uploadchan {
+			// Wait for channel to close
+		}
 	}
 	CheckError(err)
 }

--- a/gincmd/versioncmd.go
+++ b/gincmd/versioncmd.go
@@ -79,7 +79,9 @@ func checkoutcopies(commit git.GinCommit, paths []string, destination string) {
 	// Add new files to index but do not upload
 	addchan := make(chan git.RepoFileStatus)
 	go git.Add(newfiles, addchan)
-	<-addchan
+	for range addchan {
+		// Wait for channel to close
+	}
 	// TODO: Instead of adding git files, would it be better if we did get-content on annex files and then removed them from the index?
 }
 

--- a/version
+++ b/version
@@ -1,1 +1,1 @@
-version=1.0beta
+version=1.0beta2-dev


### PR DESCRIPTION
While uploading, the client now performs an explicit `git push` in order to get progress information from the `git push --progress` command.

Previously, git pushing was handled by `git annex sync`, which doesn't provide any progress output.