### PR TITLE
Changes to 'gin version' command behaviour

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ test_script:
   - xcopy /e /s /y /i %SRCDIR%\tests\conf %GIN_CONFIG_DIR%
   - go test -v ./...
   - cd %SRCDIR%\tests
-  - python -m pytest -v -k "directory or offline"
+  - python -m pytest -v -m "offline"
 
 # to disable deployment
 deploy: off
@@ -69,4 +69,4 @@ deploy: off
 on_finish:
   - appveyor PushArtifact %GIN_LOG_DIR%\gin.log
 # Uncomment next line to enable RDP
-#   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+# - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/ginclient/repos.go
+++ b/ginclient/repos.go
@@ -510,7 +510,12 @@ func RemoveRemote(remote string) error {
 
 // CheckoutVersion checks out all files specified by paths from the revision with the specified commithash.
 func CheckoutVersion(commithash string, paths []string) error {
-	return git.Checkout(commithash, paths)
+	err := git.Checkout(commithash, paths)
+	if err != nil {
+		return err
+	}
+
+	return git.AnnexFsck(paths)
 }
 
 // CheckoutFileCopies checks out copies of files specified by path from the revision with the specified commithash.

--- a/ginclient/repos.go
+++ b/ginclient/repos.go
@@ -558,9 +558,15 @@ func CheckoutFileCopies(commithash string, paths []string, outpath string, suffi
 				// strip any newlines from the end of the path
 				keypath := strings.TrimSpace(string(content))
 				_, key := path.Split(keypath)
-				fkerr := git.AnnexFromKey(key, outfile)
-				if fkerr != nil {
-					status.Err = fmt.Errorf("Error creating placeholder file %s: %s", outfile, fkerr.Error())
+				contentloc, err := git.AnnexContentLocation(key)
+				if err != nil {
+					status.Err = fmt.Errorf("Annexed content is not available locally")
+					cochan <- status
+					continue
+				}
+				err = git.CopyFile(contentloc, outfile)
+				if err != nil {
+					status.Err = fmt.Errorf("Error writing %s: %s", outfile, err.Error())
 				}
 			} else if obj.Mode == "120000" {
 				// Plain symlink

--- a/gincmd/addremotecmd.go
+++ b/gincmd/addremotecmd.go
@@ -78,12 +78,12 @@ func parseRemote(remotestr string) remote {
 
 func checkRemote(cmd *cobra.Command, url string) (err error) {
 	// Check if the remote is accessible
-	fmt.Print(":: Checking remote ")
+	fmt.Print(":: Checking remote: ")
 	if _, err = git.LsRemote(url); err == nil {
 		fmt.Fprintln(color.Output, green("OK"))
 		return nil
 	}
-	fmt.Fprintln(color.Output, red("FAILED"))
+	fmt.Println("not found")
 	return err
 }
 

--- a/gincmd/versioncmd.go
+++ b/gincmd/versioncmd.go
@@ -54,7 +54,7 @@ func repoversion(cmd *cobra.Command, args []string) {
 
 func checkoutcopies(commit git.GinCommit, paths []string, destination string) {
 	hash := commit.AbbreviatedHash
-	isodate := commit.Date.Format("2006-01-02-1504")
+	isodate := commit.Date.Format("2006-01-02-150405")
 	prettydate := commit.Date.Format("Jan 2 15:04:05 2006 (-0700)")
 	checkoutchan := make(chan ginclient.FileCheckoutStatus)
 	go ginclient.CheckoutFileCopies(hash, paths, destination, isodate, checkoutchan)

--- a/git/annex.go
+++ b/git/annex.go
@@ -922,6 +922,20 @@ func AnnexContentLocation(key string) (string, error) {
 	return sstdout, nil
 }
 
+// AnnexFsck runs fsck (filesystem check) on the specified files, fixing any
+// issues with the annexed files in the working tree.
+func AnnexFsck(paths []string) error {
+	cmdargs := []string{"fsck"}
+	cmdargs = append(cmdargs, paths...)
+	cmd := AnnexCommand(cmdargs...)
+	stdout, stderr, err := cmd.OutputError()
+	if err != nil {
+		logstd(stdout, stderr)
+		return fmt.Errorf("error fixing working tree files: %s", string(stderr))
+	}
+	return nil
+}
+
 // build exclusion argument list
 // files < annex.minsize or matching exclusion extensions will not be annexed and
 // will instead be handled by git

--- a/git/annex.go
+++ b/git/annex.go
@@ -889,6 +889,25 @@ func AnnexFromKey(key, filepath string) error {
 	return nil
 }
 
+// AnnexContentLocation returns the location of the content for a given annex
+// key. This is the location of the content file in the object store. If the
+// annexed content is not available locally, the function returns an error.
+func AnnexContentLocation(key string) (string, error) {
+	cmd := AnnexCommand("contentlocation", key)
+	stdout, stderr, err := cmd.OutputError()
+	if err != nil {
+		logstd(stdout, stderr)
+		errmsg := "content not available locally"
+		if len(stderr) > 0 {
+			errmsg = string(stderr)
+		}
+		return "", fmt.Errorf(errmsg)
+	}
+	sstdout := string(stdout)
+	sstdout = strings.TrimSpace(sstdout)
+	return sstdout, nil
+}
+
 // build exclusion argument list
 // files < annex.minsize or matching exclusion extensions will not be annexed and
 // will instead be handled by git

--- a/git/annex.go
+++ b/git/annex.go
@@ -495,6 +495,88 @@ func AnnexGet(filepaths []string, getchan chan<- RepoFileStatus) {
 	return
 }
 
+// AnnexGetKey retrieves the content of a single specified key.
+// The status channel 'getchan' is closed when this function returns.
+// (git annex get)
+func AnnexGetKey(key string, getchan chan<- RepoFileStatus) {
+	defer close(getchan)
+	cmd := AnnexCommand("get", "--json-progress", fmt.Sprintf("--key=%s", key))
+	if err := cmd.Start(); err != nil {
+		getchan <- RepoFileStatus{Err: err}
+		return
+	}
+
+	var status RepoFileStatus
+	status.State = "Downloading"
+
+	var outline []byte
+	var rerr error
+	var progress annexProgress
+	var getresult annexAction
+	var prevByteProgress int
+	var prevT time.Time
+
+	for rerr = nil; rerr == nil; outline, rerr = cmd.OutReader.ReadBytes('\n') {
+		if len(outline) == 0 {
+			// skip empty lines
+			continue
+		}
+
+		if !JsonBool {
+			lineInput := cmd.Args
+			input := strings.Join(lineInput, " ")
+			status.RawInput = input
+			status.RawOutput = string(outline)
+			getchan <- status
+			continue
+		}
+		err := json.Unmarshal(outline, &progress)
+		if err != nil || progress.Action.Command == "" {
+			// File done? Check if succeeded and continue to next line
+			err = json.Unmarshal(outline, &getresult)
+			if err != nil || getresult.Command == "" {
+				// Couldn't parse output
+				log.Write("Could not parse 'git annex get' output")
+				log.Write(string(outline))
+				// TODO: Print error at the end: Command succeeded but there was an error understanding the output
+				continue
+			}
+			status.FileName = getresult.File
+			if getresult.Success {
+				status.Progress = progcomplete
+				status.Err = nil
+			} else {
+				errmsg := getresult.Note
+				if strings.Contains(errmsg, "Unable to access") {
+					errmsg = "authorisation failed or remote storage unavailable"
+				}
+				status.Err = fmt.Errorf("failed: %s", errmsg)
+			}
+		} else {
+			status.FileName = progress.Action.File
+			status.Progress = progress.PercentProgress
+			dbytes := progress.ByteProgress - prevByteProgress
+			now := time.Now()
+			dt := now.Sub(prevT)
+			status.Rate = calcRate(dbytes, dt)
+			prevByteProgress = progress.ByteProgress
+			prevT = now
+			status.Err = nil
+		}
+
+		getchan <- status
+	}
+	if cmd.Wait() != nil {
+		var stderr, errline []byte
+		for rerr = nil; rerr == nil; errline, rerr = cmd.OutReader.ReadBytes('\000') {
+			stderr = append(stderr, errline...)
+		}
+		log.Write("Error during AnnexGet")
+		log.Write(string(stderr))
+	}
+	return
+}
+
 // AnnexDrop drops the content of specified files.
 // The status channel 'dropchan' is closed when this function returns.
 // (git annex drop)

--- a/git/util.go
+++ b/git/util.go
@@ -1,8 +1,10 @@
 package git
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -125,3 +127,35 @@ func filterpaths(paths, excludes []string) (filtered []string) {
 
 	return
 }
+
+// CopyFile copies the contents of src file into dest file.
+func CopyFile(src, dest string) error {
+	if !pathExists(src) {
+		return fmt.Errorf("source file '%s' does not exist", src)
+	}
+	if pathExists(dest) {
+		return fmt.Errorf("destination file '%s' exists; refusing to overwrite", dest)
+	}
+
+	// set up read buffer
+	srcfile, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("failed to open source file for copy: %v", err.Error())
+	}
+	reader := bufio.NewReader(srcfile)
+
+	// set up write buffer
+	destfile, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		return fmt.Errorf("failed to create destination file for copy: %v", err.Error())
+	}
+	writer := bufio.NewWriter(destfile)
+
+	if nw, err := io.Copy(writer, reader); err != nil {
+		println(nw)
+	}
+
+	return nil
+}
+
+// TODO: Move CopyFile and pathExists to a new subpackage: ginclient/ginutil or simply ginutil

--- a/git/util.go
+++ b/git/util.go
@@ -142,6 +142,7 @@ func CopyFile(src, dest string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open source file for copy: %v", err.Error())
 	}
+	defer srcfile.Close()
 	reader := bufio.NewReader(srcfile)
 
 	// set up write buffer
@@ -149,10 +150,12 @@ func CopyFile(src, dest string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create destination file for copy: %v", err.Error())
 	}
+	defer destfile.Close()
 	writer := bufio.NewWriter(destfile)
+	defer writer.Flush()
 
-	if nw, err := io.Copy(writer, reader); err != nil {
-		println(nw)
+	if _, err := io.Copy(writer, reader); err != nil {
+		return fmt.Errorf("file copy failed: %v", err.Error())
 	}
 
 	return nil


### PR DESCRIPTION
This PR changes the behaviour of the `gin version` command with the `--copy-to` flag.

**Old behaviour:** Previously, files checked out from an old version into a new directory were added (but not committed) to the git index.  Internally, we would use `git annex fromkey` to create a new pointer file to annexed content from an old revision.  When this command is run, a new pointer file is created and added to the index, since there's no way to retrieve the data it points to if it's not a file known to the repository.  Git files that were checked out from an older version would be added to the index explicitly to keep the behaviour consistent.  The fromkey command fails on Windows since git-annex tries to create a symlink, regardless of OS, filesystem, or capabilities.

**New behaviour:** The `git annex fromkey` command is replaced with a straightforward file copy.  The location of the content is retrieved using `git annex contentlocation`, which returns the file path of the annexed content.  If the content isn't available, it's automatically downloaded (more on this later).  Once the content is available, the object is copied from the git-annex object store to the location specified by the user.  None of the new files checked out from the command are checked into git.  With this new behaviour, the user can copy files from an older  version of the repository to a location outside the repository's working tree, which makes the command more flexible.

**Smaller changes:**
- Added seconds to the timestamp of files checked out using `--copy-to`
- Runs `git annex fsck` after a `gin version` command on all paths to fix any annexed pointer files that are affected.
- Changed the red FAILED message when a remote doesn't exist when running the `gin add-remote` command.

**Notes:** Automatically downloading the content might not be desirable.  I would like to either add a flag that explicitly enables automatic downloading, or have the operation prompt the user for confirmation (possibly both).