### PR TITLE
Use only local git config keys

### DIFF
--- a/ginclient/repos.go
+++ b/ginclient/repos.go
@@ -481,12 +481,12 @@ func CommitIfNew() (bool, error) {
 // DefaultRemote returns the name of the configured default gin remote.
 // If a remote is not set in the config, the remote of the default git upstream is set and returned.
 func DefaultRemote() (string, error) {
-	defremote, err := git.ConfigGet("gin.remote")
+	defremote, err := git.ConfigGetLocal("gin.remote")
 	if err == nil {
 		return defremote, nil
 	}
 	log.Write("Default remote not set. Checking master remote.")
-	defremote, err = git.ConfigGet("branch.master.remote")
+	defremote, err = git.ConfigGetLocal("branch.master.remote")
 	if err == nil {
 		SetDefaultRemote(defremote)
 		log.Write("Set default remote to %s", defremote)

--- a/git/git.go
+++ b/git/git.go
@@ -360,7 +360,27 @@ func SetGitUser(name, email string) error {
 	return ConfigSet("user.email", email)
 }
 
-// ConfigGet returns the value of a given git configuration key.
+// ConfigGetLocal returns the value of a given git configuration key
+// using the local git configuration only.
+// The returned key is always a string.
+// (git config --local --get)
+func ConfigGetLocal(key string) (string, error) {
+	fn := fmt.Sprintf("ConfigGet(%s)", key)
+	cmd := Command("config", "--local", "--get", key)
+	stdout, stderr, err := cmd.OutputError()
+	if err != nil {
+		gerr := giterror{UError: string(stderr), Origin: fn}
+		log.Write("Error during config get")
+		logstd(stdout, stderr)
+		return "", gerr
+	}
+	value := string(stdout)
+	value = strings.TrimSpace(value)
+	return value, nil
+}
+
+// ConfigGet returns the value of a given git configuration key
+// using the default git configuration.
 // The returned key is always a string.
 // (git config --get)
 func ConfigGet(key string) (string, error) {
@@ -544,7 +564,7 @@ func Checkwd() error {
 		return NotRepository
 	}
 
-	annexver, err := ConfigGet("annex.version")
+	annexver, err := ConfigGetLocal("annex.version")
 	if err != nil {
 		// Annex version config key missing: Annex not initialised
 		return NotAnnex

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -47,7 +47,7 @@ func TestInit(t *testing.T) {
 		t.Fatalf("Failed to initialise (non-bare) repository: %s", err.Error())
 	}
 
-	bare, _ := ConfigGet("core.bare")
+	bare, _ := ConfigGetLocal("core.bare")
 	if bare != "false" {
 		t.Fatalf("Expected non-bare repository: %s", bare)
 	}
@@ -63,7 +63,7 @@ func TestInit(t *testing.T) {
 		t.Fatalf("Failed to initialise bare repository: %s", err.Error())
 	}
 
-	bare, _ = ConfigGet("core.bare")
+	bare, _ = ConfigGetLocal("core.bare")
 	if bare != "true" {
 		t.Fatalf("Expected bare repository: %s", bare)
 	}


### PR DESCRIPTION
When fetching git config keys, only use keys from the local git configuration and never include a global config.

PR also references fixes in the `gin-cli-test` submodule, ignoring issues when `git annex uninit` right before the end of a test or before deleting the repo in question did not successfully complete.
