### PR TITLE
Fix for adding annexed content to git on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
 
 script:
   - make
-  - make installtest
+  - make testbuild
   - if [[ "${TRAVIS_GO_VERSION}" != "tip" ]]; then
         ./tests/start-server;
         while ! curl localhost:3000 -so /dev/null; do sleep 1; done;

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ allplatforms: linux windows macos
 install: gin
 	install $(BUILDLOC)/$(GIN) $(INSTLOC)/$(GIN)
 
-installtest: gin
-	install $(BUILDLOC)/$(GIN) $(TESTBINLOC)/$(GIN)
+testbuild: linux
+	install $(BUILDLOC)/linux/$(GIN) $(TESTBINLOC)/$(GIN)
 
 linux: $(BUILDLOC)/linux/$(GIN)
 
@@ -50,11 +50,10 @@ $(BUILDLOC)/$(GIN): $(SOURCES)
 	go build $(LDFLAGS) -o $(BUILDLOC)/$(GIN)
 
 $(BUILDLOC)/linux/$(GIN): $(SOURCES)
-	gox -output=$(BUILDLOC)/linux/$(GIN) -osarch=linux/amd64 $(LDFLAGS)
-
+	GOOS=linux GOARCH=amd64 go build -o $(BUILDLOC)/linux/$(GIN) $(LDFLAGS)
 
 $(BUILDLOC)/windows/$(GIN).exe: $(SOURCES)
-	gox -output=$(BUILDLOC)/windows/$(GIN) -osarch=windows/386 $(LDFLAGS)
+	GOOS=windows GOARCH=386 go build -o $(BUILDLOC)/windows/$(GIN) $(LDFLAGS)
 
 $(BUILDLOC)/darwin/$(GIN): $(SOURCES)
-	gox -output=$(BUILDLOC)/darwin/$(GIN) -osarch=darwin/amd64 $(LDFLAGS)
+	GOOS=darwin GOARCH=amd64 go build -o $(BUILDLOC)/darwin/$(GIN) $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ VERNUM = $(shell cut -d= -f2 version)
 ncommits = $(shell git rev-list --count HEAD)
 BUILDNUM = $(shell printf '%06d' $(ncommits))
 COMMITHASH = $(shell git rev-parse HEAD)
-LDFLAGS = -ldflags=$(PKG)="-X main.gincliversion=$(VERNUM) -X main.build=$(BUILDNUM) -X main.commit=$(COMMITHASH)"
+LDFLAGS = -ldflags="-X main.gincliversion=$(VERNUM) -X main.build=$(BUILDNUM) -X main.commit=$(COMMITHASH)"
 
 SOURCES = $(shell find . -type f -iname "*.go") version
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,30 +1,33 @@
 version: '{build}'
 build: off
 
-clone_folder: c:\gopath\src\github.com\G-Node\gin-cli
+clone_folder: C:\gopath\src\github.com\G-Node\gin-cli
 
 stack: go 1.11
 
 environment:
-  GOPATH: c:\gopath
+  SRCDIR: C:\gopath\src\github.com\G-Node\gin-cli
+  GOPATH: C:\gopath
   BINDIR: bin
   ANNEXURL: https://web.gin.g-node.org/G-Node/git-annex-windows/raw/master/git-annex-windows-v6.exe
 
 
 install:
-  - set PATH=%PATH%;%GOPATH%\bin;c:\git-annex\usr\bin
+  - set PATH=C:\Python37-x64\;%PATH%;%GOPATH%\bin;c:\git-annex\usr\bin
   # download git-annex-windows-v6.exe
-  - md \git-annex; cd \git-annex
+  - md c:\git-annex
+  - cd c:\git-annex
   - ps: Invoke-WebRequest -URI $env:ANNEXURL -OutFile "git-annex-windows-v6.exe"
   - 7z x git-annex-windows-v6.exe
   - dir usr\bin
+  - git-annex version
   # go stuff
   - go version
   - go env
   - go get -u github.com/golang/lint/golint
 
 build_script:
-  - cd %clone_folder%
+  - cd %SRCDIR%
   # download deps
   - go get github.com/spf13/viper
   - go get github.com/spf13/cobra
