### PR TITLE
Eliminate the json flags of annex cmd for verbose flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ env:
   global:
     - GO111MODULE=on
 
+
+# Three builds:
+# - Build with latest stable Go and run tests
+# - Build with latest stable Go and run tests with the minimum supported version of Git-annex
+# - Build with Go 'tip' (devel version).  This is allowed to fail.  It's meant to catch upcoming build, lint, and vet errors early.
 matrix:
   include:
     - go: "1.11.x"

--- a/gincmd/commitcmd.go
+++ b/gincmd/commitcmd.go
@@ -72,7 +72,7 @@ func CommitCmd() *cobra.Command {
 		Run:                   commit,
 		DisableFlagsInUseLine: true,
 	}
-	cmd.Flags().Bool("json", false, "Print output in JSON format.")
-	cmd.Flags().Bool("verbose", false, "Print raw information from git and git-annex commands directly.")
+	cmd.Flags().Bool("json", false, jsonHelpMsg)
+	cmd.Flags().Bool("verbose", false, verboseHelpMsg)
 	return cmd
 }

--- a/gincmd/commitcmd.go
+++ b/gincmd/commitcmd.go
@@ -15,7 +15,7 @@ import (
 func commit(cmd *cobra.Command, args []string) {
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	jsonout, _ := cmd.Flags().GetBool("json")
-	checkVerboseJson(verbose, jsonout)
+	checkVerboseJSON(verbose, jsonout)
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
 	}

--- a/gincmd/commitcmd.go
+++ b/gincmd/commitcmd.go
@@ -13,9 +13,7 @@ import (
 )
 
 func commit(cmd *cobra.Command, args []string) {
-	verbose, _ := cmd.Flags().GetBool("verbose")
-	jsonout, _ := cmd.Flags().GetBool("json")
-	checkVerboseJSON(verbose, jsonout)
+	prStyle := determinePrintStyle(cmd)
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
 	}
@@ -23,9 +21,9 @@ func commit(cmd *cobra.Command, args []string) {
 	paths := args
 	addchan := make(chan git.RepoFileStatus)
 	go ginclient.Add(paths, addchan)
-	formatOutput(addchan, 0, jsonout, verbose)
+	formatOutput(addchan, prStyle, 0)
 
-	if !jsonout && !verbose {
+	if prStyle == psDefault {
 		fmt.Print(":: Recording changes ")
 	}
 	err := git.Commit(makeCommitMessage("commit", paths))
@@ -39,7 +37,7 @@ func commit(cmd *cobra.Command, args []string) {
 	} else {
 		stat = green("OK")
 	}
-	if !jsonout && !verbose {
+	if prStyle == psDefault {
 		fmt.Fprintln(color.Output, stat)
 	}
 }

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -247,42 +247,20 @@ func verboseOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[string
 	filesuccess = make(map[string]bool)
 	var ro string
 	var tmprawin, tmpfname string
-	type Act struct {
-		Command string `json:"command"`
-		Note    string `json:"note"`
-		Key     string `json:"key"`
-		File    string `json:"file"`
-	}
-	type Jsonout struct {
-		ByteProgress    int    `json:"byte-progress"`
-		Action          Act    `json:"action"`
-		TotalSize       int    `json:"total-size"`
-		PercentProgress string `json:"percent-progress"`
-		Success         bool   `json:"success"`
-	}
 	for stat := range statuschan {
-		if stat.FileName != tmpfname {
-			fmt.Printf("File: %v\n", stat.FileName)
-			tmpfname = stat.FileName
-		}
-
 		//Raw Input
 		if stat.RawInput != tmprawin {
 			fmt.Printf("Running Command: %v\n", stat.RawInput)
 			tmprawin = stat.RawInput
 		}
-		outline := []byte(stat.RawOutput)
-		if json.Valid(outline) {
-			var output Jsonout
-			_ = json.Unmarshal(outline, &output)
-			if !output.Success {
-				fmt.Printf("%s %s %s Progress:%d/%d(%s) FileKey:%s\r", output.Action.Command, output.Action.File, output.Action.Note,
-					output.ByteProgress, output.TotalSize, output.PercentProgress, output.Action.Key)
-			}
-		} else {
-			ro = stat.RawOutput
-			fmt.Printf("%s", ro)
+		//File Name
+		if stat.FileName != tmpfname {
+			fmt.Printf("File: %v\n", stat.FileName)
+			tmpfname = stat.FileName
 		}
+		//Raw Output
+		ro = stat.RawOutput
+		fmt.Printf("%s", ro)
 	}
 	fmt.Println()
 	return
@@ -308,6 +286,7 @@ func determinePrintStyle(cmd *cobra.Command) printstyle {
 	case verboseOn && jsonOn:
 		Die("--verbose and --json cannot be used together")
 	case verboseOn:
+		git.JsonBool = false
 		return psVerbose
 	case jsonOn:
 		return psJSON

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -230,9 +230,9 @@ func printProgressOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[
 	return
 }
 
-func checkVerboseJson(verbose bool, json bool) {
+func checkVerboseJSON(verbose bool, json bool) {
 	if verbose && json {
-		Die("Verbose flag and Json flag cannot be used together")
+		Die("--verbose and --json cannot be used together")
 	}
 }
 

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -18,7 +18,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const unknownhostname = "(unknown)"
+const (
+	unknownhostname = "(unknown)"
+	jsonHelpMsg     = "Print output in JSON format."
+	verboseHelpMsg  = "Print underlying git and git-annex calls and their unmodified output."
+)
 
 var (
 	green  = color.New(color.FgGreen).SprintFunc()

--- a/gincmd/downloadcmd.go
+++ b/gincmd/downloadcmd.go
@@ -15,7 +15,7 @@ import (
 func download(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
 	verbose, _ := cmd.Flags().GetBool("verbose")
-	checkVerboseJson(verbose, jsonout)
+	checkVerboseJSON(verbose, jsonout)
 	// TODO: no client necessary? Just use remotes
 	conf := config.Read()
 	gincl := ginclient.New(conf.DefaultServer)

--- a/gincmd/downloadcmd.go
+++ b/gincmd/downloadcmd.go
@@ -54,8 +54,8 @@ func DownloadCmd() *cobra.Command {
 		Run:                   download,
 		DisableFlagsInUseLine: true,
 	}
-	cmd.Flags().Bool("json", false, "Print output in JSON format.")
-	cmd.Flags().Bool("verbose", false, "Print raw information from git and git-annex commands directly.")
+	cmd.Flags().Bool("json", false, jsonHelpMsg)
+	cmd.Flags().Bool("verbose", false, verboseHelpMsg)
 	cmd.Flags().Bool("content", false, "Download the content for all files in the repository.")
 	return cmd
 }

--- a/gincmd/getcmd.go
+++ b/gincmd/getcmd.go
@@ -15,18 +15,15 @@ func isValidRepoPath(path string) bool {
 }
 
 func getRepo(cmd *cobra.Command, args []string) {
-	flags := cmd.Flags() //  change this to make it consistent with other cmd
-	verbose, _ := flags.GetBool("verbose")
-	jsonout, _ := flags.GetBool("json")
-	checkVerboseJSON(verbose, jsonout)
-	srvalias, _ := flags.GetString("server")
+	prStyle := determinePrintStyle(cmd)
+	srvalias, _ := cmd.Flags().GetString("server")
 	conf := config.Read()
 	if srvalias == "" {
 		srvalias = conf.DefaultServer
 	}
 	repostr := args[0]
 	gincl := ginclient.New(srvalias)
-	requirelogin(cmd, gincl, !jsonout)
+	requirelogin(cmd, gincl, prStyle != psJSON)
 
 	if !isValidRepoPath(repostr) {
 		Die(fmt.Sprintf("Invalid repository path '%s'. Full repository name should be the owner's username followed by the repository name, separated by a '/'.\nType 'gin help get' for information and examples.", repostr))
@@ -34,7 +31,7 @@ func getRepo(cmd *cobra.Command, args []string) {
 
 	clonechan := make(chan git.RepoFileStatus)
 	go gincl.CloneRepo(repostr, clonechan)
-	formatOutput(clonechan, 0, jsonout, verbose)
+	formatOutput(clonechan, prStyle, 0)
 	defaultRemoteIfUnset("origin")
 	new, err := ginclient.CommitIfNew()
 	if new {

--- a/gincmd/getcmd.go
+++ b/gincmd/getcmd.go
@@ -67,8 +67,8 @@ func GetCmd() *cobra.Command {
 		Run:                   getRepo,
 		DisableFlagsInUseLine: true,
 	}
-	cmd.Flags().Bool("json", false, "Print output in JSON format.")
-	cmd.Flags().Bool("verbose", false, "Print raw information from git and git-annex commands directly.")
+	cmd.Flags().Bool("json", false, jsonHelpMsg)
+	cmd.Flags().Bool("verbose", false, verboseHelpMsg)
 	cmd.Flags().String("server", "", "Specify server `alias` for the repository. See also 'gin servers'.")
 	return cmd
 }

--- a/gincmd/getcmd.go
+++ b/gincmd/getcmd.go
@@ -18,7 +18,7 @@ func getRepo(cmd *cobra.Command, args []string) {
 	flags := cmd.Flags() //  change this to make it consistent with other cmd
 	verbose, _ := flags.GetBool("verbose")
 	jsonout, _ := flags.GetBool("json")
-	checkVerboseJson(verbose, jsonout)
+	checkVerboseJSON(verbose, jsonout)
 	srvalias, _ := flags.GetString("server")
 	conf := config.Read()
 	if srvalias == "" {

--- a/gincmd/getcontentcmd.go
+++ b/gincmd/getcontentcmd.go
@@ -9,20 +9,18 @@ import (
 )
 
 func getContent(cmd *cobra.Command, args []string) {
-	verbose, _ := cmd.Flags().GetBool("verbose")
-	jsonout, _ := cmd.Flags().GetBool("json")
-	checkVerboseJSON(verbose, jsonout)
+	prStyle := determinePrintStyle(cmd)
 	conf := config.Read()
 	// TODO: no need for client; use remotes (and all keys?)
 	gincl := ginclient.New(conf.DefaultServer)
-	requirelogin(cmd, gincl, !jsonout)
+	requirelogin(cmd, gincl, prStyle != psJSON)
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
 	}
 
 	getcchan := make(chan git.RepoFileStatus)
 	go gincl.GetContent(args, getcchan)
-	formatOutput(getcchan, 0, jsonout, verbose)
+	formatOutput(getcchan, prStyle, 0)
 }
 
 // GetContentCmd sets up the 'get-content' subcommand

--- a/gincmd/getcontentcmd.go
+++ b/gincmd/getcontentcmd.go
@@ -40,7 +40,7 @@ func GetContentCmd() *cobra.Command {
 		Aliases:               []string{"getc"},
 		DisableFlagsInUseLine: true,
 	}
-	cmd.Flags().Bool("json", false, "Print raw information from git and git-annex commands directly.")
+	cmd.Flags().Bool("json", false, "Print output in JSON format.")
 	cmd.Flags().Bool("verbose", false, "Print raw information from git and git-annex commands directly.")
 	return cmd
 }

--- a/gincmd/getcontentcmd.go
+++ b/gincmd/getcontentcmd.go
@@ -11,7 +11,7 @@ import (
 func getContent(cmd *cobra.Command, args []string) {
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	jsonout, _ := cmd.Flags().GetBool("json")
-	checkVerboseJson(verbose, jsonout)
+	checkVerboseJSON(verbose, jsonout)
 	conf := config.Read()
 	// TODO: no need for client; use remotes (and all keys?)
 	gincl := ginclient.New(conf.DefaultServer)

--- a/gincmd/getcontentcmd.go
+++ b/gincmd/getcontentcmd.go
@@ -40,7 +40,7 @@ func GetContentCmd() *cobra.Command {
 		Aliases:               []string{"getc"},
 		DisableFlagsInUseLine: true,
 	}
-	cmd.Flags().Bool("json", false, "Print output in JSON format.")
-	cmd.Flags().Bool("verbose", false, "Print raw information from git and git-annex commands directly.")
+	cmd.Flags().Bool("json", false, jsonHelpMsg)
+	cmd.Flags().Bool("verbose", false, verboseHelpMsg)
 	return cmd
 }

--- a/gincmd/lockcmd.go
+++ b/gincmd/lockcmd.go
@@ -20,9 +20,7 @@ func countItemsLock(paths []string) (count int) {
 }
 
 func lock(cmd *cobra.Command, args []string) {
-	verbose, _ := cmd.Flags().GetBool("verbose")
-	jsonout, _ := cmd.Flags().GetBool("json")
-	checkVerboseJSON(verbose, jsonout)
+	prStyle := determinePrintStyle(cmd)
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
 	}
@@ -37,7 +35,7 @@ func lock(cmd *cobra.Command, args []string) {
 	lockchan := make(chan git.RepoFileStatus)
 
 	go gincl.LockContent(args, lockchan)
-	formatOutput(lockchan, nitems, jsonout, verbose)
+	formatOutput(lockchan, prStyle, nitems)
 }
 
 // LockCmd sets up the file 'lock' subcommand

--- a/gincmd/lockcmd.go
+++ b/gincmd/lockcmd.go
@@ -54,7 +54,7 @@ func LockCmd() *cobra.Command {
 		Run:                   lock,
 		DisableFlagsInUseLine: true,
 	}
-	cmd.Flags().Bool("json", false, "Print output in JSON format.")
-	cmd.Flags().Bool("verbose", false, "Print raw information from git and git-annex commands directly.")
+	cmd.Flags().Bool("json", false, jsonHelpMsg)
+	cmd.Flags().Bool("verbose", false, verboseHelpMsg)
 	return cmd
 }

--- a/gincmd/lockcmd.go
+++ b/gincmd/lockcmd.go
@@ -22,7 +22,7 @@ func countItemsLock(paths []string) (count int) {
 func lock(cmd *cobra.Command, args []string) {
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	jsonout, _ := cmd.Flags().GetBool("json")
-	checkVerboseJson(verbose, jsonout)
+	checkVerboseJSON(verbose, jsonout)
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
 	}

--- a/gincmd/removecontentcmd.go
+++ b/gincmd/removecontentcmd.go
@@ -19,7 +19,7 @@ func countItemsRemove(paths []string) int {
 func remove(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
 	verbose, _ := cmd.Flags().GetBool("verbose")
-	checkVerboseJson(verbose, jsonout)
+	checkVerboseJSON(verbose, jsonout)
 	// TODO: Need server config? just use remotes (and all keys)
 	conf := config.Read()
 	gincl := ginclient.New(conf.DefaultServer)

--- a/gincmd/removecontentcmd.go
+++ b/gincmd/removecontentcmd.go
@@ -49,7 +49,7 @@ func RemoveContentCmd() *cobra.Command {
 		Aliases:               []string{"rmc"},
 		DisableFlagsInUseLine: true,
 	}
-	cmd.Flags().Bool("json", false, "Print output in JSON format.")
-	cmd.Flags().Bool("verbose", false, "Print raw information from git and git-annex commands directly.")
+	cmd.Flags().Bool("json", false, jsonHelpMsg)
+	cmd.Flags().Bool("verbose", false, verboseHelpMsg)
 	return cmd
 }

--- a/gincmd/removecontentcmd.go
+++ b/gincmd/removecontentcmd.go
@@ -17,13 +17,11 @@ func countItemsRemove(paths []string) int {
 }
 
 func remove(cmd *cobra.Command, args []string) {
-	jsonout, _ := cmd.Flags().GetBool("json")
-	verbose, _ := cmd.Flags().GetBool("verbose")
-	checkVerboseJSON(verbose, jsonout)
+	prStyle := determinePrintStyle(cmd)
 	// TODO: Need server config? just use remotes (and all keys)
 	conf := config.Read()
 	gincl := ginclient.New(conf.DefaultServer)
-	requirelogin(cmd, gincl, !jsonout)
+	requirelogin(cmd, gincl, prStyle != psJSON)
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
 	}
@@ -31,7 +29,7 @@ func remove(cmd *cobra.Command, args []string) {
 	nitems := countItemsRemove(args)
 	rmchan := make(chan git.RepoFileStatus)
 	go gincl.RemoveContent(args, rmchan)
-	formatOutput(rmchan, nitems, jsonout, verbose)
+	formatOutput(rmchan, prStyle, nitems)
 }
 
 // RemoveContentCmd sets up the 'remove-content' subcommand

--- a/gincmd/unlockcmd.go
+++ b/gincmd/unlockcmd.go
@@ -20,7 +20,7 @@ func countItemsUnlock(paths []string) (count int) {
 func unlock(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
 	verbose, _ := cmd.Flags().GetBool("verbose")
-	checkVerboseJson(verbose, jsonout)
+	checkVerboseJSON(verbose, jsonout)
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
 	}

--- a/gincmd/unlockcmd.go
+++ b/gincmd/unlockcmd.go
@@ -53,7 +53,7 @@ func UnlockCmd() *cobra.Command {
 		Run:                   unlock,
 		DisableFlagsInUseLine: true,
 	}
-	cmd.Flags().Bool("json", false, "Print output in JSON format.")
-	cmd.Flags().Bool("verbose", false, "Print raw information from git and git-annex commands directly.")
+	cmd.Flags().Bool("json", false, jsonHelpMsg)
+	cmd.Flags().Bool("verbose", false, verboseHelpMsg)
 	return cmd
 }

--- a/gincmd/unlockcmd.go
+++ b/gincmd/unlockcmd.go
@@ -18,9 +18,7 @@ func countItemsUnlock(paths []string) (count int) {
 }
 
 func unlock(cmd *cobra.Command, args []string) {
-	jsonout, _ := cmd.Flags().GetBool("json")
-	verbose, _ := cmd.Flags().GetBool("verbose")
-	checkVerboseJSON(verbose, jsonout)
+	prStyle := determinePrintStyle(cmd)
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
 	}
@@ -36,7 +34,7 @@ func unlock(cmd *cobra.Command, args []string) {
 	nitems := countItemsUnlock(args)
 	unlockchan := make(chan git.RepoFileStatus)
 	go gincl.UnlockContent(args, unlockchan)
-	formatOutput(unlockchan, nitems, jsonout, verbose)
+	formatOutput(unlockchan, prStyle, nitems)
 }
 
 // UnlockCmd sets up the file 'unlock' subcommand

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -10,10 +10,8 @@ import (
 )
 
 func upload(cmd *cobra.Command, args []string) {
-	jsonout, _ := cmd.Flags().GetBool("json")
-	verbose, _ := cmd.Flags().GetBool("verbose")
+	prStyle := determinePrintStyle(cmd)
 	remotes, _ := cmd.Flags().GetStringSlice("to")
-	checkVerboseJSON(verbose, jsonout)
 	gincl := ginclient.New("gin") // TODO: probably doesn't need a client
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
@@ -43,7 +41,7 @@ func upload(cmd *cobra.Command, args []string) {
 
 	uploadchan := make(chan git.RepoFileStatus)
 	go gincl.Upload(paths, remotes, uploadchan)
-	formatOutput(uploadchan, 0, jsonout, verbose)
+	formatOutput(uploadchan, prStyle, 0)
 }
 
 // UploadCmd sets up the 'upload' subcommand

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -13,7 +13,7 @@ func upload(cmd *cobra.Command, args []string) {
 	jsonout, _ := cmd.Flags().GetBool("json")
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	remotes, _ := cmd.Flags().GetStringSlice("to")
-	checkVerboseJson(verbose, jsonout)
+	checkVerboseJSON(verbose, jsonout)
 	gincl := ginclient.New("gin") // TODO: probably doesn't need a client
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -70,8 +70,8 @@ If no arguments are specified, only changes to files already being tracked are u
 		Run:                   upload,
 		DisableFlagsInUseLine: true,
 	}
-	cmd.Flags().Bool("json", false, "Print output in JSON format.")
-	cmd.Flags().Bool("verbose", false, "Print raw information from git and git-annex commands directly.")
+	cmd.Flags().Bool("json", false, jsonHelpMsg)
+	cmd.Flags().Bool("verbose", false, verboseHelpMsg)
 	cmd.Flags().StringSliceP("to", "t", nil, "Upload to specific `remote`. Supports multiple remotes, either by specifying multiple times or as a comma separated list (see Examples). If the keyword 'all' is specified, the data is uploaded to all configured remotes.")
 	return cmd
 }

--- a/gincmd/versioncmd.go
+++ b/gincmd/versioncmd.go
@@ -147,7 +147,7 @@ func VersionCmd() *cobra.Command {
 		Run:                   repoversion,
 		DisableFlagsInUseLine: true,
 	}
-	cmd.Flags().Bool("json", false, "Print output in JSON format.")
+	cmd.Flags().Bool("json", false, jsonHelpMsg)
 	cmd.Flags().UintP("max-count", "n", 10, "Maximum `number` of versions to display before prompting. 0 means 'all'.")
 	cmd.Flags().String("id", "", "Commit `ID` (hash) to return to.")
 	cmd.Flags().String("copy-to", "", "Retrieve files from history and copy them to a new `location` instead of overwriting the existing ones. The new files will be placed in the directory specified and will be renamed to include the date and time of their version.")

--- a/git/git.go
+++ b/git/git.go
@@ -42,7 +42,7 @@ type RepoFileStatus struct {
 	// original command output
 	RawOutput string `json:"rawoutput"`
 	// Errors
-	Err error `json:"err"`
+	Err error
 }
 
 // TODO: Create structs to accommodate extra information for other operations
@@ -81,11 +81,11 @@ func (s RepoFileStatus) MarshalJSON() ([]byte, error) {
 		errmsg = s.Err.Error()
 	}
 	return json.Marshal(struct {
-		RFSAlias
 		Err string `json:"err"`
+		RFSAlias
 	}{
-		RFSAlias: RFSAlias(s),
 		Err:      errmsg,
+		RFSAlias: RFSAlias(s),
 	})
 }
 


### PR DESCRIPTION
This PR is based on achilleas's verbose-flag-tweaks branch. 

My 2 commits are majorly changing the annex-json prints. Now using a Global Boolean, the --json flag in annex command is replaced. Normal output is printed.

I am thinking we should add also the RawInput and RawOutput field for AnnexWhereisRes or AnnexStatusRes.