### PR TITLE
Log trim fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ $(BUILDLOC)/linux/$(GIN): $(SOURCES)
 	GOOS=linux GOARCH=amd64 go build -o $(BUILDLOC)/linux/$(GIN) $(LDFLAGS)
 
 $(BUILDLOC)/windows/$(GIN).exe: $(SOURCES)
-	GOOS=windows GOARCH=386 go build -o $(BUILDLOC)/windows/$(GIN) $(LDFLAGS)
+	GOOS=windows GOARCH=386 go build -o $(BUILDLOC)/windows/$(GIN).exe $(LDFLAGS)
 
 $(BUILDLOC)/darwin/$(GIN): $(SOURCES)
 	GOOS=darwin GOARCH=amd64 go build -o $(BUILDLOC)/darwin/$(GIN) $(LDFLAGS)

--- a/ginclient/log/log.go
+++ b/ginclient/log/log.go
@@ -35,8 +35,12 @@ func trim(file *os.File) {
 	if err != nil {
 		return
 	}
-	file.Truncate(0)
-	file.Write(contents)
+	// Close logfile, recreate (empty), and write the trimmed contents
+	file.Close()
+	file, err = os.Create(file.Name())
+	if err == nil {
+		file.Write(contents)
+	}
 }
 
 // Init initialises the log file and logger.

--- a/ginclient/log/log.go
+++ b/ginclient/log/log.go
@@ -25,16 +25,18 @@ func trim(file *os.File) {
 	if err != nil {
 		return
 	}
-	if filestat.Size() < loglimit {
+	fsize := filestat.Size()
+	if fsize < loglimit {
 		return
 	}
-	contents := make([]byte, filestat.Size())
-	nbytes, err := file.ReadAt(contents, 0)
+	contents := make([]byte, loglimit)
+	offset := fsize - loglimit
+	_, err = file.ReadAt(contents, offset)
 	if err != nil {
 		return
 	}
 	file.Truncate(0)
-	file.Write(contents[nbytes-loglimit : nbytes])
+	file.Write(contents)
 }
 
 // Init initialises the log file and logger.

--- a/ginclient/log/log.go
+++ b/ginclient/log/log.go
@@ -45,7 +45,7 @@ func trim(file *os.File) {
 
 // Init initialises the log file and logger.
 func Init(ver string) error {
-	cachepath, err := logpath(true)
+	cachepath, err := mklogdir(true)
 	if err != nil {
 		return err
 	}
@@ -64,8 +64,8 @@ func Init(ver string) error {
 	return nil
 }
 
-// logpath returns the path where gin cache files (logs) should be stored.
-func logpath(create bool) (string, error) {
+// mklogdir returns the path where gin cache files (logs) should be stored.
+func mklogdir(create bool) (string, error) {
 	var err error
 	logpath := os.Getenv("GIN_LOG_DIR")
 	if logpath == "" {


### PR DESCRIPTION
- Fixes log trimming on Windows by closing the file and recreating it.
- Reads in only the 1 MiB tail of the log file when trimming.