@@ -35,7 +38,6 @@ build_script:
   - go get golang.org/x/crypto/ssh
   - go get github.com/gogits/go-gogs-client
   - go get github.com/fatih/color
-  - go get github.com/hashicorp/go-version
   - go get github.com/shibukawa/configdir
   - go get github.com/bbrks/wrap
   - go get github.com/docker/docker/pkg/term
@@ -44,9 +46,24 @@ build_script:
   - go vet ./...
   - gofmt -s -l .
   - golint github.com/G-Node/gin-cli...
+  - go build -ldflags "-X main.gincliversion=APPVEYOR-%APPVEYOR_REPO_NAME%-%APPVEYOR_REPO_BRANCH% -X main.build=%APPVEYOR_BUILD_NUMBER% -X main.commit=%APPVEYOR_REPO_COMMIT%" -o %GOPATH%\bin\gin.exe .
 
-after_test:
-  - go build -ldflags "-X main.gincliversion=APPVEYOR-%APPVEYOR_REPO_NAME%-%APPVEYOR_REPO_BRANCH% -X main.build=%APPVEYOR_BUILD_NUMBER% -X main.commit=%APPVEYOR_REPO_COMMIT%" -o gin.exe .
+before_test:
+  # python stuff
+  - python -m pip install pytest pyyaml
+  # clone tests submodule
+  - git submodule init
+  - git submodule update
+  # check that git and annex versions are detected properly
+  - gin --version
+  - gin help
+
+test_script:
+  - git config --global user.email "appveyor@example.com"
+  - git config --global user.name "GIN Appveyor"
+  - cd %SRCDIR%\tests
+  - xcopy /e /s /y /i conf %userprofile%\conf
+  - python -m pytest -k "annex_content"
 
 # to disable deployment
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,11 +8,17 @@ stack: go 1.11
 environment:
   GOPATH: c:\gopath
   BINDIR: bin
+  ANNEXURL: https://web.gin.g-node.org/G-Node/git-annex-windows/raw/master/git-annex-windows-v6.exe
 
 
 install:
+  - set PATH=%PATH%;%GOPATH%\bin;c:\git-annex\usr\bin
+  # download git-annex-windows-v6.exe
+  - md \git-annex; cd \git-annex
+  - ps: Invoke-WebRequest -URI $env:ANNEXURL -OutFile "git-annex-windows-v6.exe"
+  - 7z x git-annex-windows-v6.exe
+  - dir usr\bin
   # go stuff
-  - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
   - go version
   - go env
   - go get -u github.com/golang/lint/golint

