### PR TITLE
Fix log init error reporting

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,18 +28,20 @@ func init() {
 
 	gitVer, err := git.GetGitVersion()
 	if err != nil {
-		gitVer = err.Error()
+		fmt.Fprintf(os.Stderr, "Failed to get git version: %s", err.Error())
+		gitVer = ""
 	}
 	verinfo.Git = gitVer
 
 	annexVer, err := git.GetAnnexVersion()
 	if err != nil {
-		annexVer = err.Error()
+		fmt.Fprintf(os.Stderr, "Failed to get git-annex version: %s", err.Error())
+		annexVer = ""
 	}
 	verinfo.Annex = annexVer
 	err = log.Init()
 	if err != nil {
-		fmt.Println("Failed to initialise log file")
+		fmt.Fprintln(os.Stderr, "Failed to initialise log file")
 	}
 	log.Write("VERSION: %s", verinfo.String())
 }

--- a/main.go
+++ b/main.go
@@ -37,10 +37,10 @@ func init() {
 		annexVer = err.Error()
 	}
 	verinfo.Annex = annexVer
+	err = log.Init()
 	if err != nil {
 		fmt.Println("Failed to initialise log file")
 	}
-	err = log.Init()
 	log.Write("VERSION: %s", verinfo.String())
 }
 


### PR DESCRIPTION
Came across this today.  `git annex` was throwing an error and it was being reported as a log initialisation error.