### PR TITLE
Windows colors

### DIFF
--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -333,7 +333,7 @@ func disableCommands(cmds map[string]*cobra.Command, giterr, annexerr error) {
 	errmsg = fmt.Sprintf("%s\n%s", errmsg, dependencyInfo(giterr, annexerr))
 
 	for _, cname := range reqgitannex {
-		cmds[cname].Short = fmt.Sprintf("[%s] %s", red("not available"), cmds[cname].Short)
+		cmds[cname].Short = fmt.Sprintf("[not available] %s", cmds[cname].Short)
 		diemsg := fmt.Sprintf(errmsg, cname)
 		cmds[cname].Run = func(c *cobra.Command, args []string) {
 			Die(diemsg)
@@ -445,7 +445,7 @@ func SetUpCommands(verinfo VersionInfo) *cobra.Command {
 
 	if !(gitok && annexok) {
 		disableCommands(cmds, giterr, annexerr)
-		warnmsg := yellow("Some commands are not available:")
+		warnmsg := "Some commands are not available:"
 		helpTemplate = fmt.Sprintf("%s\n%s\n%s", helpTemplate, warnmsg, dependencyInfo(giterr, annexerr))
 	}
 

--- a/gincmd/initcmd.go
+++ b/gincmd/initcmd.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	ginclient "github.com/G-Node/gin-cli/ginclient"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -14,7 +15,7 @@ func initRepo(cmd *cobra.Command, args []string) {
 	CheckError(err)
 	_, err = ginclient.CommitIfNew()
 	CheckError(err)
-	fmt.Println(green("OK"))
+	fmt.Fprintln(color.Output, green("OK"))
 }
 
 // InitCmd sets up the 'init' repository subcommand

--- a/gincmd/versioncmd.go
+++ b/gincmd/versioncmd.go
@@ -8,6 +8,7 @@ import (
 
 	ginclient "github.com/G-Node/gin-cli/ginclient"
 	"github.com/G-Node/gin-cli/git"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -91,7 +92,7 @@ func verprompt(commits []git.GinCommit) git.GinCommit {
 	width := termwidth()
 	for idx, commit := range commits {
 		idxstr := fmt.Sprintf(numfmt, idx+1)
-		fmt.Printf("%s  %s * %s\n\n", idxstr, green(commit.AbbreviatedHash), commit.Date.Format("Mon Jan 2 15:04:05 2006 (-0700)"))
+		fmt.Fprintf(color.Output, "%s  %s * %s\n\n", idxstr, green(commit.AbbreviatedHash), commit.Date.Format("Mon Jan 2 15:04:05 2006 (-0700)"))
 		fmt.Printf("%s\n", winner.Wrap(commit.Subject, width))
 		if len(commit.Body) > 0 {
 			fmt.Printf("%s\n", winner.Wrap(commit.Body, width))


### PR DESCRIPTION
- Fixed coloured output in version and init commands.  Was not properly using the colour.Output writer.
- Disabled colour output from help, since we can't control the output writer when the help text is printed.