### PR TITLE
[annex] Print progress of metadata writing

### DIFF
--- a/git/annex.go
+++ b/git/annex.go
@@ -1005,8 +1005,12 @@ func AnnexAdd(filepaths []string, addchan chan<- RepoFileStatus) {
 		logstd(nil, stderr)
 	}
 	// Add metadata
+	status.State = "Writing filename metadata"
 	for _, fname := range filenames {
 		setAnnexMetadataName(fname)
+		status.FileName = fname
+		status.Progress = progcomplete
+		addchan <- status
 	}
 	return
 }


### PR DESCRIPTION
After annex add is finished, the client writes the filename to the
content metadata so that the annex content key is always associated with
the name of the file it was added as.  This is useful for knowing which
file is being transferred when uploading old versions of files (when
multiple commits happen between uploads).  The metadata writing can take
a while when a large number of files is being added, so printing this
information is useful.

See issue #269 for more info