### PR TITLE
Disable 'quotepath' in local git configuration

### DIFF
--- a/ginclient/repos.go
+++ b/ginclient/repos.go
@@ -593,7 +593,7 @@ func (gincl *Client) InitDir(bare bool) error {
 	if runtime.GOOS == "windows" {
 		// force disable symlinks even if user can create them
 		// see https://git-annex.branchable.com/bugs/Symlink_support_on_Windows_10_Creators_Update_with_Developer_Mode/
-		git.Command("config", "--local", "core.symlinks", "false").Run()
+		git.ConfigSet("core.symlinks", "false")
 	}
 
 	err = git.AnnexInit(description)

--- a/ginclient/repos.go
+++ b/ginclient/repos.go
@@ -589,6 +589,9 @@ func (gincl *Client) InitDir(bare bool) error {
 			log.Write("Failed to set local git user configuration")
 		}
 	}
+	// Disable quotepath: when enabled prints escape sequences for files with
+	// unicode characters making it hard to work with, can break JSON
+	// formatting, and sometimes impossible to reference specific files.
 	git.ConfigSet("core.quotepath", "false")
 	if runtime.GOOS == "windows" {
 		// force disable symlinks even if user can create them

--- a/ginclient/repos.go
+++ b/ginclient/repos.go
@@ -554,7 +554,7 @@ func CheckoutFileCopies(commithash string, paths []string, outpath string, suffi
 	}
 }
 
-// InitDir initialises the local directory with the default remote and annex configuration.
+// InitDir initialises the local directory with the default remote and git (and annex) configuration options.
 // Optionally initialised as a bare repository (for annex directory remotes).
 // The status channel 'initchan' is closed when this function returns.
 func (gincl *Client) InitDir(bare bool) error {
@@ -589,6 +589,7 @@ func (gincl *Client) InitDir(bare bool) error {
 			log.Write("Failed to set local git user configuration")
 		}
 	}
+	git.ConfigSet("core.quotepath", "false")
 	if runtime.GOOS == "windows" {
 		// force disable symlinks even if user can create them
 		// see https://git-annex.branchable.com/bugs/Symlink_support_on_Windows_10_Creators_Update_with_Developer_Mode/

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -212,6 +212,7 @@ func printProgressOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[
 				outappend(stat.Rate)
 			}
 		} else {
+			log.WriteError(stat.Err)
 			outappend(stat.Err.Error())
 			filesuccess[stat.FileName] = false
 		}


### PR DESCRIPTION
The git option `quotepath` (which is enabled by default) prints escape sequences for files with unicode characters making it hard to work with and sometimes impossible to reference specific files.

This PR sets `core.quotepath = false` in the local git repository's configuration during initialisation.