### PR TITLE
Force v5 repos

### DIFF
--- a/ginclient/repos.go
+++ b/ginclient/repos.go
@@ -573,10 +573,10 @@ func (gincl *Client) InitDir(bare bool) error {
 	}
 	description := fmt.Sprintf("%s@%s", gincl.Username, hostname)
 
-	// If there is no global git user.name or user.email set local ones
-	cmd := git.Command("config", "--global", "user.name")
+	// If there is no git user.name or user.email set local ones
+	cmd := git.Command("config", "user.name")
 	globalGitName, _ := cmd.Output()
-	cmd = git.Command("config", "--global", "user.email")
+	cmd = git.Command("config", "user.email")
 	globalGitEmail, _ := cmd.Output()
 	if len(globalGitName) == 0 && len(globalGitEmail) == 0 {
 		info, ierr := gincl.RequestAccount(gincl.Username)

--- a/git/annex.go
+++ b/git/annex.go
@@ -115,7 +115,7 @@ type AnnexInfoRes struct {
 // AnnexInit initialises the repository for annex.
 // (git annex init)
 func AnnexInit(description string) error {
-	args := []string{"init", description}
+	args := []string{"init", "--version=5", description}
 	cmd := AnnexCommand(args...)
 	stdout, stderr, err := cmd.OutputError()
 	if err != nil {

--- a/version
+++ b/version
@@ -1,1 +1,1 @@
-version=1.2
+version=1.3


### PR DESCRIPTION
Since git-annex version 7, the default mode is v7 repositories. This is
causing issues with commands that assume the repositories are v5. We
should eventually upgrade to v7, but for now forcing v5 repos preserves
the old behaviour and lets us use older annex versions as well.