### PR TITLE
Support custom commit messages

### DIFF
--- a/gincmd/commitcmd.go
+++ b/gincmd/commitcmd.go
@@ -18,6 +18,8 @@ func commit(cmd *cobra.Command, args []string) {
 		Die(ginerrors.NotInRepo)
 	}
 
+	commitmsg, _ := cmd.Flags().GetString("message")
+
 	// TODO: Exit with error if a path argument is neither a file known to git nor a file in the working tree
 	paths := args
 	if len(paths) > 0 {
@@ -32,7 +34,10 @@ func commit(cmd *cobra.Command, args []string) {
 	if prStyle == psDefault {
 		fmt.Print(":: Recording changes ")
 	}
-	err := git.Commit(makeCommitMessage("commit", paths))
+	if commitmsg == "" {
+		commitmsg = makeCommitMessage("commit", paths)
+	}
+	err := git.Commit(commitmsg)
 	var stat string
 	if err != nil {
 		if err.Error() == "Nothing to commit" {
@@ -69,7 +74,7 @@ func CommitCmd() *cobra.Command {
 	description := "Record changes made in a local repository. This command must be called from within the local repository clone. Specific files or directories may be specified. All changes made to the files and directories that are specified will be recorded, including addition of new files, modifications and renaming of existing files, and file deletions.\n\nIf no arguments are specified, no changes are recorded."
 	args := map[string]string{"<filenames>": "One or more directories or files to commit."}
 	var cmd = &cobra.Command{
-		Use:                   "commit [--json | --verbose] [<filenames>]...",
+		Use:                   "commit [--json | --verbose] [--message message] [<filenames>]...",
 		Short:                 "Record changes in local repository",
 		Long:                  formatdesc(description, args),
 		Args:                  cobra.ArbitraryArgs,
@@ -77,6 +82,7 @@ func CommitCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().Bool("json", false, jsonHelpMsg)
+	cmd.Flags().StringP("message", "m", "", "Commit message")
 	// cmd.Flags().Bool("verbose", false, verboseHelpMsg)
 	return cmd
 }


### PR DESCRIPTION
New commit flag "message" (or "m" for short form) can be used to set a custom commit message.

The automatic commit message includes a summary of the changes being committed (files added, removed, modified).  If this new flag is used, only the commit message specified is added.  Do you think it should add the summary as the message body?

I'm also considering going back to listing the files that were affected.  It used to do this, but I removed it thinking it might be an issue when the file list is too large.  This doesn't seem to be a common phenomenon and even in that case, we could print the filenames affected up to a certain number (or text length).