### PR TITLE
Add verbose flag to some of the cmds

### DIFF
--- a/ginclient/repos.go
+++ b/ginclient/repos.go
@@ -15,7 +15,7 @@ import (
 	"github.com/G-Node/gin-cli/ginclient/log"
 	"github.com/G-Node/gin-cli/git"
 	"github.com/G-Node/gin-cli/web"
-	"github.com/gogits/go-gogs-client"
+	gogs "github.com/gogits/go-gogs-client"
 )
 
 // High level functions for managing repositories.

--- a/gincmd/commitcmd.go
+++ b/gincmd/commitcmd.go
@@ -27,6 +27,9 @@ func commit(cmd *cobra.Command, args []string) {
 	if !jsonout && !verbose {
 		fmt.Print(":: Recording changes ")
 	}
+	if verbose {
+		fmt.Printf("Running Gin Command: %v \n", cmd.Name())
+	}
 	err := git.Commit(makeCommitMessage("commit", paths))
 	var stat string
 	if err != nil {

--- a/gincmd/commitcmd.go
+++ b/gincmd/commitcmd.go
@@ -75,6 +75,6 @@ func CommitCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")
-	cmd.Flags().Bool("verbose", false, "Print all raw information.")
+	cmd.Flags().Bool("verbose", false, "Print raw information from git and git-annex commands directly.")
 	return cmd
 }

--- a/gincmd/commitcmd.go
+++ b/gincmd/commitcmd.go
@@ -15,6 +15,7 @@ import (
 func commit(cmd *cobra.Command, args []string) {
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	jsonout, _ := cmd.Flags().GetBool("json")
+	checkVerboseJson(verbose, jsonout)
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
 	}

--- a/gincmd/commitcmd.go
+++ b/gincmd/commitcmd.go
@@ -13,6 +13,7 @@ import (
 )
 
 func commit(cmd *cobra.Command, args []string) {
+	verbose, _ := cmd.Flags().GetBool("verbose")
 	jsonout, _ := cmd.Flags().GetBool("json")
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
@@ -21,7 +22,7 @@ func commit(cmd *cobra.Command, args []string) {
 	paths := args
 	addchan := make(chan git.RepoFileStatus)
 	go ginclient.Add(paths, addchan)
-	formatOutput(addchan, 0, jsonout)
+	formatOutput(addchan, 0, jsonout, verbose)
 
 	if !jsonout {
 		fmt.Print(":: Recording changes ")
@@ -63,7 +64,7 @@ func CommitCmd() *cobra.Command {
 	description := "Record changes made in a local repository. This command must be called from within the local repository clone. Specific files or directories may be specified. All changes made to the files and directories that are specified will be recorded, including addition of new files, modifications and renaming of existing files, and file deletions.\n\nIf no arguments are specified, no changes are recorded."
 	args := map[string]string{"<filenames>": "One or more directories or files to commit."}
 	var cmd = &cobra.Command{
-		Use:                   "commit [<filenames>]...",
+		Use:                   "commit [--json | --verbose] [<filenames>]...",
 		Short:                 "Record changes in local repository",
 		Long:                  formatdesc(description, args),
 		Args:                  cobra.ArbitraryArgs,
@@ -71,5 +72,6 @@ func CommitCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")
+	cmd.Flags().Bool("verbose", false, "Print all raw information.")
 	return cmd
 }

--- a/gincmd/commitcmd.go
+++ b/gincmd/commitcmd.go
@@ -24,7 +24,7 @@ func commit(cmd *cobra.Command, args []string) {
 	go ginclient.Add(paths, addchan)
 	formatOutput(addchan, 0, jsonout, verbose)
 
-	if !jsonout {
+	if !jsonout && !verbose {
 		fmt.Print(":: Recording changes ")
 	}
 	err := git.Commit(makeCommitMessage("commit", paths))
@@ -38,7 +38,7 @@ func commit(cmd *cobra.Command, args []string) {
 	} else {
 		stat = green("OK")
 	}
-	if !jsonout {
+	if !jsonout && !verbose {
 		fmt.Fprintln(color.Output, stat)
 	}
 }

--- a/gincmd/commitcmd.go
+++ b/gincmd/commitcmd.go
@@ -28,9 +28,6 @@ func commit(cmd *cobra.Command, args []string) {
 	if !jsonout && !verbose {
 		fmt.Print(":: Recording changes ")
 	}
-	if verbose {
-		fmt.Printf("Running Gin Command: %v \n", cmd.Name())
-	}
 	err := git.Commit(makeCommitMessage("commit", paths))
 	var stat string
 	if err != nil {

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -232,66 +232,41 @@ func printProgressOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[
 
 func verboseOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[string]bool) {
 	filesuccess = make(map[string]bool)
-	var fname, state string
-	var lastprint string
-	var tmprawin, tmprawout string
+	var state string
+	var tmprawin, tmpfname string
 	for stat := range statuschan {
 		//Raw Input
 		if stat.RawInput != tmprawin {
-			fmt.Printf("InputCommand: %v\n Output: \n", stat.RawInput)
+			fmt.Printf("InputCommand: %v\nOutput: \n", stat.RawInput)
 			tmprawin = stat.RawInput
-		} else {
-			fmt.Println()
+		}
+		if stat.FileName != tmpfname {
+			fmt.Printf("Currently dealing with: %s", stat.FileName)
+			tmpfname = stat.FileName
 		}
 
-		lastprint = ""
-		fname = stat.FileName
+		fmt.Printf("%v\r", stat.RawOutput)
+		// fname := stat.FileName
 		state = stat.State
 		//	rate := stat.Rate
-		rate := stat.Rate
+		//rate := stat.Rate
 		//progress := stat.Progress
-		rawin := stat.RawInput
-		fmt.Printf("%v\n", stat.RawOutput)
 
-		// Raw Output
-		if strings.Contains(tmprawout, ":") {
-			gss := strings.Split(tmprawout, ":")
-			gs := gss[0]
-			if strings.Contains(rawout, gs) {
-				blank := fmt.Sprintf("\r%s\r", strings.Repeat(" ", len(tmprawout)))
-				rawout = fmt.Sprintf("StdOutput: %v%v\n", rawout, blank)
-			}
-		} else {
-			rawout = fmt.Sprintf("StdOutput: %v\n", rawout)
-		}
-
-		tmprawout = strings.Replace(rawout, "StdOutput: ", "", -1)
-		outappend(stat.FileName)
 		if stat.Err == nil {
 			if stat.Progress == "100%" {
 				pro := green("OK")
-				prostr := fmt.Sprintf("%v %v %v %v\r", rawin, rawout, state, pro)
-				outappend(prostr)
+				fmt.Printf("%v %v\r", state, pro)
 				filesuccess[stat.FileName] = true
 			} else {
 				pro := stat.Progress
-				prostr := fmt.Sprintf("%v %v %v %v\r", rawin, rawout, state, pro)
-				outappend(prostr)
+				fmt.Printf("%v %v\r", state, pro)
 			}
 		} else {
-			outappend(stat.Err.Error())
+			fmt.Printf("%v\n", stat.Err.Error())
 			filesuccess[stat.FileName] = false
+			continue
 		}
-		newprint := outline.String()
-		if newprint != lastprint {
-			fmt.Printf("\r%s\r", strings.Repeat(" ", len(lastprint))) // clear the line
-			fmt.Fprint(color.Output, newprint)
-			fmt.Print("\r")
-			lastprint = newprint
-		}
-	}
-	if len(lastprint) > 0 {
-		fmt.Println()
+		// fmt.Printf("The uploading process is at rate: %v", rate)
 	}
 	return
 }

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -230,16 +230,33 @@ func printProgressOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[
 	return
 }
 
-func verboseOutput(statuschan <-chan git.RepoFileStatus, cmdc string, cmd_spec_var []string) {
+func verboseOutput(statuschan <-chan git.RepoFileStatus, cmdc string, cmd_spec_var []string, files []string) {
 
-	switch c := cmdc; {
-	case c == "upload":
+	fmt.Printf("File name | Size | \n")
+	for _, file := range files {
+		fi, _ := os.Stat(file)
+		fmt.Printf("%v  %v \n", file, fi.Size())
+	}
+
+	// for command specific output
+	switch c := cmdc; c {
+	case "upload":
 		for _, url := range cmd_spec_var {
 			fmt.Printf("Currently uploading to  %v", url)
 			fmt.Println()
 		}
-	case c == "commit":
-
+	case "add":
+		fmt.Printf("add file: <%v>", nil) // add
+		fmt.Println()
+	case "download":
+		for _, url := range cmd_spec_var {
+			fmt.Printf("Currently downloading from  %v", url)
+			fmt.Println()
+		}
+	case "commit":
+		// do something like git diff, show detailed difference (maybe size) of changed files
+	case "ls":
+		// print also time file-size last-commit last-author  os.Stat
 	}
 }
 

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -232,18 +232,11 @@ func printProgressOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[
 
 func verboseOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[string]bool) {
 	filesuccess = make(map[string]bool)
-	// var rostr, rsstr string
-	// var listStr []string
-	// var state, lastState string
 	var ro string
-	// var lp bool
-	// var lastprint bool // 1 for rawoutput 0 for state
 	var tmprawin, tmpfname string
 
 	for stat := range statuschan {
-		// listStr = nil
 		if stat.FileName != tmpfname {
-			// fmt.Printf("Current File: %s\n", stat.FileName)
 			tmpfname = stat.FileName
 		}
 
@@ -252,46 +245,8 @@ func verboseOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[string
 			fmt.Printf("Running Command: %v\n", stat.RawInput)
 			tmprawin = stat.RawInput
 		}
-
 		ro = stat.RawOutput
-		// rostr = fmt.Sprintf("%v", ro)
-		// listStr = append(listStr, rostr)
 		fmt.Printf("%s", ro)
-		// if strings.Contains(ro, "done") {
-		//
-		// 	continue
-		// }
-
-		// state = stat.State
-		//
-		// if stat.Err == nil {
-		// 	if stat.Progress == "100%" && state != lastState {
-		// 		pro := green("OK")
-		// 		rsstr = fmt.Sprintf("%v:%v", state, pro)
-		// 		listStr = append(listStr, rsstr)
-		// 		filesuccess[stat.FileName] = true
-		// 		lastState = state
-		// 		lp = true
-		// 	} else if state != lastState {
-		// 		pro := stat.Progress
-		// 		rsstr = fmt.Sprintf("%v:%v", state, pro)
-		// 		listStr = append(listStr, rsstr)
-		// 	}
-		// } else {
-		// 	fmt.Printf("%v\n", stat.Err.Error())
-		// 	filesuccess[stat.FileName] = false
-		// 	continue
-		// }
-		//
-		// if len(listStr) == 2 {
-		// 	fmt.Printf("%6s|%6s\r", listStr[1], listStr[0])
-		// } else {
-		// 	fmt.Printf("%6s\r", listStr[0])
-		// }
-		// if lp {
-		// 	fmt.Println()
-		// 	lp = false
-		// }
 	}
 	fmt.Println()
 	return

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -264,20 +264,13 @@ func verboseOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[string
 			fmt.Printf("Running Command: %v\n", stat.RawInput)
 			tmprawin = stat.RawInput
 		}
-		if strings.Contains(stat.RawInput, "json") {
-			outline := []byte(stat.RawOutput)
-			if json.Valid(outline) {
-				var output Jsonout
-				_ = json.Unmarshal(outline, &output)
-				if output.Success {
-
-				} else {
-					fmt.Printf("%s %s %s Progress:%d/%d(%s) FileKey:%s\r", output.Action.Command, output.Action.File, output.Action.Note,
-						output.ByteProgress, output.TotalSize, output.PercentProgress, output.Action.Key)
-				}
-			} else {
-				ro = stat.RawOutput
-				fmt.Printf("%s", ro)
+		outline := []byte(stat.RawOutput)
+		if json.Valid(outline) {
+			var output Jsonout
+			_ = json.Unmarshal(outline, &output)
+			if !output.Success {
+				fmt.Printf("%s %s %s Progress:%d/%d(%s) FileKey:%s\r", output.Action.Command, output.Action.File, output.Action.Note,
+					output.ByteProgress, output.TotalSize, output.PercentProgress, output.Action.Key)
 			}
 		} else {
 			ro = stat.RawOutput

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -234,7 +234,12 @@ func verboseOutput(statuschan <-chan git.RepoFileStatus, cmdc string, cmd_spec_v
 
 	switch c := cmdc; {
 	case c == "upload":
-		fmt.Printf("Currently uploading to  %v", cmd_spec_var)
+		for _, url := range cmd_spec_var {
+			fmt.Printf("Currently uploading to  %v", url)
+			fmt.Println()
+		}
+	case c == "commit":
+
 	}
 }
 

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -232,65 +232,66 @@ func printProgressOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[
 
 func verboseOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[string]bool) {
 	filesuccess = make(map[string]bool)
-	var rostr, rsstr string
-	var listStr []string
-	var state, lastState string
+	// var rostr, rsstr string
+	// var listStr []string
+	// var state, lastState string
 	var ro string
-	var lp bool
+	// var lp bool
 	// var lastprint bool // 1 for rawoutput 0 for state
 	var tmprawin, tmpfname string
 
 	for stat := range statuschan {
-		listStr = nil
+		// listStr = nil
 		if stat.FileName != tmpfname {
-			fmt.Printf("\nCurrent File: %s\n", stat.FileName)
+			// fmt.Printf("Current File: %s\n", stat.FileName)
 			tmpfname = stat.FileName
 		}
 
 		//Raw Input
 		if stat.RawInput != tmprawin {
-			fmt.Printf("InputCommand: %v\nOutput: \n", stat.RawInput)
+			fmt.Printf("Running Command: %v\n", stat.RawInput)
 			tmprawin = stat.RawInput
 		}
 
 		ro = stat.RawOutput
-		rostr = fmt.Sprintf("%v", ro)
-		listStr = append(listStr, rostr)
-		if strings.Contains(ro, "done") {
-			fmt.Printf("%s\n", ro)
-			continue
-		}
+		// rostr = fmt.Sprintf("%v", ro)
+		// listStr = append(listStr, rostr)
+		fmt.Printf("%s", ro)
+		// if strings.Contains(ro, "done") {
+		//
+		// 	continue
+		// }
 
-		state = stat.State
-
-		if stat.Err == nil {
-			if stat.Progress == "100%" && state != lastState {
-				pro := green("OK")
-				rsstr = fmt.Sprintf("%v:%v", state, pro)
-				listStr = append(listStr, rsstr)
-				filesuccess[stat.FileName] = true
-				lastState = state
-				lp = true
-			} else if state != lastState {
-				pro := stat.Progress
-				rsstr = fmt.Sprintf("%v:%v", state, pro)
-				listStr = append(listStr, rsstr)
-			}
-		} else {
-			fmt.Printf("%v\n", stat.Err.Error())
-			filesuccess[stat.FileName] = false
-			continue
-		}
-
-		if len(listStr) == 2 {
-			fmt.Printf("%6s|%6s\r", listStr[1], listStr[0])
-		} else {
-			fmt.Printf("%6s\r", listStr[0])
-		}
-		if lp {
-			fmt.Println()
-			lp = false
-		}
+		// state = stat.State
+		//
+		// if stat.Err == nil {
+		// 	if stat.Progress == "100%" && state != lastState {
+		// 		pro := green("OK")
+		// 		rsstr = fmt.Sprintf("%v:%v", state, pro)
+		// 		listStr = append(listStr, rsstr)
+		// 		filesuccess[stat.FileName] = true
+		// 		lastState = state
+		// 		lp = true
+		// 	} else if state != lastState {
+		// 		pro := stat.Progress
+		// 		rsstr = fmt.Sprintf("%v:%v", state, pro)
+		// 		listStr = append(listStr, rsstr)
+		// 	}
+		// } else {
+		// 	fmt.Printf("%v\n", stat.Err.Error())
+		// 	filesuccess[stat.FileName] = false
+		// 	continue
+		// }
+		//
+		// if len(listStr) == 2 {
+		// 	fmt.Printf("%6s|%6s\r", listStr[1], listStr[0])
+		// } else {
+		// 	fmt.Printf("%6s\r", listStr[0])
+		// }
+		// if lp {
+		// 	fmt.Println()
+		// 	lp = false
+		// }
 	}
 	fmt.Println()
 	return

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -230,6 +230,12 @@ func printProgressOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[
 	return
 }
 
+func checkVerboseJson(verbose bool, json bool) {
+	if verbose && json {
+		Die("Verbose flag and Json flag cannot be used together")
+	}
+}
+
 func verboseOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[string]bool) {
 	filesuccess = make(map[string]bool)
 	var ro string
@@ -264,7 +270,7 @@ func verboseOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[string
 				var output Jsonout
 				_ = json.Unmarshal(outline, &output)
 				if output.Success {
-					fmt.Printf("\n%s", green("Success"))
+
 				} else {
 					fmt.Printf("%s %s %s Progress:%d/%d(%s) FileKey:%s\r", output.Action.Command, output.Action.File, output.Action.Note,
 						output.ByteProgress, output.TotalSize, output.PercentProgress, output.Action.Key)
@@ -287,9 +293,6 @@ func formatOutput(statuschan <-chan git.RepoFileStatus, nitems int, jsonout bool
 	var filesuccess map[string]bool
 	if jsonout {
 		filesuccess = printJSON(statuschan)
-		if verbose {
-			fmt.Fprint(color.Output, "json and verbose cannot be used together")
-		}
 	} else if verbose {
 		filesuccess = verboseOutput(statuschan)
 	} else if nitems > 0 {

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -250,7 +250,7 @@ func verboseOutput(statuschan <-chan git.RepoFileStatus, cmdc string, cmd_spec_v
 		fmt.Println()
 	case "download":
 		for _, url := range cmd_spec_var {
-			fmt.Printf("Currently downloading from  %v", url)
+			fmt.Printf("Currently downloading from  %v \n", url)
 			fmt.Println()
 		}
 	case "commit":

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -256,7 +256,8 @@ func verboseOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[string
 		ro = stat.RawOutput
 		rostr = fmt.Sprintf("%v", ro)
 		listStr = append(listStr, rostr)
-		if strings.Contains(ro, "done") && strings.Contains(ro, "100%") {
+		if strings.Contains(ro, "done") {
+			fmt.Printf("%s\n", ro)
 			continue
 		}
 

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -232,62 +232,28 @@ func printProgressOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[
 
 func verboseOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[string]bool) {
 	filesuccess = make(map[string]bool)
-	// var fname, state, raw_in, raw_out string
-	var lastprint string
-	outline := new(bytes.Buffer)
-	outappend := func(part string) {
-		if len(part) > 0 {
-			outline.WriteString(part)
-			outline.WriteString(" ")
-		}
-	}
-
 	for stat := range statuschan {
-		outline.Reset()
-		outline.WriteString(" ")
-		//
-		// if stat.FileName != fname || stat.State != state || stat.RawInput != raw_in || stat.RawOutput != raw_out {
-		// 	// New line if new file or new state
-		// 	if len(lastprint) > 0 {
-		// 		fmt.Println()
-		// 	}
-		// 	lastprint = ""
-		// 	fname = stat.FileName
-		// 	state = stat.State
-		// 	raw_in = stat.RawInput
-		// 	raw_out = stat.RawOutput
-		// }
-		if len(lastprint) > 0 {
-			fmt.Println()
-		}
-		outappend(stat.FileName)
-		outappend(stat.State)
+		fname := stat.FileName
+		fmt.Printf("%v\n", fname)
+		rate := stat.Rate
+		state := stat.State
+		progress := stat.Progress
+		rawin := stat.RawInput
+		rawout := stat.RawOutput
+
+		fmt.Printf("%v at the rate of %v\n", state, rate)
+		fmt.Printf("%v %v\n", state, progress)
+		fmt.Printf("Command: %v\n", rawin)
+		fmt.Printf("%v\n", rawout)
 
 		if stat.Err == nil {
 			if stat.Progress == "100%" {
-				outappend(green("OK"))
+				fmt.Printf("%v %v \n", state, green("OK"))
 				filesuccess[stat.FileName] = true
-			} else {
-				outappend(stat.Progress)
-				outappend(stat.Rate)
-				outappend(stat.RawInput)
-				outappend(stat.RawOutput)
 			}
 		} else {
-			outappend(stat.Err.Error())
 			filesuccess[stat.FileName] = false
 		}
-		newprint := outline.String()
-		if newprint != lastprint {
-			fmt.Printf("\r%s\r", strings.Repeat(" ", len(lastprint))) // clear the line
-			fmt.Fprint(color.Output, newprint)
-			fmt.Print("\r")
-			fmt.Printf("The uploading process is at rate: %v", stat.Rate)
-			lastprint = newprint
-		}
-	}
-	if len(lastprint) > 0 {
-		fmt.Println()
 	}
 	//
 	// // for command specific output

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"runtime"
@@ -231,13 +230,12 @@ func printProgressOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[
 	return
 }
 
-func verboseOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[string]bool) {
-	filesuccess = make(map[string]bool)
-	// if git.Command {
-	path, _ := // some file which captures output in shell
-	file, _ := ioutil.ReadFile("path")
-	fmt.Sprintf("a %s", file)
-	return
+func verboseOutput(statuschan <-chan git.RepoFileStatus, cmdc string, cmd_spec_var []string) {
+
+	switch c := cmdc; {
+	case c == "upload":
+		fmt.Printf("Currently uploading to  %v", cmd_spec_var)
+	}
 }
 
 func formatOutput(statuschan <-chan git.RepoFileStatus, nitems int, jsonout bool) {

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"math"
 	"os"
 	"runtime"
@@ -227,6 +228,15 @@ func printProgressOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[
 	if len(lastprint) > 0 {
 		fmt.Println()
 	}
+	return
+}
+
+func verboseOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[string]bool) {
+	filesuccess = make(map[string]bool)
+	// if git.Command {
+	path, _ := // some file which captures output in shell
+	file, _ := ioutil.ReadFile("path")
+	fmt.Sprintf("a %s", file)
 	return
 }
 

--- a/gincmd/downloadcmd.go
+++ b/gincmd/downloadcmd.go
@@ -25,14 +25,17 @@ func download(cmd *cobra.Command, args []string) {
 
 	content, _ := cmd.Flags().GetBool("content")
 	lockchan := make(chan git.RepoFileStatus)
+	if verbose {
+		fmt.Printf("Running Gin Command: %v \n", cmd.Name())
+	}
 	go gincl.LockContent([]string{}, lockchan)
 	formatOutput(lockchan, 0, jsonout, verbose)
-	if !jsonout {
+	if !jsonout && !verbose {
 		fmt.Print("Downloading changes ")
 	}
 	err := gincl.Download()
 	CheckError(err)
-	if !jsonout {
+	if !jsonout && !verbose {
 		fmt.Fprintln(color.Output, green("OK"))
 	}
 	if content {

--- a/gincmd/downloadcmd.go
+++ b/gincmd/downloadcmd.go
@@ -14,6 +14,7 @@ import (
 
 func download(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
+	verbose, _ := cmd.Flags().GetBool("verbose")
 	// TODO: no client necessary? Just use remotes
 	conf := config.Read()
 	gincl := ginclient.New(conf.DefaultServer)
@@ -25,7 +26,7 @@ func download(cmd *cobra.Command, args []string) {
 	content, _ := cmd.Flags().GetBool("content")
 	lockchan := make(chan git.RepoFileStatus)
 	go gincl.LockContent([]string{}, lockchan)
-	formatOutput(lockchan, 0, jsonout)
+	formatOutput(lockchan, 0, jsonout, verbose)
 	if !jsonout {
 		fmt.Print("Downloading changes ")
 	}
@@ -45,7 +46,7 @@ func download(cmd *cobra.Command, args []string) {
 func DownloadCmd() *cobra.Command {
 	description := "Downloads changes from the remote repository to the local clone. This will create new files that were added remotely, delete files that were removed, and update files that were changed.\n\nOptionally downloads the content of all files in the repository. If 'content' is not specified, new files will be empty placeholders. Content of individual files can later be retrieved using the 'get-content' command."
 	var cmd = &cobra.Command{
-		Use:                   "download [--json] [--content]",
+		Use:                   "download [--json | --verbose] [--content]",
 		Short:                 "Download all new information from a remote repository",
 		Long:                  formatdesc(description, nil),
 		Args:                  cobra.NoArgs,
@@ -53,6 +54,7 @@ func DownloadCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")
+	cmd.Flags().Bool("verbose", false, "Print all raw information.")
 	cmd.Flags().Bool("content", false, "Download the content for all files in the repository.")
 	return cmd
 }

--- a/gincmd/downloadcmd.go
+++ b/gincmd/downloadcmd.go
@@ -26,9 +26,6 @@ func download(cmd *cobra.Command, args []string) {
 
 	content, _ := cmd.Flags().GetBool("content")
 	lockchan := make(chan git.RepoFileStatus)
-	if verbose {
-		fmt.Printf("Running Gin Command: %v \n", cmd.Name())
-	}
 	go gincl.LockContent([]string{}, lockchan)
 	formatOutput(lockchan, 0, jsonout, verbose)
 	if !jsonout && !verbose {

--- a/gincmd/downloadcmd.go
+++ b/gincmd/downloadcmd.go
@@ -15,6 +15,7 @@ import (
 func download(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
 	verbose, _ := cmd.Flags().GetBool("verbose")
+	checkVerboseJson(verbose, jsonout)
 	// TODO: no client necessary? Just use remotes
 	conf := config.Read()
 	gincl := ginclient.New(conf.DefaultServer)

--- a/gincmd/downloadcmd.go
+++ b/gincmd/downloadcmd.go
@@ -57,7 +57,7 @@ func DownloadCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")
-	cmd.Flags().Bool("verbose", false, "Print all raw information.")
+	cmd.Flags().Bool("verbose", false, "Print raw information from git and git-annex commands directly.")
 	cmd.Flags().Bool("content", false, "Download the content for all files in the repository.")
 	return cmd
 }

--- a/gincmd/getcmd.go
+++ b/gincmd/getcmd.go
@@ -70,7 +70,7 @@ func GetCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")
-	cmd.Flags().Bool("verbose", false, "Print all raw information.")
+	cmd.Flags().Bool("verbose", false, "Print raw information from git and git-annex commands directly.")
 	cmd.Flags().String("server", "", "Specify server `alias` for the repository. See also 'gin servers'.")
 	return cmd
 }

--- a/gincmd/getcmd.go
+++ b/gincmd/getcmd.go
@@ -33,9 +33,6 @@ func getRepo(cmd *cobra.Command, args []string) {
 	}
 
 	clonechan := make(chan git.RepoFileStatus)
-	if verbose {
-		fmt.Printf("Running Gin Command: %v \n", cmd.Name())
-	}
 	go gincl.CloneRepo(repostr, clonechan)
 	formatOutput(clonechan, 0, jsonout, verbose)
 	defaultRemoteIfUnset("origin")

--- a/gincmd/getcmd.go
+++ b/gincmd/getcmd.go
@@ -15,7 +15,8 @@ func isValidRepoPath(path string) bool {
 }
 
 func getRepo(cmd *cobra.Command, args []string) {
-	flags := cmd.Flags()
+	flags := cmd.Flags() //  change this to make it consistent with other cmd
+	verbose, _ := flags.GetBool("verbose")
 	jsonout, _ := flags.GetBool("json")
 	srvalias, _ := flags.GetString("server")
 	conf := config.Read()
@@ -32,7 +33,7 @@ func getRepo(cmd *cobra.Command, args []string) {
 
 	clonechan := make(chan git.RepoFileStatus)
 	go gincl.CloneRepo(repostr, clonechan)
-	formatOutput(clonechan, 0, jsonout)
+	formatOutput(clonechan, 0, jsonout, verbose)
 	defaultRemoteIfUnset("origin")
 	new, err := ginclient.CommitIfNew()
 	if new {
@@ -57,7 +58,7 @@ func GetCmd() *cobra.Command {
 		"Get and initialise the repository named 'eegdata' owned by user 'peter'": "$ gin get peter/eegdata",
 	}
 	var cmd = &cobra.Command{
-		Use:                   "get [--json] <repopath>",
+		Use:                   "get [--json | --verbose] <repopath>",
 		Short:                 "Retrieve (clone) a repository from the remote server",
 		Long:                  formatdesc(description, args),
 		Example:               formatexamples(examples),
@@ -66,6 +67,7 @@ func GetCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")
+	cmd.Flags().Bool("verbose", false, "Print all raw information.")
 	cmd.Flags().String("server", "", "Specify server `alias` for the repository. See also 'gin servers'.")
 	return cmd
 }

--- a/gincmd/getcmd.go
+++ b/gincmd/getcmd.go
@@ -32,6 +32,9 @@ func getRepo(cmd *cobra.Command, args []string) {
 	}
 
 	clonechan := make(chan git.RepoFileStatus)
+	if verbose {
+		fmt.Printf("Running Gin Command: %v \n", cmd.Name())
+	}
 	go gincl.CloneRepo(repostr, clonechan)
 	formatOutput(clonechan, 0, jsonout, verbose)
 	defaultRemoteIfUnset("origin")

--- a/gincmd/getcmd.go
+++ b/gincmd/getcmd.go
@@ -18,6 +18,7 @@ func getRepo(cmd *cobra.Command, args []string) {
 	flags := cmd.Flags() //  change this to make it consistent with other cmd
 	verbose, _ := flags.GetBool("verbose")
 	jsonout, _ := flags.GetBool("json")
+	checkVerboseJson(verbose, jsonout)
 	srvalias, _ := flags.GetString("server")
 	conf := config.Read()
 	if srvalias == "" {

--- a/gincmd/getcontentcmd.go
+++ b/gincmd/getcontentcmd.go
@@ -1,8 +1,6 @@
 package gincmd
 
 import (
-	"fmt"
-
 	ginclient "github.com/G-Node/gin-cli/ginclient"
 	"github.com/G-Node/gin-cli/ginclient/config"
 	"github.com/G-Node/gin-cli/gincmd/ginerrors"
@@ -24,9 +22,6 @@ func getContent(cmd *cobra.Command, args []string) {
 
 	getcchan := make(chan git.RepoFileStatus)
 	go gincl.GetContent(args, getcchan)
-	if verbose {
-		fmt.Printf("Running Gin Command: %v \n", cmd.Name())
-	}
 	formatOutput(getcchan, 0, jsonout, verbose)
 }
 

--- a/gincmd/getcontentcmd.go
+++ b/gincmd/getcontentcmd.go
@@ -13,6 +13,7 @@ import (
 func getContent(cmd *cobra.Command, args []string) {
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	jsonout, _ := cmd.Flags().GetBool("json")
+	checkVerboseJson(verbose, jsonout)
 	conf := config.Read()
 	// TODO: no need for client; use remotes (and all keys?)
 	gincl := ginclient.New(conf.DefaultServer)

--- a/gincmd/getcontentcmd.go
+++ b/gincmd/getcontentcmd.go
@@ -1,6 +1,8 @@
 package gincmd
 
 import (
+	"fmt"
+
 	ginclient "github.com/G-Node/gin-cli/ginclient"
 	"github.com/G-Node/gin-cli/ginclient/config"
 	"github.com/G-Node/gin-cli/gincmd/ginerrors"
@@ -21,6 +23,9 @@ func getContent(cmd *cobra.Command, args []string) {
 
 	getcchan := make(chan git.RepoFileStatus)
 	go gincl.GetContent(args, getcchan)
+	if verbose {
+		fmt.Printf("Running Gin Command: %v \n", cmd.Name())
+	}
 	formatOutput(getcchan, 0, jsonout, verbose)
 }
 

--- a/gincmd/getcontentcmd.go
+++ b/gincmd/getcontentcmd.go
@@ -9,6 +9,7 @@ import (
 )
 
 func getContent(cmd *cobra.Command, args []string) {
+	verbose, _ := cmd.Flags().GetBool("verbose")
 	jsonout, _ := cmd.Flags().GetBool("json")
 	conf := config.Read()
 	// TODO: no need for client; use remotes (and all keys?)
@@ -20,7 +21,7 @@ func getContent(cmd *cobra.Command, args []string) {
 
 	getcchan := make(chan git.RepoFileStatus)
 	go gincl.GetContent(args, getcchan)
-	formatOutput(getcchan, 0, jsonout)
+	formatOutput(getcchan, 0, jsonout, verbose)
 }
 
 // GetContentCmd sets up the 'get-content' subcommand
@@ -30,7 +31,7 @@ func GetContentCmd() *cobra.Command {
 		"<filenames>": "One or more directories or files to download.",
 	}
 	var cmd = &cobra.Command{
-		Use:                   "get-content [--json] [<filenames>]...",
+		Use:                   "get-content [--json | --verbose] [<filenames>]...",
 		Short:                 "Download the content of files from a remote repository",
 		Long:                  formatdesc(description, args),
 		Args:                  cobra.ArbitraryArgs,
@@ -39,5 +40,6 @@ func GetContentCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")
+	cmd.Flags().Bool("verbose", false, "Print all raw information.")
 	return cmd
 }

--- a/gincmd/getcontentcmd.go
+++ b/gincmd/getcontentcmd.go
@@ -44,7 +44,7 @@ func GetContentCmd() *cobra.Command {
 		Aliases:               []string{"getc"},
 		DisableFlagsInUseLine: true,
 	}
-	cmd.Flags().Bool("json", false, "Print output in JSON format.")
-	cmd.Flags().Bool("verbose", false, "Print all raw information.")
+	cmd.Flags().Bool("json", false, "Print raw information from git and git-annex commands directly.")
+	cmd.Flags().Bool("verbose", false, "Print raw information from git and git-annex commands directly.")
 	return cmd
 }

--- a/gincmd/lockcmd.go
+++ b/gincmd/lockcmd.go
@@ -20,6 +20,7 @@ func countItemsLock(paths []string) (count int) {
 }
 
 func lock(cmd *cobra.Command, args []string) {
+	verbose, _ := cmd.Flags().GetBool("verbose")
 	jsonout, _ := cmd.Flags().GetBool("json")
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
@@ -34,7 +35,7 @@ func lock(cmd *cobra.Command, args []string) {
 	nitems := countItemsLock(args)
 	lockchan := make(chan git.RepoFileStatus)
 	go gincl.LockContent(args, lockchan)
-	formatOutput(lockchan, nitems, jsonout)
+	formatOutput(lockchan, nitems, jsonout, verbose)
 }
 
 // LockCmd sets up the file 'lock' subcommand
@@ -44,7 +45,7 @@ func LockCmd() *cobra.Command {
 		"<filenames>": "One or more directories or files to lock.",
 	}
 	var cmd = &cobra.Command{
-		Use:                   "lock [--json] [<filenames>]...",
+		Use:                   "lock [--json | --verbose] [<filenames>]...",
 		Short:                 "Lock files",
 		Long:                  formatdesc(description, args),
 		Args:                  cobra.ArbitraryArgs,
@@ -52,5 +53,6 @@ func LockCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")
+	cmd.Flags().Bool("verbose", false, "Print all raw information.")
 	return cmd
 }

--- a/gincmd/lockcmd.go
+++ b/gincmd/lockcmd.go
@@ -59,6 +59,6 @@ func LockCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")
-	cmd.Flags().Bool("verbose", false, "Print all raw information.")
+	cmd.Flags().Bool("verbose", false, "Print raw information from git and git-annex commands directly.")
 	return cmd
 }

--- a/gincmd/lockcmd.go
+++ b/gincmd/lockcmd.go
@@ -1,8 +1,6 @@
 package gincmd
 
 import (
-	"fmt"
-
 	"github.com/G-Node/gin-cli/ginclient"
 	"github.com/G-Node/gin-cli/ginclient/config"
 	"github.com/G-Node/gin-cli/gincmd/ginerrors"
@@ -39,9 +37,6 @@ func lock(cmd *cobra.Command, args []string) {
 	lockchan := make(chan git.RepoFileStatus)
 
 	go gincl.LockContent(args, lockchan)
-	if verbose == true {
-		fmt.Printf("Running Gin Command: %v \n", cmd.Name())
-	}
 	formatOutput(lockchan, nitems, jsonout, verbose)
 }
 

--- a/gincmd/lockcmd.go
+++ b/gincmd/lockcmd.go
@@ -1,6 +1,8 @@
 package gincmd
 
 import (
+	"fmt"
+
 	"github.com/G-Node/gin-cli/ginclient"
 	"github.com/G-Node/gin-cli/ginclient/config"
 	"github.com/G-Node/gin-cli/gincmd/ginerrors"
@@ -34,7 +36,11 @@ func lock(cmd *cobra.Command, args []string) {
 	gincl := ginclient.New(conf.DefaultServer)
 	nitems := countItemsLock(args)
 	lockchan := make(chan git.RepoFileStatus)
+
 	go gincl.LockContent(args, lockchan)
+	if verbose == true {
+		fmt.Printf("Running Gin Command: %v \n", cmd.Name())
+	}
 	formatOutput(lockchan, nitems, jsonout, verbose)
 }
 

--- a/gincmd/lockcmd.go
+++ b/gincmd/lockcmd.go
@@ -24,6 +24,7 @@ func countItemsLock(paths []string) (count int) {
 func lock(cmd *cobra.Command, args []string) {
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	jsonout, _ := cmd.Flags().GetBool("json")
+	checkVerboseJson(verbose, jsonout)
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
 	}

--- a/gincmd/removecontentcmd.go
+++ b/gincmd/removecontentcmd.go
@@ -1,8 +1,6 @@
 package gincmd
 
 import (
-	"fmt"
-
 	ginclient "github.com/G-Node/gin-cli/ginclient"
 	"github.com/G-Node/gin-cli/ginclient/config"
 	"github.com/G-Node/gin-cli/gincmd/ginerrors"
@@ -33,9 +31,6 @@ func remove(cmd *cobra.Command, args []string) {
 	nitems := countItemsRemove(args)
 	rmchan := make(chan git.RepoFileStatus)
 	go gincl.RemoveContent(args, rmchan)
-	if verbose {
-		fmt.Printf("Running Gin Command: %v \n", cmd.Name())
-	}
 	formatOutput(rmchan, nitems, jsonout, verbose)
 }
 

--- a/gincmd/removecontentcmd.go
+++ b/gincmd/removecontentcmd.go
@@ -21,6 +21,7 @@ func countItemsRemove(paths []string) int {
 func remove(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
 	verbose, _ := cmd.Flags().GetBool("verbose")
+	checkVerboseJson(verbose, jsonout)
 	// TODO: Need server config? just use remotes (and all keys)
 	conf := config.Read()
 	gincl := ginclient.New(conf.DefaultServer)

--- a/gincmd/removecontentcmd.go
+++ b/gincmd/removecontentcmd.go
@@ -1,6 +1,8 @@
 package gincmd
 
 import (
+	"fmt"
+
 	ginclient "github.com/G-Node/gin-cli/ginclient"
 	"github.com/G-Node/gin-cli/ginclient/config"
 	"github.com/G-Node/gin-cli/gincmd/ginerrors"
@@ -30,6 +32,9 @@ func remove(cmd *cobra.Command, args []string) {
 	nitems := countItemsRemove(args)
 	rmchan := make(chan git.RepoFileStatus)
 	go gincl.RemoveContent(args, rmchan)
+	if verbose {
+		fmt.Printf("Running Gin Command: %v \n", cmd.Name())
+	}
 	formatOutput(rmchan, nitems, jsonout, verbose)
 }
 

--- a/gincmd/removecontentcmd.go
+++ b/gincmd/removecontentcmd.go
@@ -54,6 +54,6 @@ func RemoveContentCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")
-	cmd.Flags().Bool("verbose", false, "Print all raw information.")
+	cmd.Flags().Bool("verbose", false, "Print raw information from git and git-annex commands directly.")
 	return cmd
 }

--- a/gincmd/removecontentcmd.go
+++ b/gincmd/removecontentcmd.go
@@ -18,6 +18,7 @@ func countItemsRemove(paths []string) int {
 
 func remove(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
+	verbose, _ := cmd.Flags().GetBool("verbose")
 	// TODO: Need server config? just use remotes (and all keys)
 	conf := config.Read()
 	gincl := ginclient.New(conf.DefaultServer)
@@ -29,7 +30,7 @@ func remove(cmd *cobra.Command, args []string) {
 	nitems := countItemsRemove(args)
 	rmchan := make(chan git.RepoFileStatus)
 	go gincl.RemoveContent(args, rmchan)
-	formatOutput(rmchan, nitems, jsonout)
+	formatOutput(rmchan, nitems, jsonout, verbose)
 }
 
 // RemoveContentCmd sets up the 'remove-content' subcommand
@@ -39,7 +40,7 @@ func RemoveContentCmd() *cobra.Command {
 		"<filenames>": "One or more directories or files to remove.",
 	}
 	var cmd = &cobra.Command{
-		Use:                   "remove-content [--json] [<filenames>]...",
+		Use:                   "remove-content [--json | --verbose] [<filenames>]...",
 		Short:                 "Remove the content of local files that have already been uploaded",
 		Long:                  formatdesc(description, args),
 		Args:                  cobra.ArbitraryArgs,
@@ -48,5 +49,6 @@ func RemoveContentCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")
+	cmd.Flags().Bool("verbose", false, "Print all raw information.")
 	return cmd
 }

--- a/gincmd/unlockcmd.go
+++ b/gincmd/unlockcmd.go
@@ -20,6 +20,7 @@ func countItemsUnlock(paths []string) (count int) {
 func unlock(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
 	verbose, _ := cmd.Flags().GetBool("verbose")
+	checkVerboseJson(verbose, jsonout)
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
 	}

--- a/gincmd/unlockcmd.go
+++ b/gincmd/unlockcmd.go
@@ -19,6 +19,7 @@ func countItemsUnlock(paths []string) (count int) {
 
 func unlock(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
+	verbose, _ := cmd.Flags().GetBool("verbose")
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
 	}
@@ -34,7 +35,7 @@ func unlock(cmd *cobra.Command, args []string) {
 	nitems := countItemsUnlock(args)
 	unlockchan := make(chan git.RepoFileStatus)
 	go gincl.UnlockContent(args, unlockchan)
-	formatOutput(unlockchan, nitems, jsonout)
+	formatOutput(unlockchan, nitems, jsonout, verbose)
 }
 
 // UnlockCmd sets up the file 'unlock' subcommand
@@ -44,7 +45,7 @@ func UnlockCmd() *cobra.Command {
 		"<filenames>": "One or more directories or files to unllock.",
 	}
 	var cmd = &cobra.Command{
-		Use:                   "unlock [--json] [<filenames>]...",
+		Use:                   "unlock [--json | --verbose] [<filenames>]...",
 		Short:                 "Unlock files for editing",
 		Long:                  formatdesc(description, args),
 		Args:                  cobra.ArbitraryArgs,
@@ -52,5 +53,6 @@ func UnlockCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")
+	cmd.Flags().Bool("verbose", false, "Print all raw information.")
 	return cmd
 }

--- a/gincmd/unlockcmd.go
+++ b/gincmd/unlockcmd.go
@@ -53,6 +53,6 @@ func UnlockCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")
-	cmd.Flags().Bool("verbose", false, "Print all raw information.")
+	cmd.Flags().Bool("verbose", false, "Print raw information from git and git-annex commands directly.")
 	return cmd
 }

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -11,7 +11,7 @@ import (
 
 func upload(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
-	// verbose, _ := cmd.Flags().GetBool("verbose")
+	verbose, _ := cmd.Flags().GetBool("verbose")
 	remotes, _ := cmd.Flags().GetStringSlice("to")
 	gincl := ginclient.New("gin") // TODO: probably doesn't need a client
 	// if ver
@@ -44,18 +44,18 @@ func upload(cmd *cobra.Command, args []string) {
 
 	uploadchan := make(chan git.RepoFileStatus)
 	go gincl.Upload(paths, remotes, uploadchan)
-	formatOutput(uploadchan, 0, jsonout)
-	// if verbose == true {
-	// 	var cmd_spec_var []string
-	// 	path, _ := git.RemoteShow()
-	// 	for _, v := range path {
-	// 		cmd_spec_var = append(cmd_spec_var, v)
-	// 	}
-	// 	verboseOutput(uploadchan, "upload", cmd_spec_var, paths)
-	// 	// fmt.Printf("%v", *os.Stdin)
-	// 	s, _ := os.Getwd()
-	// 	fmt.Printf("%v", s)
-	// }
+	if verbose == true {
+		var cmd_spec_var []string
+		path, _ := git.RemoteShow()
+		for _, v := range path {
+			cmd_spec_var = append(cmd_spec_var, v)
+		}
+		for _, url := range cmd_spec_var {
+			fmt.Printf("Currently uploading to  %v", url)
+			fmt.Println()
+		}
+	}
+	formatOutput(uploadchan, 0, jsonout, verbose)
 }
 
 // UploadCmd sets up the 'upload' subcommand
@@ -83,7 +83,7 @@ If no arguments are specified, only changes to files already being tracked are u
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")
-	cmd.Flags().Bool("verbose", false, "Print all information.")
+	cmd.Flags().Bool("verbose", false, "Print all raw information.")
 	cmd.Flags().StringSliceP("to", "t", nil, "Upload to specific `remote`. Supports multiple remotes, either by specifying multiple times or as a comma separated list (see Examples). If the keyword 'all' is specified, the data is uploaded to all configured remotes.")
 	return cmd
 }

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -43,16 +43,14 @@ func upload(cmd *cobra.Command, args []string) {
 
 	uploadchan := make(chan git.RepoFileStatus)
 	go gincl.Upload(paths, remotes, uploadchan)
-	if verbose == false {
-		formatOutput(uploadchan, 0, jsonout)
-	} else {
+	formatOutput(uploadchan, 0, jsonout)
+	if verbose == true {
 		var cmd_spec_var []string
-		formatOutput(uploadchan, 0, jsonout)
 		path, _ := git.RemoteShow()
 		for _, v := range path {
 			cmd_spec_var = append(cmd_spec_var, v)
 		}
-		verboseOutput(uploadchan, "upload", cmd_spec_var)
+		verboseOutput(uploadchan, "upload", cmd_spec_var, paths)
 	}
 }
 

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -43,18 +43,6 @@ func upload(cmd *cobra.Command, args []string) {
 
 	uploadchan := make(chan git.RepoFileStatus)
 	go gincl.Upload(paths, remotes, uploadchan)
-	if verbose {
-		var cmd_spec_var []string
-		path, _ := git.RemoteShow()
-		for _, v := range path {
-			cmd_spec_var = append(cmd_spec_var, v)
-		}
-		for _, url := range cmd_spec_var {
-			fmt.Printf("Running Gin Command: %v \n", cmd.Name())
-			fmt.Printf("Currently uploading to  %v ", url)
-			fmt.Println()
-		}
-	}
 	formatOutput(uploadchan, 0, jsonout, verbose)
 }
 

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -2,6 +2,7 @@ package gincmd
 
 import (
 	"fmt"
+	"os"
 
 	ginclient "github.com/G-Node/gin-cli/ginclient"
 	"github.com/G-Node/gin-cli/gincmd/ginerrors"
@@ -14,6 +15,7 @@ func upload(cmd *cobra.Command, args []string) {
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	remotes, _ := cmd.Flags().GetStringSlice("to")
 	gincl := ginclient.New("gin") // TODO: probably doesn't need a client
+	if ver
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
 	}
@@ -51,6 +53,9 @@ func upload(cmd *cobra.Command, args []string) {
 			cmd_spec_var = append(cmd_spec_var, v)
 		}
 		verboseOutput(uploadchan, "upload", cmd_spec_var, paths)
+		// fmt.Printf("%v", *os.Stdin)
+		s, _ := os.Getwd()
+		fmt.Printf("%v", s)
 	}
 }
 

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -83,7 +83,7 @@ If no arguments are specified, only changes to files already being tracked are u
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")
-	cmd.Flags().Bool("verbose", false, "Print raw information from git, git-annex and called gin commands.")
+	cmd.Flags().Bool("verbose", false, "Print raw information from git and git-annex commands directly.")
 	cmd.Flags().StringSliceP("to", "t", nil, "Upload to specific `remote`. Supports multiple remotes, either by specifying multiple times or as a comma separated list (see Examples). If the keyword 'all' is specified, the data is uploaded to all configured remotes.")
 	return cmd
 }

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -14,7 +14,6 @@ func upload(cmd *cobra.Command, args []string) {
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	remotes, _ := cmd.Flags().GetStringSlice("to")
 	gincl := ginclient.New("gin") // TODO: probably doesn't need a client
-	// if ver
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
 	}

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -42,11 +42,13 @@ func upload(cmd *cobra.Command, args []string) {
 	}
 
 	uploadchan := make(chan git.RepoFileStatus)
-	go gincl.Upload(paths, remotes, uploadchan)
+	gincl.Upload(paths, remotes, uploadchan)
 	if verbose == false {
 		formatOutput(uploadchan, 0, jsonout)
 	} else {
-		fmt.Println("abc")
+		fmt.Println("testing")
+		formatOutput(uploadchan, 0, jsonout)
+		verboseOutput(uploadchan, "upload", paths)
 	}
 }
 
@@ -75,7 +77,7 @@ If no arguments are specified, only changes to files already being tracked are u
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")
-	cmd.Flags().Bool("verbose", false, "Print all information")
+	cmd.Flags().Bool("verbose", false, "Print all information.")
 	cmd.Flags().StringSliceP("to", "t", nil, "Upload to specific `remote`. Supports multiple remotes, either by specifying multiple times or as a comma separated list (see Examples). If the keyword 'all' is specified, the data is uploaded to all configured remotes.")
 	return cmd
 }

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -13,6 +13,7 @@ func upload(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	remotes, _ := cmd.Flags().GetStringSlice("to")
+	checkVerboseJson(verbose, jsonout)
 	gincl := ginclient.New("gin") // TODO: probably doesn't need a client
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
@@ -35,7 +36,6 @@ func upload(cmd *cobra.Command, args []string) {
 			break
 		}
 	}
-	fmt.Println(args)
 	paths := args
 	if len(paths) > 0 {
 		commit(cmd, paths)
@@ -43,7 +43,7 @@ func upload(cmd *cobra.Command, args []string) {
 
 	uploadchan := make(chan git.RepoFileStatus)
 	go gincl.Upload(paths, remotes, uploadchan)
-	if verbose == true {
+	if verbose {
 		var cmd_spec_var []string
 		path, _ := git.RemoteShow()
 		for _, v := range path {

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -2,7 +2,6 @@ package gincmd
 
 import (
 	"fmt"
-	"os"
 
 	ginclient "github.com/G-Node/gin-cli/ginclient"
 	"github.com/G-Node/gin-cli/gincmd/ginerrors"
@@ -12,10 +11,10 @@ import (
 
 func upload(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
-	verbose, _ := cmd.Flags().GetBool("verbose")
+	// verbose, _ := cmd.Flags().GetBool("verbose")
 	remotes, _ := cmd.Flags().GetStringSlice("to")
 	gincl := ginclient.New("gin") // TODO: probably doesn't need a client
-	if ver
+	// if ver
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
 	}
@@ -46,17 +45,17 @@ func upload(cmd *cobra.Command, args []string) {
 	uploadchan := make(chan git.RepoFileStatus)
 	go gincl.Upload(paths, remotes, uploadchan)
 	formatOutput(uploadchan, 0, jsonout)
-	if verbose == true {
-		var cmd_spec_var []string
-		path, _ := git.RemoteShow()
-		for _, v := range path {
-			cmd_spec_var = append(cmd_spec_var, v)
-		}
-		verboseOutput(uploadchan, "upload", cmd_spec_var, paths)
-		// fmt.Printf("%v", *os.Stdin)
-		s, _ := os.Getwd()
-		fmt.Printf("%v", s)
-	}
+	// if verbose == true {
+	// 	var cmd_spec_var []string
+	// 	path, _ := git.RemoteShow()
+	// 	for _, v := range path {
+	// 		cmd_spec_var = append(cmd_spec_var, v)
+	// 	}
+	// 	verboseOutput(uploadchan, "upload", cmd_spec_var, paths)
+	// 	// fmt.Printf("%v", *os.Stdin)
+	// 	s, _ := os.Getwd()
+	// 	fmt.Printf("%v", s)
+	// }
 }
 
 // UploadCmd sets up the 'upload' subcommand

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -42,13 +42,17 @@ func upload(cmd *cobra.Command, args []string) {
 	}
 
 	uploadchan := make(chan git.RepoFileStatus)
-	gincl.Upload(paths, remotes, uploadchan)
+	go gincl.Upload(paths, remotes, uploadchan)
 	if verbose == false {
 		formatOutput(uploadchan, 0, jsonout)
 	} else {
-		fmt.Println("testing")
+		var cmd_spec_var []string
 		formatOutput(uploadchan, 0, jsonout)
-		verboseOutput(uploadchan, "upload", paths)
+		path, _ := git.RemoteShow()
+		for _, v := range path {
+			cmd_spec_var = append(cmd_spec_var, v)
+		}
+		verboseOutput(uploadchan, "upload", cmd_spec_var)
 	}
 }
 

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -51,7 +51,8 @@ func upload(cmd *cobra.Command, args []string) {
 			cmd_spec_var = append(cmd_spec_var, v)
 		}
 		for _, url := range cmd_spec_var {
-			fmt.Printf("Currently uploading to  %v", url)
+			fmt.Printf("Running Gin Command: %v \n", cmd.Name())
+			fmt.Printf("Currently uploading to  %v ", url)
 			fmt.Println()
 		}
 	}
@@ -83,7 +84,7 @@ If no arguments are specified, only changes to files already being tracked are u
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")
-	cmd.Flags().Bool("verbose", false, "Print all raw information.")
+	cmd.Flags().Bool("verbose", false, "Print raw information from git, git-annex and called gin commands.")
 	cmd.Flags().StringSliceP("to", "t", nil, "Upload to specific `remote`. Supports multiple remotes, either by specifying multiple times or as a comma separated list (see Examples). If the keyword 'all' is specified, the data is uploaded to all configured remotes.")
 	return cmd
 }

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -11,6 +11,7 @@ import (
 
 func upload(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
+	verbose, _ := cmd.Flags().GetBool("verbose")
 	remotes, _ := cmd.Flags().GetStringSlice("to")
 	gincl := ginclient.New("gin") // TODO: probably doesn't need a client
 	if !git.IsRepo() {
@@ -42,7 +43,11 @@ func upload(cmd *cobra.Command, args []string) {
 
 	uploadchan := make(chan git.RepoFileStatus)
 	go gincl.Upload(paths, remotes, uploadchan)
-	formatOutput(uploadchan, 0, jsonout)
+	if verbose == false {
+		formatOutput(uploadchan, 0, jsonout)
+	} else {
+		fmt.Println("abc")
+	}
 }
 
 // UploadCmd sets up the 'upload' subcommand
@@ -61,7 +66,7 @@ If no arguments are specified, only changes to files already being tracked are u
 		"Upload all '.zip' files to remotes named 'gin' and 'labdata'":      "$ gin upload --to gin --to labdata *.zip\n    or\n$ gin upload --to gin,labdata *.zip",
 	}
 	var cmd = &cobra.Command{
-		Use:                   "upload [--json] [--to <remote>] [<filenames>]...",
+		Use:                   "upload [--json | --verbose] [--to <remote>] [<filenames>]...",
 		Short:                 "Upload local changes to a remote repository",
 		Long:                  formatdesc(description, args),
 		Args:                  cobra.ArbitraryArgs,
@@ -70,6 +75,7 @@ If no arguments are specified, only changes to files already being tracked are u
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, "Print output in JSON format.")
+	cmd.Flags().Bool("verbose", false, "Print all information")
 	cmd.Flags().StringSliceP("to", "t", nil, "Upload to specific `remote`. Supports multiple remotes, either by specifying multiple times or as a comma separated list (see Examples). If the keyword 'all' is specified, the data is uploaded to all configured remotes.")
 	return cmd
 }

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -35,7 +35,7 @@ func upload(cmd *cobra.Command, args []string) {
 			break
 		}
 	}
-
+	fmt.Println(args)
 	paths := args
 	if len(paths) > 0 {
 		commit(cmd, paths)

--- a/git/annex.go
+++ b/git/annex.go
@@ -307,6 +307,10 @@ func AnnexPush(paths []string, remote string, pushchan chan<- RepoFileStatus) {
 				continue
 			}
 			status.FileName = getresult.File
+			linInput := cmd.Args
+			iinput := strings.Join(linInput, " ")
+			status.RawInput = iinput
+			// output shouldn't be needed
 			if getresult.Success {
 				status.Progress = progcomplete
 				status.Err = nil

--- a/git/annex.go
+++ b/git/annex.go
@@ -294,6 +294,7 @@ func AnnexPush(paths []string, remote string, pushchan chan<- RepoFileStatus) {
 			// skip empty lines
 			continue
 		}
+		status.RawOutput = string(outline)
 		err := json.Unmarshal(outline, &progress)
 		if err != nil || progress == (annexProgress{}) {
 			time.Sleep(1 * time.Second)
@@ -310,7 +311,6 @@ func AnnexPush(paths []string, remote string, pushchan chan<- RepoFileStatus) {
 			lineInput := cmd.Args
 			input := strings.Join(lineInput, " ")
 			status.RawInput = input
-			// output shouldn't be needed
 			if getresult.Success {
 				status.Progress = progcomplete
 				status.Err = nil

--- a/git/annex.go
+++ b/git/annex.go
@@ -307,9 +307,9 @@ func AnnexPush(paths []string, remote string, pushchan chan<- RepoFileStatus) {
 				continue
 			}
 			status.FileName = getresult.File
-			linInput := cmd.Args
-			iinput := strings.Join(linInput, " ")
-			status.RawInput = iinput
+			lineInput := cmd.Args
+			input := strings.Join(lineInput, " ")
+			status.RawInput = input
 			// output shouldn't be needed
 			if getresult.Success {
 				status.Progress = progcomplete

--- a/git/annex.go
+++ b/git/annex.go
@@ -382,11 +382,15 @@ func AnnexGet(filepaths []string, getchan chan<- RepoFileStatus) {
 	var getresult annexAction
 	var prevByteProgress int
 	var prevT time.Time
+	lineInput := cmd.Args
+	input := strings.Join(lineInput, " ")
+	status.RawInput = input
 	for rerr = nil; rerr == nil; outline, rerr = cmd.OutReader.ReadBytes('\n') {
 		if len(outline) == 0 {
 			// skip empty lines
 			continue
 		}
+		status.RawOutput = string(outline)
 		err := json.Unmarshal(outline, &progress)
 		if err != nil || progress == (annexProgress{}) {
 			// File done? Check if succeeded and continue to next line
@@ -458,12 +462,16 @@ func AnnexDrop(filepaths []string, dropchan chan<- RepoFileStatus) {
 	status.State = "Removing content"
 	var line string
 	var rerr error
+	lineInput := cmd.Args
+	input := strings.Join(lineInput, " ")
+	status.RawInput = input
 	for rerr = nil; rerr == nil; line, rerr = cmd.OutReader.ReadString('\n') {
 		line = strings.TrimSpace(line)
 		if len(line) == 0 {
 			// Empty line output. Ignore
 			continue
 		}
+		status.RawOutput = line
 		// Send file name
 		err = json.Unmarshal([]byte(line), &annexDropRes)
 		if err != nil {
@@ -645,7 +653,11 @@ func AnnexUnlock(filepaths []string, unlockchan chan<- RepoFileStatus) {
 	var outline []byte
 	var rerr error
 	var unlockres annexAction
+	lineInput := cmd.Args
+	input := strings.Join(lineInput, " ")
+	status.RawInput = input
 	for rerr = nil; rerr == nil; outline, rerr = cmd.OutReader.ReadBytes('\n') {
+		status.RawOutput = string(outline)
 		if len(outline) == 0 {
 			// Empty line output. Ignore
 			continue
@@ -797,6 +809,10 @@ func annexAddCommon(filepaths []string, update bool, addchan chan<- RepoFileStat
 			continue
 		}
 		status.FileName = addresult.File
+		lineInput := cmd.Args
+		input := strings.Join(lineInput, " ")
+		status.RawInput = input
+		status.RawOutput = string(outline)
 		if addresult.Success {
 			log.Write("%s added to annex", addresult.File)
 			status.Err = nil

--- a/git/git.go
+++ b/git/git.go
@@ -243,7 +243,7 @@ func Push(remote string, pushchan chan<- RepoFileStatus) {
 			status.State = fmt.Sprintf("Uploading git files (to: %s)", remote)
 		}
 		status.Progress = fmt.Sprintf("%s%%", match[2])
-		status.RawOutput = fmt.Sprintf("%s \r", line)
+		status.RawOutput = fmt.Sprintf("%s", line)
 		pushchan <- status
 	}
 	return

--- a/git/git.go
+++ b/git/git.go
@@ -283,8 +283,12 @@ func Add(filepaths []string, addchan chan<- RepoFileStatus) {
 	var status RepoFileStatus
 	var line string
 	var rerr error
+	lineInput := cmd.Args
+	input := strings.Join(lineInput, " ")
+	status.RawInput = input
 	for rerr = nil; rerr == nil; line, rerr = cmd.OutReader.ReadString('\n') {
 		fname := strings.TrimSpace(line)
+		status.RawOutput = line
 		if len(fname) == 0 {
 			// skip empty lines
 			continue

--- a/git/git.go
+++ b/git/git.go
@@ -167,7 +167,7 @@ func Clone(remotepath string, repopath string, clonechan chan<- RepoFileStatus) 
 						rate = strings.TrimSuffix(rate, ",")
 					}
 					status.Rate = rate
-					status.RawOutput = fmt.Sprintf("%s", line)
+					status.RawOutput = line
 				}
 			}
 			clonechan <- status
@@ -243,7 +243,7 @@ func Push(remote string, pushchan chan<- RepoFileStatus) {
 			status.State = fmt.Sprintf("Uploading git files (to: %s)", remote)
 		}
 		status.Progress = fmt.Sprintf("%s%%", match[2])
-		status.RawOutput = fmt.Sprintf("%s", line)
+		status.RawOutput = line
 		pushchan <- status
 	}
 	return

--- a/git/git.go
+++ b/git/git.go
@@ -37,6 +37,10 @@ type RepoFileStatus struct {
 	Progress string `json:"progress"`
 	// The data rate, if available.
 	Rate string `json:"rate"`
+	// original cmd input
+	RawInput string `json:"rawinput"`
+	// original command output
+	RawOutput string `json:"rawoutput"`
 	// Errors
 	Err error `json:"err"`
 }
@@ -222,6 +226,9 @@ func Push(remote string, pushchan chan<- RepoFileStatus) {
 	var line string
 	var rerr error
 	re := regexp.MustCompile(`(?P<state>Compressing|Writing) objects:\s+(?P<progress>[0-9]{2,3})% \((?P<n>[0-9]+)/(?P<N>[0-9]+)\)`)
+	li_input := cmd.Args
+	input := strings.Join(li_input, " ")
+	status.RawInput = input
 	for rerr = nil; rerr == nil; line, rerr = cmd.ErrReader.ReadString('\r') {
 		if !re.MatchString(line) {
 			continue
@@ -232,6 +239,7 @@ func Push(remote string, pushchan chan<- RepoFileStatus) {
 			status.State = fmt.Sprintf("Uploading git files (to: %s)", remote)
 		}
 		status.Progress = fmt.Sprintf("%s%%", match[2])
+		status.RawOutput = fmt.Sprintf("%s", line)
 		pushchan <- status
 	}
 	return


### PR DESCRIPTION
With the verbose flag, raw git or git annex input and output will be print.


(Things that may not be ok)
1. still need some check on verbose flag on get and remove command
2. I will change a bit the download command (json in annex and verbose together looks weird ) 

