### PR TITLE
Annex upgrade notice

### DIFF
--- a/ginclient/repos.go
+++ b/ginclient/repos.go
@@ -454,7 +454,7 @@ func (gincl *Client) CloneRepo(repopath string, clonechan chan<- git.RepoFileSta
 // If a new commit is created and a default remote exists, the new commit is pushed to initialise the remote as well.
 // Returns 'true' if (and only if) a commit was created.
 func CommitIfNew() (bool, error) {
-	if !git.IsRepo() {
+	if !git.Checkwd() {
 		return false, fmt.Errorf("not a repository")
 	}
 	_, err := git.RevParse("HEAD")
@@ -635,7 +635,7 @@ func CheckoutFileCopies(commithash string, paths []string, outpath string, suffi
 // Optionally initialised as a bare repository (for annex directory remotes).
 func (gincl *Client) InitDir(bare bool) error {
 	initerr := ginerror{Origin: "InitDir", Description: "Error initialising local directory"}
-	if !git.IsRepo() {
+	if !git.Checkwd() {
 		err := git.Init(bare)
 		if err != nil {
 			initerr.UError = err.Error()

--- a/ginclient/repos.go
+++ b/ginclient/repos.go
@@ -454,7 +454,8 @@ func (gincl *Client) CloneRepo(repopath string, clonechan chan<- git.RepoFileSta
 // If a new commit is created and a default remote exists, the new commit is pushed to initialise the remote as well.
 // Returns 'true' if (and only if) a commit was created.
 func CommitIfNew() (bool, error) {
-	if !git.Checkwd() {
+	if git.Checkwd() == git.NotRepository {
+		// Other errors allowed
 		return false, fmt.Errorf("not a repository")
 	}
 	_, err := git.RevParse("HEAD")
@@ -635,7 +636,7 @@ func CheckoutFileCopies(commithash string, paths []string, outpath string, suffi
 // Optionally initialised as a bare repository (for annex directory remotes).
 func (gincl *Client) InitDir(bare bool) error {
 	initerr := ginerror{Origin: "InitDir", Description: "Error initialising local directory"}
-	if !git.Checkwd() {
+	if git.Checkwd() == git.NotRepository {
 		err := git.Init(bare)
 		if err != nil {
 			initerr.UError = err.Error()

--- a/gincmd/addremotecmd.go
+++ b/gincmd/addremotecmd.go
@@ -152,7 +152,7 @@ func defaultRemoteIfUnset(name string) {
 }
 
 func addRemote(cmd *cobra.Command, args []string) {
-	if !git.Checkwd() {
+	if git.Checkwd() == git.NotRepository {
 		Die(ginerrors.NotInRepo)
 	}
 	flags := cmd.Flags()

--- a/gincmd/addremotecmd.go
+++ b/gincmd/addremotecmd.go
@@ -152,7 +152,7 @@ func defaultRemoteIfUnset(name string) {
 }
 
 func addRemote(cmd *cobra.Command, args []string) {
-	if !git.IsRepo() {
+	if !git.Checkwd() {
 		Die(ginerrors.NotInRepo)
 	}
 	flags := cmd.Flags()

--- a/gincmd/commitcmd.go
+++ b/gincmd/commitcmd.go
@@ -14,7 +14,7 @@ import (
 
 func commit(cmd *cobra.Command, args []string) {
 	prStyle := determinePrintStyle(cmd)
-	if !git.IsRepo() {
+	if !git.Checkwd() {
 		Die(ginerrors.NotInRepo)
 	}
 

--- a/gincmd/commitcmd.go
+++ b/gincmd/commitcmd.go
@@ -14,8 +14,13 @@ import (
 
 func commit(cmd *cobra.Command, args []string) {
 	prStyle := determinePrintStyle(cmd)
-	if !git.Checkwd() {
+	switch git.Checkwd() {
+	case git.NotRepository:
 		Die(ginerrors.NotInRepo)
+	case git.NotAnnex:
+		Warn(ginerrors.MissingAnnex)
+	case git.UpgradeRequired:
+		annexVersionNotice()
 	}
 
 	commitmsg, _ := cmd.Flags().GetString("message")

--- a/gincmd/common.go
+++ b/gincmd/common.go
@@ -72,6 +72,12 @@ func Die(msg interface{}) {
 	os.Exit(1)
 }
 
+// Warn prints a warning message to stderr, logs it, and returns without interruption.
+func Warn(msg string) {
+	log.Write("Showing warning: %q", msg)
+	fmt.Fprintf(color.Error, "%s %s\n", yellow("[warning]"), msg)
+}
+
 // Exit prints a message to stdout and exits the program with status 0.
 func Exit(msg string) {
 	if len(msg) > 0 {
@@ -111,6 +117,22 @@ func CheckErrorMsg(err error, msg string) {
 // The function should be called at the start of any command that requires being logged in to run.
 func requirelogin(cmd *cobra.Command, gincl *ginclient.Client, prompt bool) {
 	gincl.LoadToken()
+}
+
+func annexVersionNotice() {
+	msg := `The current repository is using an old layout for annexed data.  It is recommended that you upgrade to the newest version.  You may still use it as is for now, but in the future the upgrade will happen automatically.  This message will continue to appear for affected git-annex operations until you upgrade.
+
+Run 'gin annex upgrade' followed by 'gin init' to upgrade this repository now.  The operation should only take a few seconds.
+
+Visit the following page for a description of how this change may affect your workflow:`
+	w := termwidth()
+	if w > 80 {
+		w = 80
+	}
+	msg = wrap.Wrap(msg, w)
+	// append URL after wrapping to avoid breaking the URL with spaces
+	msg += "https://gin.g-node.org/G-Node/gin-cli-releases/src/master/v1.7#changes"
+	fmt.Println(msg)
 }
 
 func usageDie(cmd *cobra.Command) {

--- a/gincmd/downloadcmd.go
+++ b/gincmd/downloadcmd.go
@@ -17,7 +17,7 @@ func download(cmd *cobra.Command, args []string) {
 	// TODO: no client necessary? Just use remotes
 	conf := config.Read()
 	gincl := ginclient.New(conf.DefaultServer)
-	if !git.IsRepo() {
+	if !git.Checkwd() {
 		Die(ginerrors.NotInRepo)
 	}
 	remote, err := ginclient.DefaultRemote()

--- a/gincmd/downloadcmd.go
+++ b/gincmd/downloadcmd.go
@@ -17,8 +17,13 @@ func download(cmd *cobra.Command, args []string) {
 	// TODO: no client necessary? Just use remotes
 	conf := config.Read()
 	gincl := ginclient.New(conf.DefaultServer)
-	if !git.Checkwd() {
+	switch git.Checkwd() {
+	case git.NotRepository:
 		Die(ginerrors.NotInRepo)
+	case git.NotAnnex:
+		Warn(ginerrors.MissingAnnex)
+	case git.UpgradeRequired:
+		annexVersionNotice()
 	}
 	remote, err := ginclient.DefaultRemote()
 	if err != nil { // TODO && len(remotes) == 0 {

--- a/gincmd/getcontentcmd.go
+++ b/gincmd/getcontentcmd.go
@@ -16,8 +16,13 @@ func getContent(cmd *cobra.Command, args []string) {
 	// TODO: no need for client; use remotes (and all keys?)
 	gincl := ginclient.New(conf.DefaultServer)
 	requirelogin(cmd, gincl, prStyle != psJSON)
-	if !git.Checkwd() {
+	switch git.Checkwd() {
+	case git.NotRepository:
 		Die(ginerrors.NotInRepo)
+	case git.NotAnnex:
+		Warn(ginerrors.MissingAnnex)
+	case git.UpgradeRequired:
+		annexVersionNotice()
 	}
 
 	if prStyle == psDefault {

--- a/gincmd/getcontentcmd.go
+++ b/gincmd/getcontentcmd.go
@@ -16,7 +16,7 @@ func getContent(cmd *cobra.Command, args []string) {
 	// TODO: no need for client; use remotes (and all keys?)
 	gincl := ginclient.New(conf.DefaultServer)
 	requirelogin(cmd, gincl, prStyle != psJSON)
-	if !git.IsRepo() {
+	if !git.Checkwd() {
 		Die(ginerrors.NotInRepo)
 	}
 

--- a/gincmd/ginerrors/errors.go
+++ b/gincmd/ginerrors/errors.go
@@ -15,4 +15,7 @@ const (
 
 	// MissingGitUser is returned when a string is assumed to be a git configuration but does not contain a user (missing @)
 	MissingGitUser = "could not determine git username (no @)"
+
+	// MissingAnnex is returned when a repository doesn't have annex initialised (can also be used as a warning)
+	MissingAnnex = "no annex information found: run 'gin init' to initialise annex"
 )

--- a/gincmd/lockcmd.go
+++ b/gincmd/lockcmd.go
@@ -12,7 +12,7 @@ import (
 
 func lock(cmd *cobra.Command, args []string) {
 	prStyle := determinePrintStyle(cmd)
-	if !git.IsRepo() {
+	if !git.Checkwd() {
 		Die(ginerrors.NotInRepo)
 	}
 	if prStyle != psJSON {

--- a/gincmd/lockcmd.go
+++ b/gincmd/lockcmd.go
@@ -12,8 +12,13 @@ import (
 
 func lock(cmd *cobra.Command, args []string) {
 	prStyle := determinePrintStyle(cmd)
-	if !git.Checkwd() {
+	switch git.Checkwd() {
+	case git.NotRepository:
 		Die(ginerrors.NotInRepo)
+	case git.NotAnnex:
+		Warn(ginerrors.MissingAnnex)
+	case git.UpgradeRequired:
+		annexVersionNotice()
 	}
 	if prStyle != psJSON {
 		fmt.Println(":: Locking files")

--- a/gincmd/lscmd.go
+++ b/gincmd/lscmd.go
@@ -15,7 +15,7 @@ import (
 )
 
 func lsRepo(cmd *cobra.Command, args []string) {
-	if !git.IsRepo() {
+	if !git.Checkwd() {
 		Die(ginerrors.NotInRepo)
 	}
 

--- a/gincmd/lscmd.go
+++ b/gincmd/lscmd.go
@@ -15,8 +15,11 @@ import (
 )
 
 func lsRepo(cmd *cobra.Command, args []string) {
-	if !git.Checkwd() {
+	switch git.Checkwd() {
+	case git.NotRepository:
 		Die(ginerrors.NotInRepo)
+	case git.NotAnnex:
+		Warn(ginerrors.MissingAnnex)
 	}
 
 	flags := cmd.Flags()

--- a/gincmd/remotescmd.go
+++ b/gincmd/remotescmd.go
@@ -15,7 +15,7 @@ func printremotes(cmd *cobra.Command, args []string) {
 	flags := cmd.Flags()
 	jsonout, _ := flags.GetBool("json")
 
-	if !git.IsRepo() {
+	if !git.Checkwd() {
 		Die(ginerrors.NotInRepo)
 	}
 

--- a/gincmd/remotescmd.go
+++ b/gincmd/remotescmd.go
@@ -15,8 +15,11 @@ func printremotes(cmd *cobra.Command, args []string) {
 	flags := cmd.Flags()
 	jsonout, _ := flags.GetBool("json")
 
-	if !git.Checkwd() {
+	switch git.Checkwd() {
+	case git.NotRepository:
 		Die(ginerrors.NotInRepo)
+	case git.NotAnnex:
+		Warn(ginerrors.MissingAnnex)
 	}
 
 	remotes, err := git.RemoteShow()

--- a/gincmd/removecontentcmd.go
+++ b/gincmd/removecontentcmd.go
@@ -24,7 +24,7 @@ func remove(cmd *cobra.Command, args []string) {
 	conf := config.Read()
 	gincl := ginclient.New(conf.DefaultServer)
 	requirelogin(cmd, gincl, prStyle != psJSON)
-	if !git.IsRepo() {
+	if !git.Checkwd() {
 		Die(ginerrors.NotInRepo)
 	}
 	nitems := countItemsRemove(args)

--- a/gincmd/removecontentcmd.go
+++ b/gincmd/removecontentcmd.go
@@ -24,8 +24,13 @@ func remove(cmd *cobra.Command, args []string) {
 	conf := config.Read()
 	gincl := ginclient.New(conf.DefaultServer)
 	requirelogin(cmd, gincl, prStyle != psJSON)
-	if !git.Checkwd() {
+	switch git.Checkwd() {
+	case git.NotRepository:
 		Die(ginerrors.NotInRepo)
+	case git.NotAnnex:
+		Warn(ginerrors.MissingAnnex)
+	case git.UpgradeRequired:
+		annexVersionNotice()
 	}
 	nitems := countItemsRemove(args)
 	rmchan := make(chan git.RepoFileStatus)

--- a/gincmd/removeremotecmd.go
+++ b/gincmd/removeremotecmd.go
@@ -10,7 +10,7 @@ import (
 )
 
 func rmRemote(cmd *cobra.Command, args []string) {
-	if !git.Checkwd() {
+	if git.Checkwd() == git.NotRepository {
 		Die(ginerrors.NotInRepo)
 	}
 	name := args[0]

--- a/gincmd/removeremotecmd.go
+++ b/gincmd/removeremotecmd.go
@@ -10,7 +10,7 @@ import (
 )
 
 func rmRemote(cmd *cobra.Command, args []string) {
-	if !git.IsRepo() {
+	if !git.Checkwd() {
 		Die(ginerrors.NotInRepo)
 	}
 	name := args[0]

--- a/gincmd/synccmd.go
+++ b/gincmd/synccmd.go
@@ -16,7 +16,7 @@ func sync(cmd *cobra.Command, args []string) {
 	// TODO: no client necessary? Just use remotes
 	conf := config.Read()
 	gincl := ginclient.New(conf.DefaultServer)
-	if !git.IsRepo() {
+	if !git.Checkwd() {
 		Die(ginerrors.NotInRepo)
 	}
 

--- a/gincmd/synccmd.go
+++ b/gincmd/synccmd.go
@@ -16,8 +16,13 @@ func sync(cmd *cobra.Command, args []string) {
 	// TODO: no client necessary? Just use remotes
 	conf := config.Read()
 	gincl := ginclient.New(conf.DefaultServer)
-	if !git.Checkwd() {
+	switch git.Checkwd() {
+	case git.NotRepository:
 		Die(ginerrors.NotInRepo)
+	case git.NotAnnex:
+		Warn(ginerrors.MissingAnnex)
+	case git.UpgradeRequired:
+		annexVersionNotice()
 	}
 
 	content, _ := cmd.Flags().GetBool("content")

--- a/gincmd/unlockcmd.go
+++ b/gincmd/unlockcmd.go
@@ -22,8 +22,13 @@ func countItemsLockChange(paths []string) (count int) {
 
 func unlock(cmd *cobra.Command, args []string) {
 	prStyle := determinePrintStyle(cmd)
-	if !git.Checkwd() {
+	switch git.Checkwd() {
+	case git.NotRepository:
 		Die(ginerrors.NotInRepo)
+	case git.NotAnnex:
+		Warn(ginerrors.MissingAnnex)
+	case git.UpgradeRequired:
+		annexVersionNotice()
 	}
 
 	if prStyle != psJSON {

--- a/gincmd/unlockcmd.go
+++ b/gincmd/unlockcmd.go
@@ -22,7 +22,7 @@ func countItemsLockChange(paths []string) (count int) {
 
 func unlock(cmd *cobra.Command, args []string) {
 	prStyle := determinePrintStyle(cmd)
-	if !git.IsRepo() {
+	if !git.Checkwd() {
 		Die(ginerrors.NotInRepo)
 	}
 

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -13,8 +13,13 @@ func upload(cmd *cobra.Command, args []string) {
 	prStyle := determinePrintStyle(cmd)
 	remotes, _ := cmd.Flags().GetStringSlice("to")
 	gincl := ginclient.New("gin") // TODO: probably doesn't need a client
-	if !git.Checkwd() {
+	switch git.Checkwd() {
+	case git.NotRepository:
 		Die(ginerrors.NotInRepo)
+	case git.NotAnnex:
+		Warn(ginerrors.MissingAnnex)
+	case git.UpgradeRequired:
+		annexVersionNotice()
 	}
 
 	// Fail early if no default remote

--- a/gincmd/uploadcmd.go
+++ b/gincmd/uploadcmd.go
@@ -13,7 +13,7 @@ func upload(cmd *cobra.Command, args []string) {
 	prStyle := determinePrintStyle(cmd)
 	remotes, _ := cmd.Flags().GetStringSlice("to")
 	gincl := ginclient.New("gin") // TODO: probably doesn't need a client
-	if !git.IsRepo() {
+	if !git.Checkwd() {
 		Die(ginerrors.NotInRepo)
 	}
 

--- a/gincmd/useremotecmd.go
+++ b/gincmd/useremotecmd.go
@@ -10,7 +10,7 @@ import (
 )
 
 func useRemote(cmd *cobra.Command, args []string) {
-	if !git.Checkwd() {
+	if git.Checkwd() == git.NotRepository {
 		Die(ginerrors.NotInRepo)
 	}
 	if len(args) > 0 {

--- a/gincmd/useremotecmd.go
+++ b/gincmd/useremotecmd.go
@@ -10,7 +10,7 @@ import (
 )
 
 func useRemote(cmd *cobra.Command, args []string) {
-	if !git.IsRepo() {
+	if !git.Checkwd() {
 		Die(ginerrors.NotInRepo)
 	}
 	if len(args) > 0 {

--- a/gincmd/versioncmd.go
+++ b/gincmd/versioncmd.go
@@ -13,7 +13,7 @@ import (
 )
 
 func repoversion(cmd *cobra.Command, args []string) {
-	if !git.IsRepo() {
+	if !git.Checkwd() {
 		Die("This command must be run from inside a gin repository.")
 	}
 	count, _ := cmd.Flags().GetUint("max-count")

--- a/gincmd/versioncmd.go
+++ b/gincmd/versioncmd.go
@@ -7,14 +7,20 @@ import (
 	"strings"
 
 	ginclient "github.com/G-Node/gin-cli/ginclient"
+	"github.com/G-Node/gin-cli/gincmd/ginerrors"
 	"github.com/G-Node/gin-cli/git"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
 func repoversion(cmd *cobra.Command, args []string) {
-	if !git.Checkwd() {
-		Die("This command must be run from inside a gin repository.")
+	switch git.Checkwd() {
+	case git.NotRepository:
+		Die(ginerrors.NotInRepo)
+	case git.NotAnnex:
+		Warn(ginerrors.MissingAnnex)
+	case git.UpgradeRequired:
+		annexVersionNotice()
 	}
 	count, _ := cmd.Flags().GetUint("max-count")
 	jsonout, _ := cmd.Flags().GetBool("json")

--- a/git/annex.go
+++ b/git/annex.go
@@ -150,12 +150,6 @@ func AnnexInit(description string) error {
 	return nil
 }
 
-// AnnexUpgrade upgrades a repository to the current (newest) layout.
-// Use this to upgrade v5 repositories to v7.
-func AnnexUpgrade() error {
-	return nil
-}
-
 // AnnexPull downloads all annexed files. Optionally also downloads all file content.
 // (git annex sync --no-push [--content])
 func AnnexPull(remote string) error {

--- a/git/annex.go
+++ b/git/annex.go
@@ -150,6 +150,12 @@ func AnnexInit(description string) error {
 	return nil
 }
 
+// AnnexUpgrade upgrades a repository to the current (newest) layout.
+// Use this to upgrade v5 repositories to v7.
+func AnnexUpgrade() error {
+	return nil
+}
+
 // AnnexPull downloads all annexed files. Optionally also downloads all file content.
 // (git annex sync --no-push [--content])
 func AnnexPull(remote string) error {

--- a/git/git.go
+++ b/git/git.go
@@ -17,8 +17,21 @@ import (
 	"github.com/G-Node/gin-cli/git/shell"
 )
 
-const progcomplete = "100%"
-const unknownhostname = "(unknown)"
+type Error string
+
+func (e Error) Error() string {
+	return string(e)
+}
+
+const (
+	progcomplete    = "100%"
+	unknownhostname = "(unknown)"
+
+	// Constant errors
+	NotRepository   = Error("Not a repository")
+	NotAnnex        = Error("No annex found")
+	UpgradeRequired = Error("Repository upgrade needed")
+)
 
 // giterror convenience alias to util.Error
 type giterror = shell.Error
@@ -336,7 +349,8 @@ func Add(filepaths []string, addchan chan<- RepoFileStatus) {
 
 // SetGitUser sets the user.name and user.email configuration values for the local git repository.
 func SetGitUser(name, email string) error {
-	if !Checkwd() {
+	if Checkwd() == NotRepository {
+		// Other errors allowed
 		return fmt.Errorf("not a repository")
 	}
 	err := ConfigSet("user.name", name)
@@ -520,13 +534,46 @@ func RevParse(rev string) (string, error) {
 }
 
 // Checkwd checks whether the current working directory is in a git repository.
-// This function will also return true for bare repositories that use git annex (direct mode).
-func Checkwd() bool {
+// Returns NotRepository if the working directory is not inside a repository.
+// Returns NotAnnex if the working directory is inside a repository but there is no annex.
+// Returns UpgradeRequired if the annex is an old version (< v7).
+func Checkwd() error {
 	path, _ := filepath.Abs(".")
 	_, err := FindRepoRoot(path)
-	yes := err == nil
-	log.Write("%v", yes)
-	return yes
+	if err != nil {
+		return NotRepository
+	}
+
+	annexver, err := ConfigGet("annex.version")
+	if err != nil {
+		// Annex version config key missing: Annex not initialised
+		return NotAnnex
+	}
+
+	ver, err := strconv.Atoi(annexver)
+	if err != nil {
+		// Annex version string should be number.  Something went wrong.
+		// Return UpgradeRequired to upgrade and fix the repository info.
+		return UpgradeRequired
+	}
+
+	if ver < 7 {
+		return UpgradeRequired
+	}
+
+	return nil
+}
+
+// FindRepoRoot returns the absolute path to the root of the repository.
+// For bare repositories, it returns an empty string, but no error.
+// (git rev-parse --show-toplevel)
+func FindRepoRoot(path string) (string, error) {
+	cmd := Command("rev-parse", "--show-toplevel")
+	stdout, stderr, err := cmd.OutputError()
+	if err != nil || bytes.Contains(stderr, []byte("not a git repository")) {
+		return "", fmt.Errorf("Not a repository")
+	}
+	return string(bytes.TrimRight(stdout, "\n")), nil
 }
 
 // **************** //

--- a/git/git.go
+++ b/git/git.go
@@ -336,7 +336,7 @@ func Add(filepaths []string, addchan chan<- RepoFileStatus) {
 
 // SetGitUser sets the user.name and user.email configuration values for the local git repository.
 func SetGitUser(name, email string) error {
-	if !IsRepo() {
+	if !Checkwd() {
 		return fmt.Errorf("not a repository")
 	}
 	err := ConfigSet("user.name", name)
@@ -519,11 +519,10 @@ func RevParse(rev string) (string, error) {
 	return string(stdout), nil
 }
 
-// IsRepo checks whether the current working directory is in a git repository.
+// Checkwd checks whether the current working directory is in a git repository.
 // This function will also return true for bare repositories that use git annex (direct mode).
-func IsRepo() bool {
+func Checkwd() bool {
 	path, _ := filepath.Abs(".")
-	log.Write("IsRepo '%s'?", path)
 	_, err := FindRepoRoot(path)
 	yes := err == nil
 	log.Write("%v", yes)

--- a/git/util.go
+++ b/git/util.go
@@ -61,28 +61,6 @@ func cutline(b []byte) (string, bool) {
 	return string(b[:idx]), false
 }
 
-// FindRepoRoot starts from a given directory and searches upwards through a directory structure looking for the root of a repository, indicated by the existence of a .git directory.
-// A path to the repository root is returned, or an error if the root of the filesystem is reached first.
-// The returned path is absolute.
-func FindRepoRoot(path string) (string, error) {
-	var err error
-	path, err = filepath.Abs(path)
-	if err != nil {
-		return "", err
-	}
-	gitdir := filepath.Join(path, ".git")
-	if pathExists(gitdir) {
-		return path, nil
-	}
-	updir := filepath.Dir(path)
-	if updir == path {
-		// root reached
-		return "", fmt.Errorf("Not a repository")
-	}
-
-	return FindRepoRoot(updir)
-}
-
 // pathExists returns true if the path exists
 func pathExists(path string) bool {
 	if _, err := os.Stat(path); os.IsNotExist(err) {

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/gogits/go-gogs-client v0.0.0-20190710002546-4c3c18947c15
 	github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c
 	github.com/mattn/go-colorable v0.1.2 // indirect
+	github.com/pkg/errors v0.8.0
 	github.com/shibukawa/configdir v0.0.0-20170330084843-e180dbdc8da0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.3


### PR DESCRIPTION
Renamed `IsRepo()` function to `Checkwd()`.  New function checks the status of the repository and returns one of three errors.
- NotRepositor: Like the original use of the function, returned when the
working directory is not a repository
- NotAnnex: When there is no annex information.  This usually results in
a warning and suggests running 'gin init' to (re)initialise the
repository.
- UpgradeRequired: If a v5 (or < v7) repository is detected.  This is
used to warn the user that they should upgrade the annex.

In the latter case, the user is instructed to run `gin annex upgrade` followed by `gin init` to upgrade the repository annex layout to v7.