### PR TITLE
Less intrusive Windows paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
       os: linux
     - go: "1.14.x"
       os: osx
+      osx_image: xcode12.2
       addons:
         homebrew:
           packages:

--- a/dorelease
+++ b/dorelease
@@ -453,14 +453,14 @@ def winbundle(binfile, git_pkg, annex_pkg):
         os.makedirs(gitdir)
 
         # extract git portable and annex into git dir
-        cmd = ["7z", "x", f"-o{gitdir}", git_pkg]
+        cmd = ["7z", "x", "-y", f"-o{gitdir}", git_pkg]
         print(f"Running {' '.join(cmd)}")
         if run(cmd, stdout=DEVNULL) > 0:
             print(f"Failed to extract git archive {git_pkg} to {gitdir}",
                   file=sys.stderr)
             return None
 
-        cmd = ["7z", "x", f"-o{gitdir}", annex_pkg]
+        cmd = ["7z", "x", "-y", f"-o{gitdir}", annex_pkg]
         print(f"Running {' '.join(cmd)}")
         if run(cmd, stdout=DEVNULL) > 0:
             print(f"Failed to extract git archive {annex_pkg} to {gitdir}",

--- a/dorelease
+++ b/dorelease
@@ -439,6 +439,7 @@ def winbundle(binfile, git_pkg, annex_pkg):
         shutil.copy("README.md", pkgroot)
         shutil.copy(os.path.join("scripts", "gin-shell.bat"), pkgroot)
         shutil.copy(os.path.join("scripts", "set-global.bat"), pkgroot)
+        shutil.copy(os.path.join("scripts", "gin.bat"), pkgroot)
 
         gitdir = os.path.join(pkgroot, "git")
         os.makedirs(gitdir)

--- a/dorelease
+++ b/dorelease
@@ -19,8 +19,8 @@ import re
 from glob import glob
 from subprocess import check_output, call, DEVNULL
 from tempfile import TemporaryDirectory
-import requests
 import plistlib
+import requests
 from requests.exceptions import ConnectionError as ConnError
 
 DESTDIR = "dist"
@@ -71,8 +71,10 @@ def download(url, fname=None):
     except ConnError:
         print(f"Error while trying to download {url}", file=sys.stderr)
         print("Skipping.", file=sys.stderr)
-        return
-    size = int(req.headers.get("content-length"))
+        return None
+    size = 0
+    if sizestr := req.headers.get("content-length"):
+        size = int(sizestr)
     etag = req.headers.get("etag")
     oldet = ETAGS.get(url)
     if etag == oldet and os.path.exists(fname):
@@ -215,15 +217,6 @@ def debianize(binfile, annexsa_archive):
     """
     For each Linux binary make a deb package with git annex standalone.
     """
-    def docker_cleanup():
-        print("Stopping and cleaning up docker container")
-        cmd = ["docker", "kill", "gin-deb-build"]
-        run(cmd)
-        cmd = ["docker", "container", "rm", "gin-deb-build"]
-        run(cmd)
-
-    docker_cleanup()
-
     # The default temporary root on macOS is /var/folders
     # Docker currently has issues mounting directories under /var
     # Forcing temporary directory to be rooted at /tmp instead
@@ -316,7 +309,6 @@ def debianize(binfile, annexsa_archive):
         print("Running debian build script")
         if run(cmd) > 0:
             print("Deb build failed", file=sys.stderr)
-            docker_cleanup()
             return
 
         debfilename = f"{pkgname}.deb"
@@ -326,7 +318,6 @@ def debianize(binfile, annexsa_archive):
             os.remove(debfiledest)
         shutil.copy(debfilepath, debfiledest)
         print("Done")
-        docker_cleanup()
     return debfiledest
 
 

--- a/scripts/gin.bat
+++ b/scripts/gin.bat
@@ -1,0 +1,18 @@
+:: GIN client entry point for Windows
+::
+:: This file should be part of the gin client Windows bundle.
+::
+:: The purpose of the file is to act as a wrapper for the GIN CLI binary. It
+:: sets the path to use the bundled dependencies without polluting the user's
+:: permanent global path.
+
+
+@echo off
+
+setlocal
+set gindir=%~dp0
+set ginpaths=%gindir%bin;%gindir%git\usr\bin;%gindir%git\bin
+set path=%ginpaths%;%path%
+
+gin.exe %*
+endlocal

--- a/scripts/set-global.bat
+++ b/scripts/set-global.bat
@@ -1,16 +1,30 @@
 :: GIN client global setup for Windows
-:: 
+::
 :: This file should be part of the gin client Windows bundle. The purpose of
 :: the file is to permanently change the user path environment to be able to
 :: run GIN commands from the command line (cmd and PowerShell).
 
-echo off
+@echo off
 
-set curdir=%~dp0
+set ginpath=%~dp0
 
-set ginbinpath=%curdir%\bin
-set gitpaths=%curdir%\git\usr\bin;%curdir%\git\bin
-echo Appending "%ginbinpath%;%gitpaths%" to path
-echo %path%|find /I "%curdir%">nul || setx path "%path%;%ginbinpath%;%gitpaths%"
+:: Get user path *only* (No system path)
+for /F "skip=2 tokens=1,2*" %%N in ('%SystemRoot%\System32\reg.exe query "HKCU\Environment" /v "Path" 2^>nul') do if /I "%%N" == "Path" call set "userpath=%%P"
+
+echo "Checking"
+echo %userpath%|find /I "gin">nul && (
+    echo Please edit the "Path" variable and remove all previous GIN CLI paths.
+    echo The environment variables settings window will open automatically.
+    pause
+    rundll32 sysdm.cpl,EditEnvironmentVariables
+)
+
+:: Read again
+for /F "skip=2 tokens=1,2*" %%N in ('%SystemRoot%\System32\reg.exe query "HKCU\Environment" /v "Path" 2^>nul') do if /I "%%N" == "Path" call set "userpath=%%P"
+
+:: Prepend GIN path
+echo Prepending "%ginpath%;" to path
+setx path "%ginpath%;%userpath%"
+
 echo GIN CLI is ready
 pause

--- a/version
+++ b/version
@@ -1,1 +1,1 @@
-version=1.11
+version=1.12dev


### PR DESCRIPTION
Adding a new wrapper script for running `gin` commands on Windows.

The new script (`gin.bat`) acts as the main entrypoint for commands on Windows.  It sets up a temporary (local) path where the gin-cli can find all necessary binaries (git, git-annex, etc.) and then runs the command with the user's arguments.  If this script is in the user's `%path%`, the rest of the software doesn't need to be.  The bundled binaries take precedence over any existing binaries with the same name in the `%path%` since the temporary paths are prepended before calling `gin.exe`.

The `set-global.bat` file has been adjusted to add only the path with the `gin.bat` in it.  It also prompts the user to clean their path of any existing GIN CLI directories, if any are detected.  This is better done manually, since parsing and editing the path is too error prone.

The PR also includes a small change to the configuration loading and small code quality improvements to the release script.