### PR TITLE
Merge conflict error messages and handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ services:
 
 matrix:
   include:
-    - go: "1.10.x"
+    - go: "1.11.x"
       env: testscript="run-cont-tests"
-    - go: "1.10.x"
+    - go: "1.11.x"
       env: testscript="run-cont-tests-mv"
     - go: tip
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,6 @@ after_script:
         echo $GISTTOKEN > ./tests/testuserhome/.gist;
         mv ./tests/testuserhome/log/gin.log ./tests/testuserhome/log/gin-${TRAVIS_BRANCH}-${testscript}.log;
         mv ./tests/testuserhome/log/tests.log ./tests/testuserhome/log/tests-${TRAVIS_BRANCH}-${testscript}.log;
-        ./tests/run-cont gist -u 59e3b1c2fc3ff525127f9b3af81e7f4c ./testuserhome/log/*.log;
+        ./tests/run-cont find ./log -type f -exec gist -u 59e3b1c2fc3ff525127f9b3af81e7f4c {} \+ ;
         rm ./tests/testuserhome/.gist;
     fi

--- a/gincmd/downloadcmd.go
+++ b/gincmd/downloadcmd.go
@@ -45,11 +45,11 @@ func download(cmd *cobra.Command, args []string) {
 func DownloadCmd() *cobra.Command {
 	description := "Downloads changes from the remote repository to the local clone. This will create new files that were added remotely, delete files that were removed, and update files that were changed.\n\nOptionally downloads the content of all files in the repository. If 'content' is not specified, new files will be empty placeholders. Content of individual files can later be retrieved using the 'get-content' command."
 	var cmd = &cobra.Command{
-		Use:   "download [--json] [--content]",
-		Short: "Download all new information from a remote repository",
-		Long:  formatdesc(description, nil),
-		Args:  cobra.NoArgs,
-		Run:   download,
+		Use:                   "download [--json] [--content]",
+		Short:                 "Download all new information from a remote repository",
+		Long:                  formatdesc(description, nil),
+		Args:                  cobra.NoArgs,
+		Run:                   download,
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")

--- a/git/annex.go
+++ b/git/annex.go
@@ -136,6 +136,7 @@ func AnnexPull() error {
 	args := []string{"sync", "--no-push", "--no-commit"}
 	cmd := AnnexCommand(args...)
 	stdout, stderr, err := cmd.OutputError()
+	cmd.Wait()
 	sstdout := string(stdout)
 	sstderr := string(stderr)
 	if err != nil {

--- a/git/git.go
+++ b/git/git.go
@@ -934,10 +934,18 @@ func IsVersion6() bool {
 	return ver == "6"
 }
 
-// mergeAbort aborts an unfinished  git merge.
+// mergeAbort aborts an unfinished git merge.
 func mergeAbort() {
+	// Here, we run a git status without checking any part of the result. It
+	// seems git-annex performs some cleanup or consistency fixes to the index
+	// when git status is run and before that, the merge --abort fails.
+	Command("status").Run()
 	cmd := Command("merge", "--abort")
-	cmd.Run()
+	stdout, stderr, err := cmd.OutputError()
+	if err != nil {
+		// log error but do nothing
+		logstd(stdout, stderr)
+	}
 }
 
 func SetBare(state bool) {

--- a/git/git.go
+++ b/git/git.go
@@ -934,6 +934,12 @@ func IsVersion6() bool {
 	return ver == "6"
 }
 
+// mergeAbort aborts an unfinished  git merge.
+func mergeAbort() {
+	cmd := Command("merge", "--abort")
+	cmd.Run()
+}
+
 func SetBare(state bool) {
 	setBare(state)
 }

--- a/git/git.go
+++ b/git/git.go
@@ -501,7 +501,8 @@ func Commit(commitmsg string) error {
 	stdout, stderr, err := cmd.OutputError()
 
 	if err != nil {
-		if strings.Contains(string(stdout), "nothing to commit") {
+		sstdout := string(stdout)
+		if strings.Contains(sstdout, "nothing to commit") || strings.Contains(sstdout, "nothing added to commit") {
 			// Return special error
 			log.Write("Nothing to commit")
 			return fmt.Errorf("Nothing to commit")


### PR DESCRIPTION
This PR makes some minor changes to how merge conflicts are detected and handled on `gin download`.
- In the case where a download fails in order to avoid overwriting locally modified or untracked files (`download failed: local modified or untracked files would be overwritten by download`), the files in question are listed after the error message.
- In the case where a download fails because git files can't be merged, a new error message is printed `download failed: files changed locally and remotely and cannot be automatically merged (merge conflict)` and the files in question are listed after the error message.
- In the case where a download fails because annex files can't be merged, a new error message is printed `files changed locally and remotely. Both files have been kept` and the files in question are listed after the error message.

In the latter case, conflicting files are kept in the local directory and added automatically by git annex (with a unique suffix).