### PR TITLE
Don't prompt for login with --json

### DIFF
--- a/gincmd/repoinfocmd.go
+++ b/gincmd/repoinfocmd.go
@@ -37,7 +37,7 @@ func repoinfo(cmd *cobra.Command, args []string) {
 		srvalias = conf.DefaultServer
 	}
 	gincl := ginclient.New(srvalias)
-	requirelogin(cmd, gincl, true)
+	requirelogin(cmd, gincl, !jsonout)
 	repoinfo, err := gincl.GetRepo(args[0])
 	CheckError(err)
 

--- a/gincmd/reposcmd.go
+++ b/gincmd/reposcmd.go
@@ -32,7 +32,7 @@ func repos(cmd *cobra.Command, args []string) {
 	}
 
 	gincl := ginclient.New(srvalias)
-	requirelogin(cmd, gincl, true)
+	requirelogin(cmd, gincl, !jsonout)
 	username := gincl.Username
 	if len(args) == 1 && args[0] != username {
 		username = args[0]


### PR DESCRIPTION
'repos' and 'repoinfo' commands would still prompt for login when called
with --json flag.  Passing '!jsonout' to 'requirelogin()' like all the
other commands fixes this.

Fixes #234