### PR TITLE
Bugfix: Do not try to annex-copy deleted files

### DIFF
--- a/ginclient/repos.go
+++ b/ginclient/repos.go
@@ -285,14 +285,28 @@ func (gincl *Client) Upload(paths []string, remotes []string, uploadchan chan<- 
 			continue
 		}
 
+		// start routine to check which files are annexed
+		wichan := make(chan git.AnnexWhereisRes)
+		go git.AnnexWhereis(paths, wichan)
+
 		gitpushchan := make(chan git.RepoFileStatus)
 		go git.Push(remote, gitpushchan)
 		for stat := range gitpushchan {
 			uploadchan <- stat
 		}
 
+		// collect annex paths for annex copy command
+		annexpaths := make([]string, 0, len(paths))
+		for info := range wichan {
+			annexpaths = append(annexpaths, info.File)
+		}
+
+		if len(annexpaths) == 0 {
+			continue
+		}
+
 		annexpushchan := make(chan git.RepoFileStatus)
-		go git.AnnexPush(paths, remote, annexpushchan)
+		go git.AnnexPush(annexpaths, remote, annexpushchan)
 		for stat := range annexpushchan {
 			uploadchan <- stat
 		}

--- a/git/annex.go
+++ b/git/annex.go
@@ -247,6 +247,20 @@ func AnnexPush(paths []string, remote string, pushchan chan<- RepoFileStatus) {
 		return
 	}
 
+	// check which files are annexed
+	wichan := make(chan AnnexWhereisRes)
+	go AnnexWhereis(paths, wichan)
+
+	// collect annex paths for annex copy command
+	annexpaths := make([]string, 0, len(paths))
+	for info := range wichan {
+		annexpaths = append(annexpaths, info.File)
+	}
+
+	if len(annexpaths) == 0 {
+		return
+	}
+
 	args := []string{"copy", "--json-progress", fmt.Sprintf("--to=%s", remote)}
 	if len(paths) == 0 {
 		paths = []string{"--all"}


### PR DESCRIPTION
When a file was deleted and a user wanted to upload that deletion by issuing a `gin upload deletedfile`, the commit and git push would succeed, but then the path `deletedfile` would be passed on to `git annex copy` which would fail with an error that the file doesn't exist.

The upload handling now runs a `git annex whereis` on all provided paths, collects only the files known to git annex, and passes only those on to the `git annex copy` command. There's also the added benefit that even outside of deletions, git files are also never sent to the copy command.