### PR TITLE
More consistent file operation messages

### DIFF
--- a/gincmd/commitcmd.go
+++ b/gincmd/commitcmd.go
@@ -19,9 +19,11 @@ func commit(cmd *cobra.Command, args []string) {
 	}
 
 	paths := args
-	addchan := make(chan git.RepoFileStatus)
-	go ginclient.Add(paths, addchan)
-	formatOutput(addchan, prStyle, 0)
+	if len(paths) > 0 {
+		addchan := make(chan git.RepoFileStatus)
+		go ginclient.Add(paths, addchan)
+		formatOutput(addchan, prStyle, 0)
+	}
 
 	if prStyle == psDefault {
 		fmt.Print(":: Recording changes ")

--- a/gincmd/commitcmd.go
+++ b/gincmd/commitcmd.go
@@ -20,6 +20,9 @@ func commit(cmd *cobra.Command, args []string) {
 
 	paths := args
 	if len(paths) > 0 {
+		if prStyle == psDefault {
+			fmt.Println(":: Adding file changes")
+		}
 		addchan := make(chan git.RepoFileStatus)
 		go ginclient.Add(paths, addchan)
 		formatOutput(addchan, prStyle, 0)
@@ -32,7 +35,7 @@ func commit(cmd *cobra.Command, args []string) {
 	var stat string
 	if err != nil {
 		if err.Error() == "Nothing to commit" {
-			stat = "N/A\n:: No changes recorded"
+			stat = "\n   No changes recorded"
 		} else {
 			Die(err)
 		}

--- a/gincmd/commitcmd.go
+++ b/gincmd/commitcmd.go
@@ -76,6 +76,6 @@ func CommitCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, jsonHelpMsg)
-	cmd.Flags().Bool("verbose", false, verboseHelpMsg)
+	// cmd.Flags().Bool("verbose", false, verboseHelpMsg)
 	return cmd
 }

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -161,6 +161,7 @@ func printProgressWithBar(statuschan <-chan git.RepoFileStatus, nitems int) (fil
 			outline.WriteString(" ")
 		}
 	}
+	printed := false
 	for stat := range statuschan {
 		ncomplt++
 		outline.Reset()
@@ -184,6 +185,10 @@ func printProgressWithBar(statuschan <-chan git.RepoFileStatus, nitems int) (fil
 		blanks := strings.Repeat(" ", barwidth-complsigns)
 		dprg := fmt.Sprintf(dfmt, ncomplt, nitems)
 		fmt.Printf("\n [%s%s] %s\r", blocks, blanks, dprg)
+		printed = true
+	}
+	if !printed {
+		fmt.Println("   Nothing to do")
 	}
 	if outline.Len() > 0 {
 		fmt.Println()
@@ -202,6 +207,8 @@ func printProgressOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[
 			outline.WriteString(" ")
 		}
 	}
+
+	printed := false
 	for stat := range statuschan {
 		outline.Reset()
 		outline.WriteString(" ")
@@ -235,7 +242,11 @@ func printProgressOutput(statuschan <-chan git.RepoFileStatus) (filesuccess map[
 			fmt.Fprint(color.Output, newprint)
 			fmt.Print("\r")
 			lastprint = newprint
+			printed = true
 		}
+	}
+	if !printed {
+		fmt.Println("   Nothing to do")
 	}
 	if len(lastprint) > 0 {
 		fmt.Println()

--- a/gincmd/downloadcmd.go
+++ b/gincmd/downloadcmd.go
@@ -23,9 +23,6 @@ func download(cmd *cobra.Command, args []string) {
 	}
 
 	content, _ := cmd.Flags().GetBool("content")
-	lockchan := make(chan git.RepoFileStatus)
-	go gincl.LockContent([]string{}, lockchan)
-	formatOutput(lockchan, prStyle, 0)
 	if prStyle == psDefault {
 		fmt.Print(":: Downloading changes ")
 	}

--- a/gincmd/downloadcmd.go
+++ b/gincmd/downloadcmd.go
@@ -50,7 +50,7 @@ func DownloadCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, jsonHelpMsg)
-	cmd.Flags().Bool("verbose", false, verboseHelpMsg)
+	// cmd.Flags().Bool("verbose", false, verboseHelpMsg)
 	cmd.Flags().Bool("content", false, "Download the content for all files in the repository.")
 	return cmd
 }

--- a/gincmd/downloadcmd.go
+++ b/gincmd/downloadcmd.go
@@ -27,7 +27,7 @@ func download(cmd *cobra.Command, args []string) {
 	go gincl.LockContent([]string{}, lockchan)
 	formatOutput(lockchan, prStyle, 0)
 	if prStyle == psDefault {
-		fmt.Print("Downloading changes ")
+		fmt.Print(":: Downloading changes ")
 	}
 	err := gincl.Download()
 	CheckError(err)

--- a/gincmd/getcmd.go
+++ b/gincmd/getcmd.go
@@ -65,7 +65,7 @@ func GetCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, jsonHelpMsg)
-	cmd.Flags().Bool("verbose", false, verboseHelpMsg)
+	// cmd.Flags().Bool("verbose", false, verboseHelpMsg)
 	cmd.Flags().String("server", "", "Specify server `alias` for the repository. See also 'gin servers'.")
 	return cmd
 }

--- a/gincmd/getcontentcmd.go
+++ b/gincmd/getcontentcmd.go
@@ -44,6 +44,6 @@ func GetContentCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, jsonHelpMsg)
-	cmd.Flags().Bool("verbose", false, verboseHelpMsg)
+	// cmd.Flags().Bool("verbose", false, verboseHelpMsg)
 	return cmd
 }

