### PR TITLE
Push only to target remote

### DIFF
--- a/gincmd/addremotecmd.go
+++ b/gincmd/addremotecmd.go
@@ -175,12 +175,12 @@ A new remote is set as the default for uploading if no other remotes are configu
 		"Add a directory on a storage drive as a remote named 'datastore'": "$ gin add-remote datastore dir:/mnt/gindatastore",
 	}
 	var cmd = &cobra.Command{
-		Use:     "add-remote <name> <location>",
-		Short:   "Add a remote to the current repository for uploading and downloading",
-		Long:    formatdesc(description, args),
-		Example: formatexamples(examples),
-		Args:    cobra.ExactArgs(2),
-		Run:     addRemote,
+		Use:                   "add-remote <name> <location>",
+		Short:                 "Add a remote to the current repository for uploading and downloading",
+		Long:                  formatdesc(description, args),
+		Example:               formatexamples(examples),
+		Args:                  cobra.ExactArgs(2),
+		Run:                   addRemote,
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("create", false, "Create the remote on the server if it does not already exist.")

--- a/gincmd/addservercmd.go
+++ b/gincmd/addservercmd.go
@@ -173,12 +173,12 @@ See the Examples section for a full example.
 		"This is what configuring the built-in G-Node GIN server would look like (note: this is already configured)": "$ gin add-server --web https://web.gin.g-node.org:443 --git git@git.g-node.org:22 gin",
 	}
 	var cmd = &cobra.Command{
-		Use:     "add-server [--web http[s]://<hostname>[:<port>]] [--git [<gituser>@]<hostname>[:<port>]] <alias>",
-		Short:   "Add a new GIN server configuration",
-		Long:    formatdesc(description, args),
-		Args:    cobra.ExactArgs(1),
-		Example: formatexamples(examples),
-		Run:     addServer,
+		Use:                   "add-server [--web http[s]://<hostname>[:<port>]] [--git [<gituser>@]<hostname>[:<port>]] <alias>",
+		Short:                 "Add a new GIN server configuration",
+		Long:                  formatdesc(description, args),
+		Args:                  cobra.ExactArgs(1),
+		Example:               formatexamples(examples),
+		Run:                   addServer,
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().String("web", "", "Set the address and port for the web server.")

--- a/gincmd/annexcmd.go
+++ b/gincmd/annexcmd.go
@@ -28,11 +28,11 @@ func annexrun(cmd *cobra.Command, args []string) {
 // AnnexCmd sets up the 'annex' passthrough subcommand
 func AnnexCmd() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "annex <cmd> [<args>]...",
-		Short: "Run a 'git annex' command through the gin client",
-		Long:  "",
-		Args:  cobra.ArbitraryArgs,
-		Run:   annexrun,
+		Use:                   "annex <cmd> [<args>]...",
+		Short:                 "Run a 'git annex' command through the gin client",
+		Long:                  "",
+		Args:                  cobra.ArbitraryArgs,
+		Run:                   annexrun,
 		DisableFlagsInUseLine: true,
 		Hidden:                true,
 		DisableFlagParsing:    true,

--- a/gincmd/commitcmd.go
+++ b/gincmd/commitcmd.go
@@ -1,7 +1,6 @@
 package gincmd
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 
@@ -13,16 +12,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func countItemsAdd(paths []string) int {
-	args := append([]string{"add", "--dry-run"}, paths...)
-	cmd := git.Command(args...)
-	output, err := cmd.Output()
-	if err != nil {
-		return 0
-	}
-	return len(bytes.Split(bytes.TrimSpace(output), []byte("\n")))
-}
-
 func commit(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
 	if !git.IsRepo() {
@@ -31,9 +20,8 @@ func commit(cmd *cobra.Command, args []string) {
 
 	paths := args
 	addchan := make(chan git.RepoFileStatus)
-	nitems := countItemsAdd(paths)
 	go ginclient.Add(paths, addchan)
-	formatOutput(addchan, nitems, jsonout)
+	formatOutput(addchan, 0, jsonout)
 
 	if !jsonout {
 		fmt.Print(":: Recording changes ")

--- a/gincmd/commitcmd.go
+++ b/gincmd/commitcmd.go
@@ -75,11 +75,11 @@ func CommitCmd() *cobra.Command {
 	description := "Record changes made in a local repository. This command must be called from within the local repository clone. Specific files or directories may be specified. All changes made to the files and directories that are specified will be recorded, including addition of new files, modifications and renaming of existing files, and file deletions.\n\nIf no arguments are specified, no changes are recorded."
 	args := map[string]string{"<filenames>": "One or more directories or files to commit."}
 	var cmd = &cobra.Command{
-		Use:   "commit [<filenames>]...",
-		Short: "Record changes in local repository",
-		Long:  formatdesc(description, args),
-		Args:  cobra.ArbitraryArgs,
-		Run:   commit,
+		Use:                   "commit [<filenames>]...",
+		Short:                 "Record changes in local repository",
+		Long:                  formatdesc(description, args),
+		Args:                  cobra.ArbitraryArgs,
+		Run:                   commit,
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")

--- a/gincmd/createcmd.go
+++ b/gincmd/createcmd.go
@@ -86,12 +86,12 @@ func CreateCmd() *cobra.Command {
 	}
 
 	var cmd = &cobra.Command{
-		Use:     "create [--here | --no-clone] [<repository>] [<description>]",
-		Short:   "Create a new repository on the GIN server",
-		Long:    formatdesc(description, args),
-		Example: formatexamples(examples),
-		Args:    cobra.MaximumNArgs(2),
-		Run:     createRepo,
+		Use:                   "create [--here | --no-clone] [<repository>] [<description>]",
+		Short:                 "Create a new repository on the GIN server",
+		Long:                  formatdesc(description, args),
+		Example:               formatexamples(examples),
+		Args:                  cobra.MaximumNArgs(2),
+		Run:                   createRepo,
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("here", false, "Create the local repository clone in the current working directory. Cannot be used with --no-clone.")

--- a/gincmd/deletecmd.go
+++ b/gincmd/deletecmd.go
@@ -57,11 +57,11 @@ func deleteRepo(cmd *cobra.Command, args []string) {
 // DeleteCmd sets up the 'delete' repository subcommand
 func DeleteCmd() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "delete <repository>",
-		Short: "Delete a repository from the GIN server",
-		Long:  "Delete a repository from the GIN server.",
-		Args:  cobra.ExactArgs(1),
-		Run:   deleteRepo,
+		Use:                   "delete <repository>",
+		Short:                 "Delete a repository from the GIN server",
+		Long:                  "Delete a repository from the GIN server.",
+		Args:                  cobra.ExactArgs(1),
+		Run:                   deleteRepo,
 		DisableFlagsInUseLine: true,
 		Hidden:                true,
 	}

--- a/gincmd/getcmd.go
+++ b/gincmd/getcmd.go
@@ -57,12 +57,12 @@ func GetCmd() *cobra.Command {
 		"Get and initialise the repository named 'eegdata' owned by user 'peter'": "$ gin get peter/eegdata",
 	}
 	var cmd = &cobra.Command{
-		Use:     "get [--json] <repopath>",
-		Short:   "Retrieve (clone) a repository from the remote server",
-		Long:    formatdesc(description, args),
-		Example: formatexamples(examples),
-		Args:    cobra.ExactArgs(1),
-		Run:     getRepo,
+		Use:                   "get [--json] <repopath>",
+		Short:                 "Retrieve (clone) a repository from the remote server",
+		Long:                  formatdesc(description, args),
+		Example:               formatexamples(examples),
+		Args:                  cobra.ExactArgs(1),
+		Run:                   getRepo,
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")

--- a/gincmd/gitcmd.go
+++ b/gincmd/gitcmd.go
@@ -32,11 +32,11 @@ func gitrun(cmd *cobra.Command, args []string) {
 // GitCmd sets up the 'git' passthrough subcommand
 func GitCmd() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "git <cmd> [<args>]...",
-		Short: "Run a 'git' command through the gin client",
-		Long:  "",
-		Args:  cobra.ArbitraryArgs,
-		Run:   gitrun,
+		Use:                   "git <cmd> [<args>]...",
+		Short:                 "Run a 'git' command through the gin client",
+		Long:                  "",
+		Args:                  cobra.ArbitraryArgs,
+		Run:                   gitrun,
 		DisableFlagsInUseLine: true,
 		Hidden:                true,
 		DisableFlagParsing:    true,

--- a/gincmd/infocmd.go
+++ b/gincmd/infocmd.go
@@ -54,11 +54,11 @@ func InfoCmd() *cobra.Command {
 		"<username>": "The name of the user whose information should be printed. This can be the username of the currently logged in user (default), in which case the command will print all the profile information with indicators for which data is publicly visible. If it is the username of a different user, only the publicly visible information is printed.",
 	}
 	var cmd = &cobra.Command{
-		Use:   "info [username]",
-		Short: "Print a user's information",
-		Long:  formatdesc(description, args),
-		Args:  cobra.MaximumNArgs(1),
-		Run:   printAccountInfo,
+		Use:                   "info [username]",
+		Short:                 "Print a user's information",
+		Long:                  formatdesc(description, args),
+		Args:                  cobra.MaximumNArgs(1),
+		Run:                   printAccountInfo,
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().String("server", "", "Specify server `alias` for info lookup. See also 'gin servers'.")

--- a/gincmd/initcmd.go
+++ b/gincmd/initcmd.go
@@ -21,11 +21,11 @@ func initRepo(cmd *cobra.Command, args []string) {
 func InitCmd() *cobra.Command {
 	description := "Initialise a local repository in the current directory with the default options."
 	var cmd = &cobra.Command{
-		Use:   "init",
-		Short: "Initialise the current directory as a gin repository",
-		Long:  formatdesc(description, nil),
-		Args:  cobra.NoArgs,
-		Run:   initRepo,
+		Use:                   "init",
+		Short:                 "Initialise the current directory as a gin repository",
+		Long:                  formatdesc(description, nil),
+		Args:                  cobra.NoArgs,
+		Run:                   initRepo,
 		DisableFlagsInUseLine: true,
 	}
 	return cmd

--- a/gincmd/keyscmd.go
+++ b/gincmd/keyscmd.go
@@ -99,12 +99,12 @@ func KeysCmd() *cobra.Command {
 		"Add a public key to your account, as generated from the default ssh-keygen command": "$ gin keys --add ~/.ssh/id_rsa.pub",
 	}
 	var cmd = &cobra.Command{
-		Use:     "keys [--add <filename> | --delete <keynum> | --verbose | -v]",
-		Short:   "List, add, or delete public keys on the GIN services",
-		Long:    formatdesc(description, nil),
-		Example: formatexamples(examples),
-		Args:    cobra.MaximumNArgs(1),
-		Run:     keys,
+		Use:                   "keys [--add <filename> | --delete <keynum> | --verbose | -v]",
+		Short:                 "List, add, or delete public keys on the GIN services",
+		Long:                  formatdesc(description, nil),
+		Example:               formatexamples(examples),
+		Args:                  cobra.MaximumNArgs(1),
+		Run:                   keys,
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().String("add", "", "Specify a `filename` which contains a public key to be added to the GIN server.")

--- a/gincmd/lockcmd.go
+++ b/gincmd/lockcmd.go
@@ -42,11 +42,11 @@ func LockCmd() *cobra.Command {
 		"<filenames>": "One or more directories or files to lock.",
 	}
 	var cmd = &cobra.Command{
-		Use:   "lock [--json] [<filenames>]...",
-		Short: "Lock files",
-		Long:  formatdesc(description, args),
-		Args:  cobra.ArbitraryArgs,
-		Run:   lock,
+		Use:                   "lock [--json] [<filenames>]...",
+		Short:                 "Lock files",
+		Long:                  formatdesc(description, args),
+		Args:                  cobra.ArbitraryArgs,
+		Run:                   lock,
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")

--- a/gincmd/logincmd.go
+++ b/gincmd/logincmd.go
@@ -67,11 +67,11 @@ func login(cmd *cobra.Command, args []string) {
 func LoginCmd() *cobra.Command {
 	description := "Login to the GIN services.\n\nIf no username is specified on the command line, you will be prompted for it. The login command always prompts for a password."
 	var cmd = &cobra.Command{
-		Use:   "login [<username>]",
-		Short: "Login to the GIN services",
-		Long:  formatdesc(description, nil),
-		Args:  cobra.MaximumNArgs(1),
-		Run:   login,
+		Use:                   "login [<username>]",
+		Short:                 "Login to the GIN services",
+		Long:                  formatdesc(description, nil),
+		Args:                  cobra.MaximumNArgs(1),
+		Run:                   login,
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().String("server", "", "Specify server `alias` to log into. See also 'gin servers'.")

--- a/gincmd/logoutcmd.go
+++ b/gincmd/logoutcmd.go
@@ -32,11 +32,11 @@ func logout(cmd *cobra.Command, args []string) {
 // LogoutCmd sets up the 'logout' subcommand
 func LogoutCmd() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "logout",
-		Short: "Logout of the GIN services",
-		Long:  "Logout of the GIN services.\n\nThis command takes no arguments.",
-		Args:  cobra.NoArgs,
-		Run:   logout,
+		Use:                   "logout",
+		Short:                 "Logout of the GIN services",
+		Long:                  "Logout of the GIN services.\n\nThis command takes no arguments.",
+		Args:                  cobra.NoArgs,
+		Run:                   logout,
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().String("server", "", "Specify server `alias` where the repository will be created. See also 'gin servers'.")

--- a/gincmd/lscmd.go
+++ b/gincmd/lscmd.go
@@ -92,11 +92,11 @@ RM: The file has been removed from the repository.
 	}
 
 	var cmd = &cobra.Command{
-		Use:   "ls [--json | --short | -s] [<filenames>]...",
-		Short: "List the sync status of files in the local repository",
-		Long:  formatdesc(description, args),
-		Args:  cobra.ArbitraryArgs,
-		Run:   lsRepo,
+		Use:                   "ls [--json | --short | -s] [<filenames>]...",
+		Short:                 "List the sync status of files in the local repository",
+		Long:                  formatdesc(description, args),
+		Args:                  cobra.ArbitraryArgs,
+		Run:                   lsRepo,
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print listing in JSON format (uses short form abbreviations).")

--- a/gincmd/lscmd.go
+++ b/gincmd/lscmd.go
@@ -97,6 +97,7 @@ RM: The file has been removed from the repository.
 		Long:                  formatdesc(description, args),
 		Args:                  cobra.ArbitraryArgs,
 		Run:                   lsRepo,
+		Aliases:               []string{"status"},
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print listing in JSON format (uses short form abbreviations).")

--- a/gincmd/remotescmd.go
+++ b/gincmd/remotescmd.go
@@ -33,11 +33,11 @@ func remotes(cmd *cobra.Command, args []string) {
 func RemotesCmd() *cobra.Command {
 	description := `List configured remotes and their information.`
 	var cmd = &cobra.Command{
-		Use:   "remotes",
-		Short: "List the repository's configured remotes",
-		Long:  formatdesc(description, nil),
-		Args:  cobra.NoArgs,
-		Run:   remotes,
+		Use:                   "remotes",
+		Short:                 "List the repository's configured remotes",
+		Long:                  formatdesc(description, nil),
+		Args:                  cobra.NoArgs,
+		Run:                   remotes,
 		DisableFlagsInUseLine: true,
 	}
 	return cmd

--- a/gincmd/repoinfocmd.go
+++ b/gincmd/repoinfocmd.go
@@ -57,11 +57,11 @@ func RepoInfoCmd() *cobra.Command {
 		"<repopath>": "The repository path must be specified on the command line. A repository path is the owner's username, followed by a \"/\" and the repository name.",
 	}
 	var cmd = &cobra.Command{
-		Use:   "repoinfo --json <repopath>",
-		Short: "Show the information for a specific repository",
-		Long:  formatdesc(description, args),
-		Args:  cobra.ExactArgs(1),
-		Run:   repoinfo,
+		Use:                   "repoinfo --json <repopath>",
+		Short:                 "Show the information for a specific repository",
+		Long:                  formatdesc(description, args),
+		Args:                  cobra.ExactArgs(1),
+		Run:                   repoinfo,
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print information in JSON format.")

--- a/gincmd/reposcmd.go
+++ b/gincmd/reposcmd.go
@@ -92,11 +92,11 @@ func ReposCmd() *cobra.Command {
 		"<username>": "The name of the user whose repositories should be listed. The list consists of public repositories and repositories shared with the logged in user.",
 	}
 	var cmd = &cobra.Command{
-		Use:   "repos [--shared | --all | <username>]",
-		Short: "List available remote repositories",
-		Long:  formatdesc(description, args),
-		Args:  cobra.MaximumNArgs(1),
-		Run:   repos,
+		Use:                   "repos [--shared | --all | <username>]",
+		Short:                 "List available remote repositories",
+		Long:                  formatdesc(description, args),
+		Args:                  cobra.MaximumNArgs(1),
+		Run:                   repos,
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("all", false, "List all repositories accessible to the logged in user.")

--- a/gincmd/serverscmd.go
+++ b/gincmd/serverscmd.go
@@ -29,11 +29,11 @@ func servers(cmd *cobra.Command, args []string) {
 func ServersCmd() *cobra.Command {
 	description := `List globally configured servers and their information.`
 	var cmd = &cobra.Command{
-		Use:   "servers",
-		Short: "List the globally configured servers",
-		Long:  formatdesc(description, nil),
-		Args:  cobra.NoArgs,
-		Run:   servers,
+		Use:                   "servers",
+		Short:                 "List the globally configured servers",
+		Long:                  formatdesc(description, nil),
+		Args:                  cobra.NoArgs,
+		Run:                   servers,
 		DisableFlagsInUseLine: true,
 	}
 	return cmd

--- a/gincmd/unlockcmd.go
+++ b/gincmd/unlockcmd.go
@@ -44,11 +44,11 @@ func UnlockCmd() *cobra.Command {
 		"<filenames>": "One or more directories or files to unllock.",
 	}
 	var cmd = &cobra.Command{
-		Use:   "unlock [--json] [<filenames>]...",
-		Short: "Unlock files for editing",
-		Long:  formatdesc(description, args),
-		Args:  cobra.ArbitraryArgs,
-		Run:   unlock,
+		Use:                   "unlock [--json] [<filenames>]...",
+		Short:                 "Unlock files for editing",
+		Long:                  formatdesc(description, args),
+		Args:                  cobra.ArbitraryArgs,
+		Run:                   unlock,
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -24,7 +24,7 @@ func upload(cmd *cobra.Command, args []string) {
 
 	// If any of the specified remotes is the special name 'all', upload to all configured remotes
 	for _, remote := range remotes {
-		if remote == "all" {
+		if remote == allremotes {
 			confremotes, err := git.RemoteShow()
 			CheckErrorMsg(err, fmt.Sprintf("'all' remotes specified, but could not determine configured remotes: %s", err))
 			remotes = make([]string, 0, len(confremotes))
@@ -61,12 +61,12 @@ If no arguments are specified, only changes to files already being tracked are u
 		"Upload all '.zip' files to remotes named 'gin' and 'labdata'":      "$ gin upload --to gin --to labdata *.zip\n    or\n$ gin upload --to gin,labdata *.zip",
 	}
 	var cmd = &cobra.Command{
-		Use:     "upload [--json] [--to <remote>] [<filenames>]...",
-		Short:   "Upload local changes to a remote repository",
-		Long:    formatdesc(description, args),
-		Args:    cobra.ArbitraryArgs,
-		Example: formatexamples(examples),
-		Run:     upload,
+		Use:                   "upload [--json] [--to <remote>] [<filenames>]...",
+		Short:                 "Upload local changes to a remote repository",
+		Long:                  formatdesc(description, args),
+		Args:                  cobra.ArbitraryArgs,
+		Example:               formatexamples(examples),
+		Run:                   upload,
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")

--- a/gincmd/useremotecmd.go
+++ b/gincmd/useremotecmd.go
@@ -32,11 +32,11 @@ With no arguments, this command simply prints the currently configured default r
 		"<name>": "The name of the remote to use by default",
 	}
 	var cmd = &cobra.Command{
-		Use:   "use-remote [<name>]",
-		Short: "Set the repository's default upload remote",
-		Long:  formatdesc(description, args),
-		Args:  cobra.MaximumNArgs(1),
-		Run:   useRemote,
+		Use:                   "use-remote [<name>]",
+		Short:                 "Set the repository's default upload remote",
+		Long:                  formatdesc(description, args),
+		Args:                  cobra.MaximumNArgs(1),
+		Run:                   useRemote,
 		DisableFlagsInUseLine: true,
 	}
 	return cmd

--- a/gincmd/useservercmd.go
+++ b/gincmd/useservercmd.go
@@ -31,11 +31,11 @@ With no arguments, this command simply prints the currently configured default s
 		"<name>": "The name of the server to use by default",
 	}
 	var cmd = &cobra.Command{
-		Use:   "use-server [<name>]",
-		Short: "Set the default server for the client",
-		Long:  formatdesc(description, args),
-		Args:  cobra.MaximumNArgs(1),
-		Run:   useServer,
+		Use:                   "use-server [<name>]",
+		Short:                 "Set the default server for the client",
+		Long:                  formatdesc(description, args),
+		Args:                  cobra.MaximumNArgs(1),
+		Run:                   useServer,
 		DisableFlagsInUseLine: true,
 	}
 	return cmd

--- a/gincmd/versioncmd.go
+++ b/gincmd/versioncmd.go
@@ -138,12 +138,12 @@ func VersionCmd() *cobra.Command {
 		"Show the 15 most recent versions of data.zip, prompt for version, and copy the selected version to the current directory": "$ gin version -n 15 --copy-to . data.zip",
 	}
 	var cmd = &cobra.Command{
-		Use:     "version [--json] [--max-count n | --id hash | --copy-to location] [<filenames>]...",
-		Short:   "Roll back files or directories to older versions",
-		Long:    formatdesc(description, args),
-		Example: formatexamples(examples),
-		Args:    cobra.ArbitraryArgs,
-		Run:     repoversion,
+		Use:                   "version [--json] [--max-count n | --id hash | --copy-to location] [<filenames>]...",
+		Short:                 "Roll back files or directories to older versions",
+		Long:                  formatdesc(description, args),
+		Example:               formatexamples(examples),
+		Args:                  cobra.ArbitraryArgs,
+		Run:                   repoversion,
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")

--- a/git/annex.go
+++ b/git/annex.go
@@ -228,9 +228,8 @@ func parseFilesOverwrite(errmsg string) []string {
 // (git annex sync --no-pull; git annex copy --to=<defaultremote>)
 func AnnexPush(paths []string, remote string, pushchan chan<- RepoFileStatus) {
 	defer close(pushchan)
-	cmd := AnnexCommand("sync", "--no-pull", "--no-commit") // NEVER commit changes when doing annex-sync
+	cmd := AnnexCommand("sync", "--no-pull", "--no-commit", remote) // NEVER commit changes when doing annex-sync
 	stdout, stderr, err := cmd.OutputError()
-	// TODO: Parse git push output for progress
 	if err != nil {
 		log.Write("Error during AnnexPush (sync --no-pull)")
 		log.Write("[Error]: %v", err)


### PR DESCRIPTION
## Primary change

This PR changes the behaviour of `gin upload` to only push to the default or specified remotes.

Previously, when performing a `gin upload --to=<remote>` with multiple remotes configured, the client would would `git push` to all remotes (via `git-annex sync`) and then only transfer the annexed content to the specified remote. The same occurred with a simple `gin upload`, where the default remote is implied as a desired destination.

This was not a  bug. The idea here was that pushing the annex metadata everywhere was a nice, low cost way to keep every remote up to date with the state of the repository without requiring uploads of the content to each remote. This raises two issues, however:
1. If there is a configured remote that is read-only, then doing a `gin upload` will produce an error while it tries to push to the RO remote. This can be circumvented and managed, but it would either annoy the user with warnings, or fail silently, neither of which I like.
2. If a user is not annexing data, then all data gets pushed everywhere. This is particularly bad if a user has a public and a private remote and they want to keep the public one outdated until some date when they upload everything to the public remote.

## Secondary change

I've disabled the dry-run that occurs before certain operations because it doubled the hashing time. When adding files to either git or annex (either via commit, lock, or upload), the client would do a dry-run of the operation to check how many file operations were actually necessary and so it would be able to give the user a progress bar of the entire operation. The dry-run however requires as long to run as the actual operation, so we were doubling the processing time for the mere benefit of giving the user feedback. Also, during the (potentially long) dry-run, the user would get no feedback.

I don't know how if I'm going to bring progress bars back, but if I am, I'll have to find a quick way to predict how many operations are going to occur before actually doing any processing.