### PR TITLE
Count only T (typechange) files

### DIFF
--- a/gincmd/lockcmd.go
+++ b/gincmd/lockcmd.go
@@ -11,8 +11,10 @@ import (
 func countItemsLock(paths []string) (count int) {
 	statchan := make(chan git.AnnexStatusRes)
 	go git.AnnexStatus(paths, statchan)
-	for range statchan {
-		count++
+	for stat := range statchan {
+		if stat.Status == "T" {
+			count++
+		}
 	}
 	return
 }


### PR DESCRIPTION
When locking, we should only count the files that are unlocked, not modified or untracked files.

Fixes #226