--- a/gincmd/getcontentcmd.go
+++ b/gincmd/getcontentcmd.go
@@ -1,6 +1,8 @@
 package gincmd
 
 import (
+	"fmt"
+
 	ginclient "github.com/G-Node/gin-cli/ginclient"
 	"github.com/G-Node/gin-cli/ginclient/config"
 	"github.com/G-Node/gin-cli/gincmd/ginerrors"
@@ -18,6 +20,9 @@ func getContent(cmd *cobra.Command, args []string) {
 		Die(ginerrors.NotInRepo)
 	}
 
+	if prStyle == psDefault {
+		fmt.Println(":: Downloading file content")
+	}
 	getcchan := make(chan git.RepoFileStatus)
 	go gincl.GetContent(args, getcchan)
 	formatOutput(getcchan, prStyle, 0)

--- a/gincmd/helptemplate.go
+++ b/gincmd/helptemplate.go
@@ -13,17 +13,16 @@ func wrappedFlagUsages(cmd *cobra.Command) string {
 	return cmd.Flags().FlagUsagesWrapped(width - 1)
 }
 
-var helpTemplate = `Usage:
+var helpTemplate = `{{.UsageString}}`
+var usageTemplate = `Usage:
 
   {{if .HasAvailableSubCommands}}{{.CommandPath}} [command]{{else}}{{.UseLine}}{{end}}
 
-{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
-
-var usageTemplate = `{{if gt (len .Aliases) 0}}
+{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}{{end}}{{if gt (len .Aliases) 0}}
 
 Aliases:
 
-  {{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}
+{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}
 
 Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}

--- a/gincmd/lockcmd.go
+++ b/gincmd/lockcmd.go
@@ -45,10 +45,10 @@ func LockCmd() *cobra.Command {
 		"<filenames>": "One or more directories or files to lock.",
 	}
 	var cmd = &cobra.Command{
-		Use:                   "lock [--json | --verbose] [<filenames>]...",
+		Use:                   "lock [--json | --verbose] <filenames>...",
 		Short:                 "Lock files",
 		Long:                  formatdesc(description, args),
-		Args:                  cobra.ArbitraryArgs,
+		Args:                  cobra.MinimumNArgs(1),
 		Run:                   lock,
 		DisableFlagsInUseLine: true,
 	}

--- a/gincmd/lockcmd.go
+++ b/gincmd/lockcmd.go
@@ -1,6 +1,8 @@
 package gincmd
 
 import (
+	"fmt"
+
 	"github.com/G-Node/gin-cli/ginclient"
 	"github.com/G-Node/gin-cli/ginclient/config"
 	"github.com/G-Node/gin-cli/gincmd/ginerrors"
@@ -24,8 +26,12 @@ func lock(cmd *cobra.Command, args []string) {
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
 	}
+	if prStyle != psJSON {
+		fmt.Println(":: Locking files")
+	}
 	// lock should do nothing in direct mode
 	if git.IsDirect() {
+		fmt.Print("   Repository is in DIRECT mode: files are always unlocked")
 		return
 	}
 	// TODO: need server config? Just use remotes

--- a/gincmd/lockcmd.go
+++ b/gincmd/lockcmd.go
@@ -59,6 +59,6 @@ func LockCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, jsonHelpMsg)
-	cmd.Flags().Bool("verbose", false, verboseHelpMsg)
+	// cmd.Flags().Bool("verbose", false, verboseHelpMsg)
 	return cmd
 }

--- a/gincmd/removecontentcmd.go
+++ b/gincmd/removecontentcmd.go
@@ -1,6 +1,8 @@
 package gincmd
 
 import (
+	"fmt"
+
 	ginclient "github.com/G-Node/gin-cli/ginclient"
 	"github.com/G-Node/gin-cli/ginclient/config"
 	"github.com/G-Node/gin-cli/gincmd/ginerrors"
@@ -28,6 +30,9 @@ func remove(cmd *cobra.Command, args []string) {
 	lock(cmd, args)
 	nitems := countItemsRemove(args)
 	rmchan := make(chan git.RepoFileStatus)
+	if prStyle == psProgress {
+		fmt.Println(":: Removing file content")
+	}
 	go gincl.RemoveContent(args, rmchan)
 	formatOutput(rmchan, prStyle, nitems)
 }

--- a/gincmd/removecontentcmd.go
+++ b/gincmd/removecontentcmd.go
@@ -53,6 +53,6 @@ func RemoveContentCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, jsonHelpMsg)
-	cmd.Flags().Bool("verbose", false, verboseHelpMsg)
+	// cmd.Flags().Bool("verbose", false, verboseHelpMsg)
 	return cmd
 }

--- a/gincmd/unlockcmd.go
+++ b/gincmd/unlockcmd.go
@@ -59,6 +59,6 @@ func UnlockCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, jsonHelpMsg)
-	cmd.Flags().Bool("verbose", false, verboseHelpMsg)
+	// cmd.Flags().Bool("verbose", false, verboseHelpMsg)
 	return cmd
 }

--- a/gincmd/unlockcmd.go
+++ b/gincmd/unlockcmd.go
@@ -48,7 +48,7 @@ func unlock(cmd *cobra.Command, args []string) {
 func UnlockCmd() *cobra.Command {
 	description := "Unlock one or more files for editing. Files added to the repository are left in a locked state, which allows reading but prevents editing. In order to edit or write to a file, it must first be unlocked. When done editing, it is recommended that the file be locked again using the 'lock' command.\n\nAfter performing an 'upload, 'download', or 'get', affected files are always reverted to the locked state.\n\nUnlocking a file takes longer depending on its size."
 	args := map[string]string{
-		"<filenames>": "One or more directories or files to unllock.",
+		"<filenames>": "One or more directories or files to unlock.",
 	}
 	var cmd = &cobra.Command{
 		Use:                   "unlock [--json | --verbose] <filenames>...",

--- a/gincmd/unlockcmd.go
+++ b/gincmd/unlockcmd.go
@@ -1,6 +1,8 @@
 package gincmd
 
 import (
+	"fmt"
+
 	ginclient "github.com/G-Node/gin-cli/ginclient"
 	"github.com/G-Node/gin-cli/ginclient/config"
 	"github.com/G-Node/gin-cli/gincmd/ginerrors"
@@ -22,8 +24,13 @@ func unlock(cmd *cobra.Command, args []string) {
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
 	}
+
+	if prStyle != psJSON {
+		fmt.Println(":: Unlocking files")
+	}
 	// unlock should do nothing in direct mode
 	if git.IsDirect() {
+		fmt.Print("   Repository is in DIRECT mode: files are always unlocked")
 		return
 	}
 

--- a/gincmd/unlockcmd.go
+++ b/gincmd/unlockcmd.go
@@ -44,10 +44,10 @@ func UnlockCmd() *cobra.Command {
 		"<filenames>": "One or more directories or files to unllock.",
 	}
 	var cmd = &cobra.Command{
-		Use:                   "unlock [--json | --verbose] [<filenames>]...",
+		Use:                   "unlock [--json | --verbose] <filenames>...",
 		Short:                 "Unlock files for editing",
 		Long:                  formatdesc(description, args),
-		Args:                  cobra.ArbitraryArgs,
+		Args:                  cobra.MinimumNArgs(1),
 		Run:                   unlock,
 		DisableFlagsInUseLine: true,
 	}

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -74,7 +74,7 @@ If no arguments are specified, only changes to files already being tracked are u
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, jsonHelpMsg)
-	cmd.Flags().Bool("verbose", false, verboseHelpMsg)
+	// cmd.Flags().Bool("verbose", false, verboseHelpMsg)
 	cmd.Flags().StringSliceP("to", "t", nil, "Upload to specific `remote`. Supports multiple remotes, either by specifying multiple times or as a comma separated list (see Examples). If the keyword 'all' is specified, the data is uploaded to all configured remotes.")
 	return cmd
 }

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -34,9 +34,14 @@ func upload(cmd *cobra.Command, args []string) {
 			break
 		}
 	}
+
 	paths := args
 	if len(paths) > 0 {
 		commit(cmd, paths)
+	}
+
+	if prStyle != psJSON {
+		fmt.Println(":: Uploading")
 	}
 
 	uploadchan := make(chan git.RepoFileStatus)

--- a/git/git.go
+++ b/git/git.go
@@ -518,7 +518,7 @@ func Commit(commitmsg string) error {
 
 	if err != nil {
 		sstdout := string(stdout)
-		if strings.Contains(sstdout, "nothing to commit") || strings.Contains(sstdout, "nothing added to commit") {
+		if strings.Contains(sstdout, "nothing to commit") || strings.Contains(sstdout, "nothing added to commit") || strings.Contains(sstdout, "no changes added to commit") {
 			// Return special error
 			log.Write("Nothing to commit")
 			return fmt.Errorf("Nothing to commit")


### PR DESCRIPTION
All file operations are announced before they are executed.  These operations are add, commit, get-content, remove-content, lock, unlock, and upload.  If no file is affected by the operation, the message "Nothing to do" is printed.   In direct mode, the lock and unlock commands inform the user that files are always in an unlocked state.

None of these changes affect the JSON output.  No-ops still do not print anything when JSON output is requested.

Additional changes:
- The lock and unlock commands now require at least one path argument.  Previously, a blank argument list (i.e., `gin unlock` and `gin lock`) would behave identically to `gin unlock .` and `gin lock .` (where `.` = all files under current working directory). `gin unlock` and `gin lock` with no arguments are now errors and will print the command usage.
- Download no longer locks all files.  The download command would previous lock every unlocked file in the repository.  This is no longer the case.  If a file has been replaced or updated on the server and it is currently unlocked, the behaviour is the same as a pull merge conflict.  In other words, the user will be informed that a local file will be overwritten by the download.

Closes #246 