### PR TITLE
Reuse tokens

### DIFF
--- a/ginclient/gin.go
+++ b/ginclient/gin.go
@@ -320,7 +320,6 @@ func (gincl *Client) NewToken(username, password, clientID string) error {
 	}
 	gincl.Username = username
 	gincl.Token = token.Sha1
-	log.Write("Login successful. Username: %s", username)
 	return nil
 }
 

--- a/git/git.go
+++ b/git/git.go
@@ -78,7 +78,7 @@ func (s RepoFileStatus) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(struct {
 		RFSAlias
-		Err string `json:"err"`
+		Err string
 	}{
 		RFSAlias: RFSAlias(s),
 		Err:      errmsg,

--- a/version
+++ b/version
@@ -1,1 +1,1 @@
-version=1.1
+version=1.2dev

--- a/web/web.go
+++ b/web/web.go
@@ -115,6 +115,25 @@ func (cl *Client) Post(address string, data interface{}) (*http.Response, error)
 	return resp, err
 }
 
+// GetBasicAuth sends a GET request to address.
+// The username and password are used to perform Basic authentication.
+func (cl *Client) GetBasicAuth(address, username, password string) (*http.Response, error) {
+	fn := fmt.Sprintf("GetBasicAuth(%s)", address)
+	requrl := urlJoin(cl.Host, address)
+	req, err := http.NewRequest("GET", requrl, nil)
+	if err != nil {
+		return nil, weberror{UError: err.Error(), Origin: fn}
+	}
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", gogs.BasicAuthEncode(username, password)))
+	log.Write("Performing GET: %s", req.URL)
+	resp, err := cl.web.Do(req)
+	if err != nil {
+		err = weberror{UError: err.Error(), Origin: fn, Description: parseServerError(err)}
+	}
+	return resp, err
+}
+
 // PostBasicAuth sends a POST request to address with the provided data.
 // The username and password are used to perform Basic authentication.
 func (cl *Client) PostBasicAuth(address, username, password string, data interface{}) (*http.Response, error) {


### PR DESCRIPTION
## New client API function: GetTokens()
`GetTokens()` retrieves all the active user's tokens from the server. It uses another new function, `GetBasicAuth()`, to perform a GET request using basic auth.

The client uses these functions to retrieve existing tokens for the same type of client (same `clientID`) instead of creating a new one every time the user logs in and flooding the user's token list.