### PR TITLE
[git] Use git-annex-sync to create empty init commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
-dist: trusty
-sudo: required
+dist: xenial
 
 services:
     - docker
@@ -15,9 +14,6 @@ matrix:
     - go: tip
   allow_failures:
     - go: tip
-
-before_install:
-  - sudo apt-get update
 
 install:
   # tools
@@ -51,14 +47,4 @@ script:
         ./tests/start-server;
         while ! curl localhost:3000 -so /dev/null; do sleep 1; done;
         ./tests/${testscript};
-    fi
-
-after_script:
-  # push logs to gist
-  - if [[ "${TRAVIS_GO_VERSION}" != "tip" ]]; then
-        echo $GISTTOKEN > ./tests/testuserhome/.gist;
-        mv ./tests/testuserhome/log/gin.log ./tests/testuserhome/log/gin-${TRAVIS_BRANCH}-${testscript}.log;
-        mv ./tests/testuserhome/log/tests.log ./tests/testuserhome/log/tests-${TRAVIS_BRANCH}-${testscript}.log;
-        ./tests/run-cont find ./log -type f -exec gist -u 59e3b1c2fc3ff525127f9b3af81e7f4c {} \+ ;
-        rm ./tests/testuserhome/.gist;
     fi

--- a/git/git.go
+++ b/git/git.go
@@ -78,7 +78,7 @@ func (s RepoFileStatus) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(struct {
 		RFSAlias
-		Err string
+		Err string `json:"err"`
 	}{
 		RFSAlias: RFSAlias(s),
 		Err:      errmsg,

--- a/git/git.go
+++ b/git/git.go
@@ -516,9 +516,17 @@ func Commit(commitmsg string) error {
 
 // CommitEmpty performs a commit even when there are no new changes added to the index.
 // This is useful for initialising new repositories with a usable HEAD.
-// (git commit --allow-empty)
+// In indirect mode (non-bare repositories) simply uses git commit with the '--allow-empty' flag.
+// In direct mode it uses git-annex sync.
+// (git commit --allow-empty or git annex sync --commit)
 func CommitEmpty(commitmsg string) error {
-	cmd := Command("commit", "--allow-empty", fmt.Sprintf("--message=%s", commitmsg))
+	msgarg := fmt.Sprintf("--message=%s", commitmsg)
+	var cmd shell.Cmd
+	if !IsDirect() {
+		cmd = Command("commit", "--allow-empty", msgarg)
+	} else {
+		cmd = AnnexCommand("sync", "--commit", msgarg)
+	}
 	stdout, stderr, err := cmd.OutputError()
 	if err != nil {
 		log.Write("Error during CommitEmpty")

--- a/version
+++ b/version
@@ -1,1 +1,1 @@
-version=1.4
+version=1.5dev


### PR DESCRIPTION
In direct mode (on Windows) the initial commit would fail since it was
trying to do 'git commit' inside a bare repository. Use 'git-annex sync'
instead to create the initial empty commit. This works in both direct
and indirect mode repositories.

Fixes #224.