--- a/gincmd/cliversion.go
+++ b/gincmd/cliversion.go
@@ -22,7 +22,9 @@ type VersionInfo struct {
 // String constructs a human-readable string that contains the version numbers.
 func (v *VersionInfo) String() string {
 	if v.Version == "" {
-		return "GIN command line client [dev build]"
+		v.Version = "[dev build]"
+		v.Build = "[dev]"
+		v.Commit = "???"
 	}
 
 	gitver := v.Git

--- a/git/git.go
+++ b/git/git.go
@@ -991,13 +991,14 @@ func gitAddDirect(paths []string) (filtered []string) {
 		if wiInfo.Err != nil {
 			continue
 		}
-		annexfiles = append(annexfiles, wiInfo.File)
+		annexfiles = append(annexfiles, filepath.Clean(wiInfo.File))
 	}
 	filtered = filterpaths(paths, annexfiles)
 
 	lschan := make(chan string)
 	go LsFiles(paths, lschan)
 	for gitfile := range lschan {
+		gitfile = filepath.Clean(gitfile)
 		if !stringInSlice(gitfile, annexfiles) && !stringInSlice(gitfile, filtered) {
 			filtered = append(filtered, gitfile)
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,27 +1,20 @@
 module github.com/achilleas-k/gin-cli
 
+replace github.com/G-Node/gin-cli => ./
+
 require (
-	github.com/G-Node/gin-cli v0.0.0-20190208150212-2aac9dfbdde0
+	github.com/G-Node/gin-cli v0.0.0-20190212155606-424a32eff3a2
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc
 	github.com/bbrks/wrap v2.3.0+incompatible
-	github.com/coreos/etcd v3.3.12+incompatible // indirect
 	github.com/docker/docker v1.13.1
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.7.0
 	github.com/gogits/go-gogs-client v0.0.0-20181217004319-1cd0db3113de
 	github.com/hashicorp/go-version v1.1.0
 	github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c
-	github.com/mattn/go-colorable v0.1.0 // indirect
-	github.com/mattn/go-isatty v0.0.4 // indirect
 	github.com/shibukawa/configdir v0.0.0-20170330084843-e180dbdc8da0
-	github.com/spf13/afero v1.2.1 // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.3.1
-	github.com/stretchr/objx v0.1.1 // indirect
-	github.com/stretchr/testify v1.3.0 // indirect
-	github.com/ugorji/go/codec v0.0.0-20190204201341-e444a5086c43 // indirect
 	golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67
-	golang.org/x/sys v0.0.0-20190209173611-3b5209105503 // indirect
-	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,9 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.7.0
 	github.com/gogits/go-gogs-client v0.0.0-20181217004319-1cd0db3113de
-	github.com/hashicorp/go-version v1.1.0
 	github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c
+	github.com/mattn/go-colorable v0.1.0 // indirect
+	github.com/mattn/go-isatty v0.0.4 // indirect
 	github.com/shibukawa/configdir v0.0.0-20170330084843-e180dbdc8da0
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,6 @@ github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gogits/go-gogs-client v0.0.0-20181217004319-1cd0db3113de h1:V/MkGxjjHnVo0TprerSeUrJh+mv9FyPZeQ4Vx44k5KI=
 github.com/gogits/go-gogs-client v0.0.0-20181217004319-1cd0db3113de/go.mod h1:cY2AIrMgHm6oOHmR7jY+9TtjzSjQ3iG7tURJG3Y6XH0=
-github.com/hashicorp/go-version v1.1.0 h1:bPIoEKD27tNdebFGGxxYwcL4nepeY4j1QP23PFRGzg0=
-github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c h1:kQWxfPIHVLbgLzphqk3QUflDy9QdksZR4ygR807bpy0=

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a h1:1n5lsVfiQW3yfsRGu98756EH1
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190209173611-3b5209105503 h1:5SvYFrOM3W8Mexn9/oA44Ji7vhXAZQ9hiP+1Q/DMrWg=
 golang.org/x/sys v0.0.0-20190209173611-3b5209105503/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
This PR fixes a pretty nasty bug on Windows where a file would be added to the annex and then also to git, causing the pointer (link) file in annex to break.  The content would still remain in the repository, but the linking was wrong.

The cause of the problem was due to the way file paths are filtered during a commit.  When adding files (either new or existing ones) to the index, the client first calls `git annex add` with the filtering parameters.  This adds all files that don't match the git-annex filtering rules to the annex.  After that is done, `git add` is run on the rest of the files.  On Linux we can `git add` everything and it wont make a difference (annexed files wont get added again), but on Windows, the file in the working tree is unlocked (Windows works in **direct mode**) so a `git add` adds the whole binary file and overwrites the existing link file that was added by git-annex.  So to avoid this, the client would get a list of all annexed files (including newly added ones) and filter the path arguments so that `git add` is run only on files that are not annexed.  The bug was that the filtering function did not take into account path formatting differences between Windows and Linux.  Git and git-annex both return Unix paths (`/` separator), so on Windows, if a path contained a `\`, it wouldn't match the known paths from git-annex and the original problem persisted.

Path collection and filtering now runs `filepath.Clean()` on all path strings to unify their formatting.

With this PR we also begin running tests on Appveyor for Windows.  Currently, only a new test is run which was written to catch the bug described above.  I will soon be adapting tests so they can run on Windows without issue, or I will configure Appveyor to run a containerised GIN (GOGS) server as we do on Travis.

A smaller change is that I replaced the semver parser we were previously using (https://github.com/hashicorp/go-version) with a very lax, self written function.  On many platforms, git and git-annex both have version strings which don't follow semver rules (e.g., `git version 2.20.1.windows.1` or `6.20171205-ge5c610b29PS`), so it doesn't make sense to try to work around and use an external dependency.  This should fix all previous issues with version parsing (closes #121 and #147).