### PR TITLE
Add JSON output to info, keys, servers, and remotes commands

### DIFF
--- a/gincmd/infocmd.go
+++ b/gincmd/infocmd.go
@@ -2,6 +2,7 @@ package gincmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 
 	ginclient "github.com/G-Node/gin-cli/ginclient"
@@ -13,6 +14,7 @@ func printAccountInfo(cmd *cobra.Command, args []string) {
 	var username string
 
 	flags := cmd.Flags()
+	jsonout, _ := flags.GetBool("json")
 	srvalias, _ := flags.GetString("server")
 
 	conf := config.Read()
@@ -39,9 +41,14 @@ func printAccountInfo(cmd *cobra.Command, args []string) {
 	CheckError(err)
 
 	var outBuffer bytes.Buffer
-	_, _ = outBuffer.WriteString(fmt.Sprintf("User %s\nName: %s\n", info.UserName, info.FullName))
-	if info.Email != "" {
-		_, _ = outBuffer.WriteString(fmt.Sprintf("Email: %s\n", info.Email))
+	if jsonout {
+		infojson, _ := json.Marshal(info)
+		outBuffer.Write(infojson)
+	} else {
+		_, _ = outBuffer.WriteString(fmt.Sprintf("User %s\nName: %s\n", info.UserName, info.FullName))
+		if info.Email != "" {
+			_, _ = outBuffer.WriteString(fmt.Sprintf("Email: %s\n", info.Email))
+		}
 	}
 
 	fmt.Println(outBuffer.String())
@@ -62,5 +69,6 @@ func InfoCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().String("server", "", "Specify server `alias` for info lookup. See also 'gin servers'.")
+	cmd.Flags().Bool("json", false, jsonHelpMsg)
 	return cmd
 }

--- a/gincmd/remotescmd.go
+++ b/gincmd/remotescmd.go
@@ -1,6 +1,7 @@
 package gincmd
 
 import (
+	"encoding/json"
 	"fmt"
 
 	ginclient "github.com/G-Node/gin-cli/ginclient"
@@ -10,7 +11,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func remotes(cmd *cobra.Command, args []string) {
+func printremotes(cmd *cobra.Command, args []string) {
+	flags := cmd.Flags()
+	jsonout, _ := flags.GetBool("json")
+
 	if !git.IsRepo() {
 		Die(ginerrors.NotInRepo)
 	}
@@ -19,13 +23,18 @@ func remotes(cmd *cobra.Command, args []string) {
 	CheckError(err)
 	defremote, err := ginclient.DefaultRemote()
 	CheckError(err)
-	fmt.Println(":: Configured remotes")
-	for name, loc := range remotes {
-		fmt.Printf(" %s: %s", name, loc)
-		if name == defremote {
-			fmt.Fprintf(color.Output, green(" [default]"))
+	if jsonout {
+		remotesjson, _ := json.Marshal(remotes)
+		fmt.Print(string(remotesjson))
+	} else {
+		fmt.Println(":: Configured remotes")
+		for name, loc := range remotes {
+			fmt.Printf(" %s: %s", name, loc)
+			if name == defremote {
+				fmt.Fprintf(color.Output, green(" [default]"))
+			}
+			fmt.Println()
 		}
-		fmt.Println()
 	}
 }
 
@@ -37,8 +46,9 @@ func RemotesCmd() *cobra.Command {
 		Short:                 "List the repository's configured remotes",
 		Long:                  formatdesc(description, nil),
 		Args:                  cobra.NoArgs,
-		Run:                   remotes,
+		Run:                   printremotes,
 		DisableFlagsInUseLine: true,
 	}
+	cmd.Flags().Bool("json", false, jsonHelpMsg)
 	return cmd
 }

--- a/gincmd/reposcmd.go
+++ b/gincmd/reposcmd.go
@@ -101,7 +101,7 @@ func ReposCmd() *cobra.Command {
 	}
 	cmd.Flags().Bool("all", false, "List all repositories accessible to the logged in user.")
 	cmd.Flags().Bool("shared", false, "List all repositories that the user is a member of (excluding own repositories).")
-	cmd.Flags().Bool("json", false, "Print listing in JSON format.")
+	cmd.Flags().Bool("json", false, jsonHelpMsg)
 	cmd.Flags().String("server", "", "Specify server `alias` where the repository will be created. See also 'gin servers'.")
 	return cmd
 }

--- a/gincmd/serverscmd.go
+++ b/gincmd/serverscmd.go
@@ -1,6 +1,7 @@
 package gincmd
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/G-Node/gin-cli/ginclient/config"
@@ -9,19 +10,26 @@ import (
 )
 
 func servers(cmd *cobra.Command, args []string) {
+	flags := cmd.Flags()
+	jsonout, _ := flags.GetBool("json")
 	conf := config.Read()
 	servermap := conf.Servers
 	defserver := conf.DefaultServer
 
-	fmt.Println(":: Configured servers")
-	for alias, srvcfg := range servermap {
-		fmt.Printf("* %s", alias)
-		if alias == defserver {
-			fmt.Fprintf(color.Output, green(" [default]"))
+	if jsonout {
+		serversjson, _ := json.Marshal(conf.Servers)
+		fmt.Print(string(serversjson))
+	} else {
+		fmt.Println(":: Configured servers")
+		for alias, srvcfg := range servermap {
+			fmt.Printf("* %s", alias)
+			if alias == defserver {
+				fmt.Fprintf(color.Output, green(" [default]"))
+			}
+			fmt.Println()
+			fmt.Printf("  web: %s\n", srvcfg.Web.AddressStr())
+			fmt.Printf("  git: %s\n\n", srvcfg.Git.AddressStr())
 		}
-		fmt.Println()
-		fmt.Printf("  web: %s\n", srvcfg.Web.AddressStr())
-		fmt.Printf("  git: %s\n\n", srvcfg.Git.AddressStr())
 	}
 }
 
@@ -36,5 +44,6 @@ func ServersCmd() *cobra.Command {
 		Run:                   servers,
 		DisableFlagsInUseLine: true,
 	}
+	cmd.Flags().Bool("json", false, jsonHelpMsg)
 	return cmd
 }


### PR DESCRIPTION
The following commands now support the `--json` flag to print their output in JSON format:
- `info`: User information
- `keys`: Logged in user's public keys
- `servers`: Configured GIN servers
- `remotes`: Repository's configured remotes

Closes #235 