### PR TITLE
Windows global cmd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ env:
 
 matrix:
   include:
-    - go: "1.13.x"
+    - go: "1.14.x"
       os: linux
     - go: tip
       os: linux
-    - go: "1.13.x"
+    - go: "1.14.x"
       os: osx
       addons:
         homebrew:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ build: off
 
 clone_folder: C:\gopath\src\github.com\G-Node\gin-cli
 
-stack: go 1.12
+stack: go 1.14
 
 environment:
   SRCDIR: C:\gopath\src\github.com\G-Node\gin-cli

--- a/dorelease
+++ b/dorelease
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # Copyright (c) 2017, German Neuroinformatics Node (G-Node)
 #
 # All rights reserved.

--- a/dorelease
+++ b/dorelease
@@ -188,12 +188,9 @@ def get_git_annex_for_windows():
     """
     Download the git annex for windows installer.
     """
-    # win_git_annex_url = ("https://downloads.kitenet.net/git-annex/windows/"
-    #                      "current/git-annex-installer.exe")
-    # return download(win_git_annex_url)
-    # fixing windows installer version (again)
-    fname = os.path.join(DESTDIR, "downloads", "git-annex-installer.exe")
-    return fname
+    win_git_annex_url = ("https://downloads.kitenet.net/git-annex/windows/"
+                         "current/git-annex-installer.exe")
+    return download(win_git_annex_url)
 
 
 def package_linux_plain(binfile):
@@ -364,6 +361,8 @@ def package_mac_bundle(binfile, annex_tar):
     For each macOS binary make a zip that includes the annex.app with the gin
     binary in its path.
     """
+    if not annex_tar:
+        return None
     with TemporaryDirectory(suffix="gin-macos") as tmpdir:
         # extract macOS git-annex tar into pkgroot
         cmd = ["tar", "-xjf", annex_tar, "-C", tmpdir]

--- a/dorelease.py
+++ b/dorelease.py
@@ -446,6 +446,7 @@ def winbundle(binfile, git_pkg, annex_pkg):
         shutil.copy(binfile, bindir)
         shutil.copy("README.md", pkgroot)
         shutil.copy(os.path.join("scripts", "gin-shell.bat"), pkgroot)
+        shutil.copy(os.path.join("scripts", "set-global.bat"), pkgroot)
 
         gitdir = os.path.join(pkgroot, "git")
         os.makedirs(gitdir)

--- a/scripts/set-global.bat
+++ b/scripts/set-global.bat
@@ -1,0 +1,16 @@
+:: GIN client global setup for Windows
+:: 
+:: This file should be part of the gin client Windows bundle. The purpose of
+:: the file is to permanently change the user path environment to be able to
+:: run GIN commands from the command line (cmd and PowerShell).
+
+echo off
+
+set curdir=%~dp0
+
+echo Adding %curdir% to path
+set ginbinpath=%curdir%\bin
+set gitpaths=%curdir%\git\usr\bin;%curdir%\git\bin
+echo %path%|find /I "%curdir%">nul || setx path "%path%;%ginbinpath%;%gitpaths%"
+echo GIN CLI is ready
+pause

--- a/scripts/set-global.bat
+++ b/scripts/set-global.bat
@@ -8,9 +8,9 @@ echo off
 
 set curdir=%~dp0
 
-echo Adding %curdir% to path
 set ginbinpath=%curdir%\bin
 set gitpaths=%curdir%\git\usr\bin;%curdir%\git\bin
+echo Appending "%ginbinpath%;%gitpaths%" to path
 echo %path%|find /I "%curdir%">nul || setx path "%path%;%ginbinpath%;%gitpaths%"
 echo GIN CLI is ready
 pause

--- a/version
+++ b/version
@@ -1,1 +1,1 @@
-version=1.10
+version=1.11dev


### PR DESCRIPTION
Adding a script that, when run, sets up the user's `%path%` to be able to run gin from anywhere on Windows.

The GIN installation docs will be updated accordingly.